### PR TITLE
feat: Implements fix for the issue caused by passing batch list of objects are regular parameter

### DIFF
--- a/docling_jobkit/kfp_pipeline/docling-s3in-s3out.yaml
+++ b/docling_jobkit/kfp_pipeline/docling-s3in-s3out.yaml
@@ -1,5 +1,5 @@
 # PIPELINE DEFINITION
-# Name: docling-s3in-s3out
+# Name: inputs-s3in-s3out
 # Inputs:
 #    batch_size: int [Default: 20.0]
 #    convertion_options: dict [Default: {'force_ocr': False, 'do_code_enrichment': False, 'do_formula_enrichment': False, 'do_picture_classification': False, 'to_formats': ['md', 'json', 'html', 'text', 'doctags'], 'return_as_file': False, 'include_images': True, 'abort_on_error': False, 'ocr_lang': [], 'do_picture_description': False, 'ocr_engine': 'easyocr', 'table_mode': 'accurate', 'images_scale': 2.0, 'image_export_mode': 'placeholder', 'generate_picture_images': False, 'do_ocr': True, 'from_formats': ['docx', 'pptx', 'html', 'image', 'pdf', 'asciidoc', 'md', 'xlsx', 'xml_uspto', 'xml_jats', 'json_docling'], 'pdf_backend': 'dlparse_v2', 'do_table_structure': True}]
@@ -19,19 +19,29 @@ components:
         target:
           parameterType: STRUCT
     outputDefinitions:
+      artifacts:
+        dataset:
+          artifactType:
+            schemaTitle: system.Dataset
+            schemaVersion: 0.0.1
       parameters:
-        Output:
+        batch_indices:
           parameterType: LIST
   comp-convert-payload:
     executorLabel: exec-convert-payload
     inputDefinitions:
+      artifacts:
+        dataset:
+          artifactType:
+            schemaTitle: system.Dataset
+            schemaVersion: 0.0.1
       parameters:
+        batch_index:
+          parameterType: NUMBER_INTEGER
         options:
           parameterType: STRUCT
         source:
           parameterType: STRUCT
-        source_keys:
-          parameterType: LIST
         target:
           parameterType: STRUCT
     outputDefinitions:
@@ -47,23 +57,31 @@ components:
           componentRef:
             name: comp-convert-payload
           inputs:
+            artifacts:
+              dataset:
+                componentInputArtifact: pipelinechannel--compute-batches-dataset
             parameters:
+              batch_index:
+                componentInputParameter: pipelinechannel--compute-batches-batch_indices-loop-item
               options:
                 componentInputParameter: pipelinechannel--convertion_options
               source:
                 componentInputParameter: pipelinechannel--source
-              source_keys:
-                componentInputParameter: pipelinechannel--compute-batches-Output-loop-item
               target:
                 componentInputParameter: pipelinechannel--target
           taskInfo:
             name: convert-payload
     inputDefinitions:
+      artifacts:
+        pipelinechannel--compute-batches-dataset:
+          artifactType:
+            schemaTitle: system.Dataset
+            schemaVersion: 0.0.1
       parameters:
-        pipelinechannel--compute-batches-Output:
+        pipelinechannel--compute-batches-batch_indices:
           parameterType: LIST
-        pipelinechannel--compute-batches-Output-loop-item:
-          parameterType: LIST
+        pipelinechannel--compute-batches-batch_indices-loop-item:
+          parameterType: NUMBER_INTEGER
         pipelinechannel--convertion_options:
           parameterType: STRUCT
         pipelinechannel--source:
@@ -87,8 +105,8 @@ deploymentSpec:
           \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.8.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"'  &&\
           \  python3 -m pip install --quiet --no-warn-script-location 'pydantic' 'boto3~=1.35.36'\
-          \ 'git+https://github.com/docling-project/docling-jobkit@input-check' &&\
-          \ \"$0\" \"$@\"\n"
+          \ 'git+https://github.com/docling-project/docling-jobkit@27bad5b9159bd0fcb7c84be940416c6738c03b86'\
+          \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -100,8 +118,10 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef compute_batches(\n    source: dict,\n    target: dict,\n    batch_size:\
-          \ int = 10,\n) -> List[List[str]]:\n    from docling_jobkit.connectors.s3_helper\
+          \ *\n\ndef compute_batches(\n    source: dict,\n    target: dict,\n    dataset:\
+          \ Output[Dataset],\n    batch_size: int = 10,\n) -> NamedTuple(\"outputs\"\
+          , [(\"batch_indices\", List[int])]): # type: ignore[valid-type]\n    import\
+          \ json\n    from typing import NamedTuple\n\n    from docling_jobkit.connectors.s3_helper\
           \ import (\n        check_target_has_source_converted,\n        generate_batch_keys,\n\
           \        get_s3_connection,\n        get_source_files,\n    )\n    from\
           \ docling_jobkit.model.s3_inputs import S3Coordinates\n\n    # validate\
@@ -112,7 +132,11 @@ deploymentSpec:
           \    )\n    filtered_source_keys = check_target_has_source_converted(\n\
           \        s3_target_coords, source_objects_list, s3_coords_source.key_prefix\n\
           \    )\n    batch_keys = generate_batch_keys(\n        filtered_source_keys,\n\
-          \        batch_size=batch_size,\n    )\n\n    return batch_keys\n\n"
+          \        batch_size=batch_size,\n    )\n\n    with open(dataset.path, \"\
+          w\") as out_batches:\n        json.dump(batch_keys, out_batches)\n\n   \
+          \ batch_indices = list(range(len(batch_keys)))\n    outputs = NamedTuple(\"\
+          outputs\", [(\"batch_indices\", List[int])])\n    return outputs(batch_indices)\n\
+          \n"
         image: python:3.11
     exec-convert-payload:
       container:
@@ -129,8 +153,8 @@ deploymentSpec:
           \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.8.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"'  &&\
           \  python3 -m pip install --quiet --no-warn-script-location 'docling==2.28.0'\
-          \ 'git+https://github.com/docling-project/docling-jobkit@input-check' &&\
-          \ \"$0\" \"$@\"\n"
+          \ 'git+https://github.com/docling-project/docling-jobkit@27bad5b9159bd0fcb7c84be940416c6738c03b86'\
+          \ && \"$0\" \"$@\"\n"
         - sh
         - -ec
         - 'program_path=$(mktemp -d)
@@ -143,8 +167,9 @@ deploymentSpec:
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
           \ *\n\ndef convert_payload(\n    options: dict,\n    source: dict,\n   \
-          \ target: dict,\n    source_keys: List[str],\n) -> list:\n    import logging\n\
-          \    from typing import Optional\n\n    from docling.backend.docling_parse_backend\
+          \ target: dict,\n    batch_index: int,\n    # source_keys: List[str],\n\
+          \    dataset: Input[Dataset],\n) -> list:\n    import json\n    import logging\n\
+          \    import os\n    from typing import Optional\n\n    from docling.backend.docling_parse_backend\
           \ import DoclingParseDocumentBackend\n    from docling.backend.docling_parse_v2_backend\
           \ import DoclingParseV2DocumentBackend\n    from docling.backend.docling_parse_v4_backend\
           \ import DoclingParseV4DocumentBackend\n    from docling.backend.pdf_backend\
@@ -155,18 +180,20 @@ deploymentSpec:
           \ get_ocr_factory\n\n    from docling_jobkit.connectors.s3_helper import\
           \ DoclingConvert\n    from docling_jobkit.model.convert import ConvertDocumentsOptions\n\
           \    from docling_jobkit.model.s3_inputs import S3Coordinates\n\n    logging.basicConfig(level=logging.INFO)\n\
-          \n    # validate inputs\n    source_s3_coords = S3Coordinates.model_validate(source)\n\
-          \    target_s3_coords = S3Coordinates.model_validate(target)\n\n    convert_options\
-          \ = ConvertDocumentsOptions.model_validate(options)\n\n    backend: Optional[type[PdfDocumentBackend]]\
-          \ = None\n    if convert_options.pdf_backend:\n        if convert_options.pdf_backend\
-          \ == PdfBackend.DLPARSE_V1:\n            backend = DoclingParseDocumentBackend\n\
-          \        elif convert_options.pdf_backend == PdfBackend.DLPARSE_V2:\n  \
-          \          backend = DoclingParseV2DocumentBackend\n        elif convert_options.pdf_backend\
-          \ == PdfBackend.DLPARSE_V4:\n            backend = DoclingParseV4DocumentBackend\n\
-          \        elif convert_options.pdf_backend == PdfBackend.PYPDFIUM2:\n   \
-          \         backend = PyPdfiumDocumentBackend\n        else:\n           \
-          \ raise RuntimeError(\n                f\"Unexpected PDF backend type {convert_options.pdf_backend}\"\
-          \n            )\n\n    pipeline_options = PdfPipelineOptions()\n    pipeline_options.do_ocr\
+          \n    # set expected path to pre-loaded models\n    os.environ[\"DOCLING_ARTIFACTS_PATH\"\
+          ] = \"/opt/app-root/src/.cache/docling/models\"\n\n    # validate inputs\n\
+          \    source_s3_coords = S3Coordinates.model_validate(source)\n    target_s3_coords\
+          \ = S3Coordinates.model_validate(target)\n\n    convert_options = ConvertDocumentsOptions.model_validate(options)\n\
+          \n    backend: Optional[type[PdfDocumentBackend]] = None\n    if convert_options.pdf_backend:\n\
+          \        if convert_options.pdf_backend == PdfBackend.DLPARSE_V1:\n    \
+          \        backend = DoclingParseDocumentBackend\n        elif convert_options.pdf_backend\
+          \ == PdfBackend.DLPARSE_V2:\n            backend = DoclingParseV2DocumentBackend\n\
+          \        elif convert_options.pdf_backend == PdfBackend.DLPARSE_V4:\n  \
+          \          backend = DoclingParseV4DocumentBackend\n        elif convert_options.pdf_backend\
+          \ == PdfBackend.PYPDFIUM2:\n            backend = PyPdfiumDocumentBackend\n\
+          \        else:\n            raise RuntimeError(\n                f\"Unexpected\
+          \ PDF backend type {convert_options.pdf_backend}\"\n            )\n\n  \
+          \  pipeline_options = PdfPipelineOptions()\n    pipeline_options.do_ocr\
           \ = convert_options.do_ocr\n    ocr_factory = get_ocr_factory()\n\n    pipeline_options.ocr_options\
           \ = cast(\n        OcrOptions, ocr_factory.create_options(kind=convert_options.ocr_engine)\n\
           \    )\n\n    pipeline_options.do_table_structure = convert_options.do_table_structure\n\
@@ -182,7 +209,9 @@ deploymentSpec:
           \    # )\n\n    converter = DoclingConvert(\n        source_s3_coords=source_s3_coords,\n\
           \        target_s3_coords=target_s3_coords,\n        pipeline_options=pipeline_options,\n\
           \        allowed_formats=convert_options.from_formats,\n        to_formats=convert_options.to_formats,\n\
-          \        backend=backend,\n    )\n\n    results = []\n    for item in converter.convert_documents(source_keys):\n\
+          \        backend=backend,\n    )\n\n    with open(dataset.path) as f:\n\
+          \        batches = json.load(f)\n    source_keys = batches[batch_index]\n\
+          \n    results = []\n    for item in converter.convert_documents(source_keys):\n\
           \        results.append(item)\n        logging.info(\"Convertion result:\
           \ {}\".format(item))\n\n    return results\n\n"
         image: quay.io/docling-project/docling-serve:dev-0.0.2
@@ -192,7 +221,7 @@ deploymentSpec:
           memoryLimit: 7.0
           memoryRequest: 1.0
 pipelineInfo:
-  name: docling-s3in-s3out
+  name: inputs-s3in-s3out
 root:
   dag:
     tasks:
@@ -216,10 +245,15 @@ root:
         dependentTasks:
         - compute-batches
         inputs:
+          artifacts:
+            pipelinechannel--compute-batches-dataset:
+              taskOutputArtifact:
+                outputArtifactKey: dataset
+                producerTask: compute-batches
           parameters:
-            pipelinechannel--compute-batches-Output:
+            pipelinechannel--compute-batches-batch_indices:
               taskOutputParameter:
-                outputParameterKey: Output
+                outputParameterKey: batch_indices
                 producerTask: compute-batches
             pipelinechannel--convertion_options:
               componentInputParameter: convertion_options
@@ -230,9 +264,9 @@ root:
         iteratorPolicy:
           parallelismLimit: 3
         parameterIterator:
-          itemInput: pipelinechannel--compute-batches-Output-loop-item
+          itemInput: pipelinechannel--compute-batches-batch_indices-loop-item
           items:
-            inputParameter: pipelinechannel--compute-batches-Output
+            inputParameter: pipelinechannel--compute-batches-batch_indices
         taskInfo:
           name: for-loop-1
   inputDefinitions:


### PR DESCRIPTION
Refactoring of how batches are sent to conversion to avoid ArgoCD crashing because of too long input parameter.
Now the batches are saved and loaded as artifact between kubeflow components, only batch index is passed as regular parameter.

Pins "DOCLING_ARTIFACTS_PATH" environment variable to avoid situation where some models will still try to download "missing" parts.

**Issue resolved by this Pull Request:**
Resolves #30

