### PR TITLE
feat: add layout_model per-request option for layout analysis model selection

### DIFF
--- a/docling_jobkit/datamodel/convert.py
+++ b/docling_jobkit/datamodel/convert.py
@@ -15,6 +15,16 @@ from typing_extensions import Self
 
 from docling.datamodel import vlm_model_specs
 from docling.datamodel.base_models import InputFormat, OutputFormat
+from docling.datamodel.layout_model_specs import (
+    DOCLING_LAYOUT_EGRET_LARGE,
+    DOCLING_LAYOUT_EGRET_MEDIUM,
+    DOCLING_LAYOUT_EGRET_XLARGE,
+    DOCLING_LAYOUT_HERON,
+    DOCLING_LAYOUT_HERON_101,
+    DOCLING_LAYOUT_V2,
+    LayoutModelConfig,
+    LayoutModelType,
+)
 
 # Import new engine system (available in docling>=2.73.0)
 from docling.datamodel.pipeline_options import (
@@ -40,6 +50,15 @@ from docling.datamodel.settings import (
     PageRange,
 )
 from docling_core.types.doc import ImageRefMode, PictureClassificationLabel
+
+LAYOUT_MODEL_SPECS: dict[LayoutModelType, LayoutModelConfig] = {
+    LayoutModelType.DOCLING_LAYOUT_HERON: DOCLING_LAYOUT_HERON,
+    LayoutModelType.DOCLING_LAYOUT_HERON_101: DOCLING_LAYOUT_HERON_101,
+    LayoutModelType.DOCLING_LAYOUT_EGRET_MEDIUM: DOCLING_LAYOUT_EGRET_MEDIUM,
+    LayoutModelType.DOCLING_LAYOUT_EGRET_LARGE: DOCLING_LAYOUT_EGRET_LARGE,
+    LayoutModelType.DOCLING_LAYOUT_EGRET_XLARGE: DOCLING_LAYOUT_EGRET_XLARGE,
+    LayoutModelType.DOCLING_LAYOUT_V2: DOCLING_LAYOUT_V2,
+}
 
 
 class PictureDescriptionLocal(BaseModel):
@@ -695,6 +714,23 @@ class ConvertDocumentsOptions(BaseModel):
     ] = None
 
     # Layout Configuration
+    layout_model: Annotated[
+        Optional[LayoutModelType],
+        Field(
+            default=None,
+            description=(
+                "The layout analysis model to use. "
+                f"Allowed values: {', '.join([v.value for v in LayoutModelType])}. "
+                "Optional. When set, automatically expands into layout_custom_config. "
+                "Ignored if layout_custom_config is explicitly provided."
+            ),
+            examples=[
+                LayoutModelType.DOCLING_LAYOUT_HERON.value,
+                LayoutModelType.DOCLING_LAYOUT_EGRET_LARGE.value,
+            ],
+        ),
+    ] = None
+
     layout_custom_config: Annotated[
         Optional[dict[str, Any]],
         Field(
@@ -703,7 +739,8 @@ class ConvertDocumentsOptions(BaseModel):
                 "Custom configuration for layout model. Use this to specify a "
                 "non-default kind with its options. The 'kind' field in the config dict "
                 "determines which layout implementation to use. "
-                "If not specified, uses the default kind with preset configuration."
+                "If not specified, uses the default kind with preset configuration. "
+                "Takes precedence over layout_model when both are set."
             ),
             examples=[
                 {
@@ -786,6 +823,23 @@ class ConvertDocumentsOptions(BaseModel):
                 stacklevel=2,
             )
         return v
+
+    @model_validator(mode="before")
+    @classmethod
+    def expand_layout_model(cls, data: dict) -> dict:
+        """Expand layout_model into layout_custom_config when the latter is not set."""
+        if not isinstance(data, dict):
+            return data
+        layout_model = data.get("layout_model")
+        layout_custom_config = data.get("layout_custom_config")
+        if layout_model is not None and layout_custom_config is None:
+            model_type = LayoutModelType(layout_model)
+            spec = LAYOUT_MODEL_SPECS[model_type]
+            data["layout_custom_config"] = {
+                "kind": "docling_layout_default",
+                "model_spec": spec.model_dump(mode="json"),
+            }
+        return data
 
     @model_validator(mode="after")
     def picture_description_exclusivity(self) -> Self:

--- a/tests/test_layout_model.py
+++ b/tests/test_layout_model.py
@@ -1,0 +1,65 @@
+"""Tests for layout_model field expansion into layout_custom_config."""
+
+import pytest
+
+from docling.datamodel.layout_model_specs import LayoutModelType
+
+from docling_jobkit.datamodel.convert import (
+    LAYOUT_MODEL_SPECS,
+    ConvertDocumentsOptions,
+)
+
+
+class TestLayoutModelExpansion:
+    """Test that the layout_model field correctly expands into layout_custom_config."""
+
+    def test_layout_model_expands_to_custom_config(self):
+        opts = ConvertDocumentsOptions(
+            layout_model=LayoutModelType.DOCLING_LAYOUT_EGRET_LARGE,
+        )
+        assert opts.layout_custom_config is not None
+        assert opts.layout_custom_config["kind"] == "docling_layout_default"
+        spec = opts.layout_custom_config["model_spec"]
+        assert spec["name"] == "docling_layout_egret_large"
+        assert "docling-project" in spec["repo_id"]
+
+    def test_layout_model_all_types_expand(self):
+        for model_type in LayoutModelType:
+            opts = ConvertDocumentsOptions(layout_model=model_type)
+            assert opts.layout_custom_config is not None
+            expected_spec = LAYOUT_MODEL_SPECS[model_type].model_dump(mode="json")
+            assert opts.layout_custom_config["model_spec"] == expected_spec
+
+    def test_layout_custom_config_takes_precedence(self):
+        custom_config = {
+            "kind": "custom_layout_model",
+            "model_path": "/my/custom/model",
+        }
+        opts = ConvertDocumentsOptions(
+            layout_model=LayoutModelType.DOCLING_LAYOUT_EGRET_LARGE,
+            layout_custom_config=custom_config,
+        )
+        assert opts.layout_custom_config == custom_config
+
+    def test_layout_model_none_leaves_config_unset(self):
+        opts = ConvertDocumentsOptions(layout_model=None)
+        assert opts.layout_custom_config is None
+
+    def test_layout_model_string_value_accepted(self):
+        opts = ConvertDocumentsOptions(
+            **{"layout_model": "docling_layout_heron"}
+        )
+        assert opts.layout_custom_config is not None
+        assert opts.layout_custom_config["model_spec"]["name"] == "docling_layout_heron"
+
+    def test_invalid_layout_model_rejected(self):
+        with pytest.raises(ValueError):
+            ConvertDocumentsOptions(
+                **{"layout_model": "nonexistent_model"}
+            )
+
+    def test_default_layout_model_is_none(self):
+        """Verify that layout_model defaults to None (no override)."""
+        opts = ConvertDocumentsOptions()
+        assert opts.layout_model is None
+        assert opts.layout_custom_config is None


### PR DESCRIPTION
## Summary

Adds a `layout_model` enum field to `ConvertDocumentsOptions` so users can select between docling's 6 layout analysis models (`docling_layout_heron`, `docling_layout_heron_101`, `docling_layout_egret_medium`, `docling_layout_egret_large`, `docling_layout_egret_xlarge`, `docling_layout_v2`) without manually constructing verbose `layout_custom_config` dicts.

A `@model_validator(mode="before")` expands `layout_model` into the existing `layout_custom_config` dict, maintaining full backward compatibility. When `layout_custom_config` is explicitly provided, it takes precedence.

## Context

This was originally submitted as [docling-serve#540](https://github.com/docling-project/docling-serve/pull/540), but @dolfim-ibm [directed it here](https://github.com/docling-project/docling-serve/pull/540#issuecomment-4108566679) since the datamodel belongs in docling-jobkit. The docling-serve side (Gradio UI dropdown, `DOCLING_SERVE_DEFAULT_LAYOUT_MODEL` env var, docs) will be submitted as a follow-up PR once this is merged.

## Changes

| File | Change |
|------|--------|
| `docling_jobkit/datamodel/convert.py` | Import `LayoutModelType` + 6 model spec constants; add `LAYOUT_MODEL_SPECS` mapping; add `layout_model` field; add `expand_layout_model` model validator; update `layout_custom_config` description noting precedence |
| `tests/test_layout_model.py` | 7 unit tests covering expansion, all model types, precedence, None default, string values, and invalid model rejection |

## Test plan

- [x] `uv run pytest tests/test_layout_model.py` — all 7 tests pass
- [x] `uv run pytest tests/test_kind_selection.py tests/test_convert_options.py` — all existing tests still pass
- [x] `test_options_validator` failure is pre-existing on main (unrelated `InlineVlmOptions` comparison)

## Note on upcoming ONNX changes

@dolfim-ibm mentioned upcoming layout model changes with different ONNX runtimes. This PR only adds the `layout_model` → `layout_custom_config` expansion at the request options level and doesn't touch the runtime/converter layer, so it should be compatible with those changes. If the `LayoutModelType` enum or `LayoutModelConfig` shape changes in docling, the `LAYOUT_MODEL_SPECS` mapping here would need a corresponding update.