### PR TITLE
fix: corrected the return datatype from dict to VlmConvertOptions; if request has vlm_pipeline_preset set

### DIFF
--- a/docling_jobkit/convert/manager.py
+++ b/docling_jobkit/convert/manager.py
@@ -922,13 +922,29 @@ class DoclingConverterManager:
         """Parse VLM options from preset OR custom config."""
         # Option 1: Preset (recommended)
         if request.vlm_pipeline_preset:
-            return self._get_options_from_preset(
+            result = self._get_options_from_preset(
                 request.vlm_pipeline_preset,
                 self.vlm_preset_registry,
                 "VLM",
                 self.config.allowed_vlm_engines,
                 VlmConvertOptions.from_preset,
             )
+
+            # Custom presets return raw dicts - convert to VlmConvertOptions
+            if isinstance(result, dict):
+                config_dict = result.copy()
+
+                # Instantiate the correct engine options class
+                if "engine_options" in config_dict and isinstance(
+                    config_dict["engine_options"], dict
+                ):
+                    config_dict["engine_options"] = self._instantiate_engine_options(
+                        config_dict["engine_options"]
+                    )
+
+                return VlmConvertOptions.model_validate(config_dict)
+
+            return result
 
         # Option 2: Custom config (if allowed)
         if request.vlm_pipeline_custom_config:


### PR DESCRIPTION

The function *_parse_vlm_options* inside the **convert/manage.py** was previously returning a dictionary because of which the vlm_pipeline_preset was not able to set on /v1/convert/file endpoint. Issue: #123 

  1. Inside the _parse_vlm_options method, it checks if the result is a dict and returns the **VlmConvertOptions.model_validate(config_dict)** instead of the plain **dict** which was creating validation issues. 
  2. This make the code consistent as the if condition; where "request.vlm_pipeline_custom_config:" correctly returns the correct "VlmConvertOptions" datatype instead of a dict. Changing the code to return always VlmConvertOptions to make the code consistent 

**Issue resolved by this Pull Request:**
Resolves #123 
