### PR TITLE
feat: Implement clear_cache_task in RQ worker and invoke it on clear_converters

### DIFF
--- a/docling_jobkit/orchestrators/rq/orchestrator.py
+++ b/docling_jobkit/orchestrators/rq/orchestrator.py
@@ -255,4 +255,6 @@ class RQOrchestrator(BaseOrchestrator):
             raise RuntimeError("No connection to Redis")
 
     async def clear_converters(self):
-        pass
+        self._rq_queue.enqueue(
+            "docling_jobkit.orchestrators.rq.worker.clear_cache_task",
+        )

--- a/docling_jobkit/orchestrators/rq/worker.py
+++ b/docling_jobkit/orchestrators/rq/worker.py
@@ -187,6 +187,16 @@ def docling_task(
     return result_key
 
 
+def clear_cache_task(conversion_manager: DoclingConverterManager, **_):
+    """RQ job that clears the converter cache on the worker."""
+    _log.info("Clearing converter cache on worker")
+    conversion_manager.clear_cache()
+    import gc
+
+    gc.collect()
+    _log.info("Converter cache cleared")
+
+
 def run_worker(
     rq_config: Optional[RQOrchestratorConfig] = None,
     cm_config: Optional[DoclingConverterManagerConfig] = None,


### PR DESCRIPTION
Addresses https://github.com/docling-project/docling-serve/issues/366 with the RQ worker

This PR implements `clear_converters` on `RQOrchestrator` so that converter instances are purged from cache on `/clear/converters`.