### PR TITLE
fix: fixes name cleaning of doc on s3 for batching

### DIFF
--- a/dev/s3_helper_test.py
+++ b/dev/s3_helper_test.py
@@ -1,6 +1,3 @@
-import os
-from pathlib import Path
-
 from pydantic import Field, ValidationInfo, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict, SettingsError
 from typing_extensions import Self
@@ -12,27 +9,22 @@ from docling.backend.pdf_backend import PdfDocumentBackend
 from docling.backend.pypdfium2_backend import PyPdfiumDocumentBackend
 from docling.datamodel.pipeline_options import (
     PdfBackend,
-    PdfPipelineOptions,
-    TableFormerMode,
 )
-from docling.models.factories import get_ocr_factory
-from docling.utils.model_downloader import download_models
 
+from docling_jobkit.connectors.s3_helper import (
+    ResultsProcessor,
+    check_target_has_source_converted,
+    generate_presign_url,
+    get_s3_connection,
+    get_source_files,
+)
 from docling_jobkit.convert.manager import (
     DoclingConverterManager,
     DoclingConverterManagerConfig,
 )
 from docling_jobkit.datamodel.convert import ConvertDocumentsOptions
 from docling_jobkit.datamodel.s3_coords import S3Coordinates
-from docling.utils.model_downloader import download_models
 
-from docling_jobkit.connectors.s3_helper import (
-    ResultsProcessor,
-    check_target_has_source_converted,
-    get_s3_connection,
-    get_source_files,
-    generate_presign_url
-)
 # from docling_jobkit.datamodel.convert import ConvertDocumentsOptions
 # from docling_jobkit.datamodel.s3_coords import S3Coordinates
 
@@ -205,4 +197,3 @@ for item in result_processor.process_documents(
 ):
     results.append(item)
     print(f"Convertion result: {item}")
-

--- a/docling_jobkit/connectors/s3_helper.py
+++ b/docling_jobkit/connectors/s3_helper.py
@@ -197,15 +197,19 @@ def check_target_has_source_converted(
             s3_target_resource, coords.bucket, converted_prefix
         )
 
-        # Filter-out objects that are already processed
-        target_short_key_list = strip_prefix_postfix(
-            existing_target_objects, prefix=converted_prefix, extension=".json"
-        )
+        # At this point we should be targeting keys in the json "folder"
+        target_short_key_list = []
+        for item in existing_target_objects:
+            clean_name = str(Path(item).stem)
+            target_short_key_list.append(clean_name)
+
         filtered_source_keys = []
         logging.debug("List of source keys:")
         for key in source_objects_list:
             logging.debug("Object key: {}".format(key))
-            clean_key = key.replace(".pdf", "").replace(s3_source_prefix + "/", "")
+            # This covers the case when source docs have "folder" hierarchy in the key
+            # we don't preserve key part between prefix and "file", this part of key is not added as prefix for target
+            clean_key = str(Path(key).stem)
             if clean_key not in target_short_key_list:
                 filtered_source_keys.append(key)
 


### PR DESCRIPTION
The s3 input can contain "internal" hierarchy between prefix and actual document name. For example:
```
s3://fin_reports/AR/2010/Company_annual_report_2010.pdf
....
```
The likely prefix here would be "AR" with assumption that anything underneath will be converted. As we don't preserve the string between prefix and document, "2010/" in this case, when converted results are pushed to s3, we need to make sure that comparison is done only on the document name, to check which documents where already converted.
