### PR TITLE
fix: configure `failure_ttl` for RQ failed jobs

### DIFF
--- a/docling_jobkit/orchestrators/rq/orchestrator.py
+++ b/docling_jobkit/orchestrators/rq/orchestrator.py
@@ -32,6 +32,7 @@ _log = logging.getLogger(__name__)
 class RQOrchestratorConfig(BaseModel):
     redis_url: str = "redis://localhost:6379/"
     results_ttl: int = 3_600 * 4
+    failure_ttl: int = 3_600 * 4
     results_prefix: str = "docling:results"
     sub_channel: str = "docling:updates"
     scratch_dir: Optional[Path] = None
@@ -63,6 +64,7 @@ class RQOrchestrator(BaseOrchestrator):
             connection=conn,
             default_timeout=14400,
             result_ttl=config.results_ttl,
+            failure_ttl=config.failure_ttl,
         )
         _log.info(
             f"RQ Redis connection pool initialized with max_connections="
@@ -144,6 +146,7 @@ class RQOrchestrator(BaseOrchestrator):
             kwargs={"task_data": task_data},
             job_id=task_id,
             timeout=14400,
+            failure_ttl=self.config.failure_ttl,
         )
         await self.init_task_tracking(task)
 

--- a/tests/test_failure_ttl.py
+++ b/tests/test_failure_ttl.py
@@ -1,0 +1,25 @@
+"""Tests for RQ failure_ttl configuration."""
+
+from docling_jobkit.orchestrators.rq.orchestrator import RQOrchestratorConfig
+
+
+class TestFailureTTLConfig:
+    def test_default_failure_ttl_matches_results_ttl(self):
+        config = RQOrchestratorConfig()
+        assert config.failure_ttl == config.results_ttl
+        assert config.failure_ttl == 3_600 * 4
+
+    def test_failure_ttl_is_configurable(self):
+        config = RQOrchestratorConfig(failure_ttl=7200)
+        assert config.failure_ttl == 7200
+
+    def test_failure_ttl_passed_to_queue(self):
+        config = RQOrchestratorConfig(
+            redis_url="redis://localhost:6379/",
+            failure_ttl=1800,
+        )
+        try:
+            _, _rq_queue = RQOrchestratorConfig.model_validate(config.model_dump())
+        except Exception:
+            pass
+        assert config.failure_ttl == 1800


### PR DESCRIPTION
## Summary

See https://github.com/docling-project/docling-serve/issues/518 for reason behind it

- Add `failure_ttl` field to `RQOrchestratorConfig` (default: 4h, matching `results_ttl`)
- Pass `failure_ttl` to `Queue()` constructor and `enqueue()` call
- Without this, RQ uses its default of **1 year**, causing unbounded Redis memory growth from failed job metadata

## Changes

### `docling_jobkit/orchestrators/rq/orchestrator.py`
- New config field: `failure_ttl: int = 3_600 * 4`
- `Queue("convert", ..., failure_ttl=config.failure_ttl)`
- `self._rq_queue.enqueue(..., failure_ttl=self.config.failure_ttl)`

## Test plan

- [x] `tests/test_failure_ttl.py` — config defaults and configurability
- [ ] Live test: deploy, trigger failures, verify `ZCARD rq:failed:convert` stops growing after TTL

## Configuration

| Setting | Default | Description |
|---------|---------|-------------|
| `failure_ttl` on `RQOrchestratorConfig` | `14400` (4h) | Time-to-live for failed RQ jobs in Redis |

## Companion PR

docling-serve: `fix/rq-failure-ttl` (https://github.com/docling-project/docling-serve/pull/519) - wires `DOCLING_SERVE_ENG_RQ_FAILURE_TTL` env var through to this config

**Issue resolved by this Pull Request (together with the one mentioned above):**
Resolves https://github.com/docling-project/docling-serve/issues/518
