### PR TITLE
fix: fixing s3_connector scratch directory

### DIFF
--- a/docling_jobkit/connectors/s3_helper.py
+++ b/docling_jobkit/connectors/s3_helper.py
@@ -296,6 +296,7 @@ class ResultsProcessor:
         self.scratch_dir = scratch_dir or Path(
             tempfile.mkdtemp(prefix="docling_")
         )
+        self.scratch_dir.mkdir(exist_ok=True, parents=True)
 
     def __del__(self):
         if self.scratch_dir is not None:

--- a/docling_jobkit/connectors/s3_helper.py
+++ b/docling_jobkit/connectors/s3_helper.py
@@ -1,8 +1,8 @@
 import json
 import logging
 import os
-import tempfile
 import shutil
+import tempfile
 from datetime import datetime
 from io import BytesIO
 from pathlib import Path
@@ -282,7 +282,7 @@ class ResultsProcessor:
         generate_page_images: bool = False,
         generate_picture_images: bool = False,
         export_parquet_file: bool = True,
-        scratch_dir: Path = None
+        scratch_dir: Path | None = None,
     ):
         self.target_coords = target_s3_coords
         self.target_s3_client, _ = get_s3_connection(target_s3_coords)
@@ -293,15 +293,12 @@ class ResultsProcessor:
         self.to_formats = to_formats
         self.export_parquet_file = export_parquet_file
 
-        self.scratch_dir = scratch_dir or Path(
-            tempfile.mkdtemp(prefix="docling_")
-        )
+        self.scratch_dir = scratch_dir or Path(tempfile.mkdtemp(prefix="docling_"))
         self.scratch_dir.mkdir(exist_ok=True, parents=True)
 
     def __del__(self):
         if self.scratch_dir is not None:
             shutil.rmtree(self.scratch_dir, ignore_errors=True)
-
 
     def process_documents(self, results: Iterable[ConversionResult]):
         pd_d = DataFrame()  # DataFrame to append parquet info
@@ -348,7 +345,6 @@ class ResultsProcessor:
                             temp_json_file = temp_dir / f"{name_without_ext}.json"
 
                             conv_res.document.save_as_json(
-                                # filename=Path(temp_json_file.name),
                                 filename=temp_json_file,
                                 image_mode=ImageRefMode.REFERENCED,
                             )

--- a/docling_jobkit/connectors/s3_helper.py
+++ b/docling_jobkit/connectors/s3_helper.py
@@ -348,7 +348,8 @@ class ResultsProcessor:
                             temp_json_file = temp_dir / f"{name_without_ext}.json"
 
                             conv_res.document.save_as_json(
-                                filename=Path(temp_json_file.name),
+                                # filename=Path(temp_json_file.name),
+                                filename=temp_json_file,
                                 image_mode=ImageRefMode.REFERENCED,
                             )
                             self.upload_file_to_s3(


### PR DESCRIPTION
Temporary files where dumped into a local folder when using s3_connector. This fixes it and adds option to specify scratch folder explicitly.
