### PR TITLE
fix: normalize Chinese spacing in exported content

### DIFF
--- a/docling_jobkit/convert/results.py
+++ b/docling_jobkit/convert/results.py
@@ -1,5 +1,7 @@
+import json
 import logging
 import os
+import re
 import shutil
 import time
 from collections.abc import Iterable
@@ -37,6 +39,69 @@ if TYPE_CHECKING:
 
 _log = logging.getLogger(__name__)
 PERSIST_ROOT = Path('/work/output')
+
+_CJK_CHAR_RE = r"\u3400-\u4dbf\u4e00-\u9fff\uf900-\ufaff"
+_CJK_PUNCT_RE = r"，。！？；：、】【（）《》“”‘’、"
+_CJK_CHAR_CLASS = f"[{_CJK_CHAR_RE}]"
+_CJK_OR_PUNCT_CLASS = f"[{_CJK_CHAR_RE}{_CJK_PUNCT_RE}]"
+
+
+def _merge_broken_cjk_lines(text: str) -> str:
+    lines = text.splitlines()
+    if len(lines) <= 1:
+        return text
+
+    merged: list[str] = []
+    for raw_line in lines:
+        line = raw_line.strip()
+        if not merged:
+            merged.append(line)
+            continue
+        if not line:
+            merged.append(line)
+            continue
+
+        prev = merged[-1]
+        if not prev:
+            merged.append(line)
+            continue
+
+        is_new_block = bool(
+            re.match(r"^(#{1,6}\s|[-*+]\s|\d+[.)、]\s*|[（(]?[一二三四五六七八九十]+[）)]\s*)", line)
+        )
+        prev_ends_sentence = bool(re.search(r"[。！？!?；;：:]$", prev))
+        line_is_short_cjk = bool(re.fullmatch(rf"{_CJK_OR_PUNCT_CLASS}{{1,6}}", line))
+        prev_ends_with_cjk = bool(re.search(rf"{_CJK_OR_PUNCT_CLASS}$", prev))
+        line_starts_with_cjk = bool(re.match(rf"^{_CJK_OR_PUNCT_CLASS}", line))
+
+        if not is_new_block and not prev_ends_sentence and (
+            line_is_short_cjk or (prev_ends_with_cjk and line_starts_with_cjk)
+        ):
+            merged[-1] = prev + line
+        else:
+            merged.append(line)
+
+    return "\n".join(merged)
+
+
+def _normalize_cjk_spacing(text: str) -> str:
+    text = _merge_broken_cjk_lines(text)
+    text = re.sub(rf"(?<={_CJK_CHAR_CLASS})[ \\t]+(?={_CJK_CHAR_CLASS})", "", text)
+    text = re.sub(rf"(?<={_CJK_OR_PUNCT_CLASS})[ \\t]+(?=[{_CJK_PUNCT_RE}])", "", text)
+    text = re.sub(rf"(?<=[{_CJK_PUNCT_RE}])[ \\t]+(?={_CJK_OR_PUNCT_CLASS})", "", text)
+    text = re.sub(rf"([（《“‘【])\s+(?={_CJK_OR_PUNCT_CLASS})", r"\1", text)
+    text = re.sub(rf"(?<={_CJK_OR_PUNCT_CLASS})\s+([）》”’】])", r"\1", text)
+    return text
+
+
+def _normalize_export_json_payload(payload: object):
+    if isinstance(payload, dict):
+        return {k: _normalize_export_json_payload(v) for k, v in payload.items()}
+    if isinstance(payload, list):
+        return [_normalize_export_json_payload(v) for v in payload]
+    if isinstance(payload, str):
+        return _normalize_cjk_spacing(payload)
+    return payload
 
 
 def _persist_export_artifacts(temp_file: Path, doc_stem: str) -> tuple[Path, Path | None]:
@@ -106,7 +171,6 @@ def _export_document_as_content(
 
         if export_json:
             if output_dir is not None:
-                import json
                 fname = output_dir / f'{conv_res.input.file.stem}.json'
                 new_doc.save_as_json(
                     filename=fname,
@@ -118,7 +182,12 @@ def _export_document_as_content(
                 import logging; logging.getLogger(__name__).warning('DIAG json export output_dir=%s filename=%s persisted_file=%s artifacts=%s', document.output_dir, document.filename, persisted_file, persisted_artifacts)
                 # 重新读取 JSON 内容（图片引用已经被替换）
                 json_text = persisted_file.read_text(encoding='utf-8')
-                document.json_content = type(new_doc).model_validate_json(json_text)
+                json_payload = _normalize_export_json_payload(json.loads(json_text))
+                persisted_file.write_text(
+                    json.dumps(json_payload, ensure_ascii=False, indent=2),
+                    encoding='utf-8',
+                )
+                document.json_content = type(new_doc).model_validate(json_payload)
             else:
                 document.json_content = new_doc
         if export_html:
@@ -131,13 +200,21 @@ def _export_document_as_content(
                 )
                 persisted_file, _ = _persist_export_artifacts(fname, conv_res.input.file.stem)
                 document.output_dir = str(PERSIST_ROOT)
-                document.html_content = persisted_file.read_text(encoding='utf-8')
+                normalized_html = _normalize_cjk_spacing(
+                    persisted_file.read_text(encoding='utf-8')
+                )
+                persisted_file.write_text(normalized_html, encoding='utf-8')
+                document.html_content = normalized_html
             else:
-                document.html_content = new_doc.export_to_html(image_mode=image_mode)
+                document.html_content = _normalize_cjk_spacing(
+                    new_doc.export_to_html(image_mode=image_mode)
+                )
         if export_txt:
-            document.text_content = new_doc.export_to_markdown(
-                strict_text=True,
-                image_mode=image_mode,
+            document.text_content = _normalize_cjk_spacing(
+                new_doc.export_to_markdown(
+                    strict_text=True,
+                    image_mode=image_mode,
+                )
             )
         if export_md:
             if output_dir is not None:
@@ -151,11 +228,17 @@ def _export_document_as_content(
                 persisted_file, _ = _persist_export_artifacts(fname, conv_res.input.file.stem)
                 document.output_dir = str(PERSIST_ROOT)
                 _log.warning('DIAG results output_dir=%s filename=%s persisted_file=%s', document.output_dir, document.filename, persisted_file)
-                document.md_content = persisted_file.read_text(encoding='utf-8')
+                normalized_md = _normalize_cjk_spacing(
+                    persisted_file.read_text(encoding='utf-8')
+                )
+                persisted_file.write_text(normalized_md, encoding='utf-8')
+                document.md_content = normalized_md
             else:
-                document.md_content = new_doc.export_to_markdown(
-                    image_mode=image_mode,
-                    page_break_placeholder=md_page_break_placeholder or None,
+                document.md_content = _normalize_cjk_spacing(
+                    new_doc.export_to_markdown(
+                        image_mode=image_mode,
+                        page_break_placeholder=md_page_break_placeholder or None,
+                    )
                 )
         if export_doctags:
             document.doctags_content = new_doc.export_to_doctags()
@@ -192,6 +275,12 @@ def _export_documents_as_files(
                     image_mode=image_export_mode,
                     artifacts_dir=artifacts_dir,
                 )
+                json_payload = json.loads(fname.read_text(encoding='utf-8'))
+                json_payload = _normalize_export_json_payload(json_payload)
+                fname.write_text(
+                    json.dumps(json_payload, ensure_ascii=False, indent=2),
+                    encoding='utf-8',
+                )
 
             if export_html:
                 fname = output_dir / f'{doc_filename}.html'
@@ -200,6 +289,10 @@ def _export_documents_as_files(
                     filename=fname,
                     image_mode=image_export_mode,
                     artifacts_dir=artifacts_dir,
+                )
+                fname.write_text(
+                    _normalize_cjk_spacing(fname.read_text(encoding='utf-8')),
+                    encoding='utf-8',
                 )
 
             if export_txt:
@@ -210,6 +303,10 @@ def _export_documents_as_files(
                     strict_text=True,
                     image_mode=ImageRefMode.PLACEHOLDER,
                 )
+                fname.write_text(
+                    _normalize_cjk_spacing(fname.read_text(encoding='utf-8')),
+                    encoding='utf-8',
+                )
 
             if export_md:
                 fname = output_dir / f'{doc_filename}.md'
@@ -219,6 +316,10 @@ def _export_documents_as_files(
                     artifacts_dir=artifacts_dir,
                     image_mode=image_export_mode,
                     page_break_placeholder=md_page_break_placeholder or None,
+                )
+                fname.write_text(
+                    _normalize_cjk_spacing(fname.read_text(encoding='utf-8')),
+                    encoding='utf-8',
                 )
 
             if export_doctags:
@@ -359,7 +460,7 @@ def process_export_results(
             export_txt=export_txt,
             export_doctags=export_doctags,
             image_export_mode=conversion_options.image_export_mode,
-            md_page_break_placeholder=md_page_break_placeholder,
+            md_page_break_placeholder=conversion_options.md_page_break_placeholder,
         )
         files = os.listdir(output_dir)
         if len(files) == 0:

--- a/docling_jobkit/convert/results.py
+++ b/docling_jobkit/convert/results.py
@@ -7,10 +7,13 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 import httpx
+from urllib.parse import unquote, unquote_plus
 
 from docling.datamodel.base_models import OutputFormat
 from docling.datamodel.document import ConversionResult, ConversionStatus
-from docling.datamodel.service.callbacks import (
+from docling_core.types.doc import ImageRefMode
+
+from docling_jobkit.datamodel.callback import (
     DocumentCompletedItem,
     FailedDocsItem,
     ProgressDocumentCompleted,
@@ -18,9 +21,6 @@ from docling.datamodel.service.callbacks import (
     ProgressUpdateProcessed,
     SucceededDocsItem,
 )
-from docling.datamodel.service.targets import InBodyTarget, PutTarget
-from docling_core.types.doc import ImageRefMode
-
 from docling_jobkit.datamodel.result import (
     DoclingTaskResult,
     ExportDocumentResponse,
@@ -30,11 +30,41 @@ from docling_jobkit.datamodel.result import (
     ZipArchiveResult,
 )
 from docling_jobkit.datamodel.task import Task
+from docling_jobkit.datamodel.task_targets import InBodyTarget, PutTarget
 
 if TYPE_CHECKING:
     from docling_jobkit.orchestrators.callback_invoker import CallbackInvoker
 
 _log = logging.getLogger(__name__)
+PERSIST_ROOT = Path('/work/output')
+
+
+def _persist_export_artifacts(temp_file: Path, doc_stem: str) -> tuple[Path, Path | None]:
+    PERSIST_ROOT.mkdir(parents=True, exist_ok=True)
+    persisted_file = PERSIST_ROOT / temp_file.name
+    shutil.copy2(temp_file, persisted_file)
+
+    temp_artifacts_dir = temp_file.parent / 'artifacts'
+    # 🔧 解码中文文件名
+    decoded_stem = doc_stem
+    for decoder in [unquote, unquote_plus]:
+        try:
+            candidate = decoder(doc_stem)
+            if '%' not in candidate and candidate != doc_stem:
+                decoded_stem = candidate
+                break
+        except Exception:
+            pass
+    persisted_artifacts_dir = PERSIST_ROOT / f'{decoded_stem}_artifacts'
+    if temp_artifacts_dir.exists():
+        if persisted_artifacts_dir.exists():
+            shutil.rmtree(persisted_artifacts_dir)
+        shutil.copytree(temp_artifacts_dir, persisted_artifacts_dir)
+        _log.warning('DIAG persisted artifacts temp=%s persisted=%s', temp_artifacts_dir, persisted_artifacts_dir)
+        return persisted_file, persisted_artifacts_dir
+
+    _log.warning('DIAG no temp artifacts dir for %s (expected %s)', temp_file, temp_artifacts_dir)
+    return persisted_file, None
 
 
 def _export_document_as_content(
@@ -46,29 +76,87 @@ def _export_document_as_content(
     export_doctags: bool,
     image_mode: ImageRefMode,
     md_page_break_placeholder: str,
+    work_dir: Path | None = None,
 ) -> ExportDocumentResponse:
     document = ExportDocumentResponse(filename=conv_res.input.file.name)
+
+    # 🔧 关键修复：如果 work_dir 是 None，强制使用 scratch
+    if work_dir is None:
+        try:
+            from docling_serve.storage import get_scratch
+            work_dir = get_scratch()
+            import logging
+            _log = logging.getLogger(__name__)
+            _log.warning("DIAG fixed work_dir from None to scratch: %s", work_dir)
+        except Exception as e:
+            import logging
+            _log = logging.getLogger(__name__)
+            _log.warning("DIAG failed to get scratch, work_dir still None: %s", e)
 
     if conv_res.status == ConversionStatus.SUCCESS:
         new_doc = conv_res.document._make_copy_with_refmode(
             Path(), image_mode, page_no=None
         )
 
-        # Create the different formats
+        output_dir = None
+        artifacts_dir = Path('artifacts/')
+        if work_dir is not None and image_mode == ImageRefMode.REFERENCED:
+            output_dir = work_dir / 'output'
+            output_dir.mkdir(parents=True, exist_ok=True)
+
         if export_json:
-            document.json_content = new_doc
+            if output_dir is not None:
+                import json
+                fname = output_dir / f'{conv_res.input.file.stem}.json'
+                new_doc.save_as_json(
+                    filename=fname,
+                    image_mode=image_mode,
+                    artifacts_dir=artifacts_dir,
+                )
+                persisted_file, persisted_artifacts = _persist_export_artifacts(fname, conv_res.input.file.stem)
+                document.output_dir = str(PERSIST_ROOT)
+                import logging; logging.getLogger(__name__).warning('DIAG json export output_dir=%s filename=%s persisted_file=%s artifacts=%s', document.output_dir, document.filename, persisted_file, persisted_artifacts)
+                # 重新读取 JSON 内容（图片引用已经被替换）
+                json_text = persisted_file.read_text(encoding='utf-8')
+                document.json_content = type(new_doc).model_validate_json(json_text)
+            else:
+                document.json_content = new_doc
         if export_html:
-            document.html_content = new_doc.export_to_html(image_mode=image_mode)
+            if output_dir is not None:
+                fname = output_dir / f'{conv_res.input.file.stem}.html'
+                new_doc.save_as_html(
+                    filename=fname,
+                    image_mode=image_mode,
+                    artifacts_dir=artifacts_dir,
+                )
+                persisted_file, _ = _persist_export_artifacts(fname, conv_res.input.file.stem)
+                document.output_dir = str(PERSIST_ROOT)
+                document.html_content = persisted_file.read_text(encoding='utf-8')
+            else:
+                document.html_content = new_doc.export_to_html(image_mode=image_mode)
         if export_txt:
             document.text_content = new_doc.export_to_markdown(
                 strict_text=True,
                 image_mode=image_mode,
             )
         if export_md:
-            document.md_content = new_doc.export_to_markdown(
-                image_mode=image_mode,
-                page_break_placeholder=md_page_break_placeholder or None,
-            )
+            if output_dir is not None:
+                fname = output_dir / f'{conv_res.input.file.stem}.md'
+                new_doc.save_as_markdown(
+                    filename=fname,
+                    artifacts_dir=artifacts_dir,
+                    image_mode=image_mode,
+                    page_break_placeholder=md_page_break_placeholder or None,
+                )
+                persisted_file, _ = _persist_export_artifacts(fname, conv_res.input.file.stem)
+                document.output_dir = str(PERSIST_ROOT)
+                _log.warning('DIAG results output_dir=%s filename=%s persisted_file=%s', document.output_dir, document.filename, persisted_file)
+                document.md_content = persisted_file.read_text(encoding='utf-8')
+            else:
+                document.md_content = new_doc.export_to_markdown(
+                    image_mode=image_mode,
+                    page_break_placeholder=md_page_break_placeholder or None,
+                )
         if export_doctags:
             document.doctags_content = new_doc.export_to_doctags()
 
@@ -89,47 +177,43 @@ def _export_documents_as_files(
     success_count = 0
     failure_count = 0
 
-    artifacts_dir = Path("artifacts/")  # will be relative to the fname
+    artifacts_dir = Path('artifacts/')
 
     for conv_res in conv_results:
         if conv_res.status == ConversionStatus.SUCCESS:
             success_count += 1
             doc_filename = conv_res.input.file.stem
 
-            # Export JSON format:
             if export_json:
-                fname = output_dir / f"{doc_filename}.json"
-                _log.info(f"writing JSON output to {fname}")
+                fname = output_dir / f'{doc_filename}.json'
+                _log.info(f'writing JSON output to {fname}')
                 conv_res.document.save_as_json(
                     filename=fname,
                     image_mode=image_export_mode,
                     artifacts_dir=artifacts_dir,
                 )
 
-            # Export HTML format:
             if export_html:
-                fname = output_dir / f"{doc_filename}.html"
-                _log.info(f"writing HTML output to {fname}")
+                fname = output_dir / f'{doc_filename}.html'
+                _log.info(f'writing HTML output to {fname}')
                 conv_res.document.save_as_html(
                     filename=fname,
                     image_mode=image_export_mode,
                     artifacts_dir=artifacts_dir,
                 )
 
-            # Export Text format:
             if export_txt:
-                fname = output_dir / f"{doc_filename}.txt"
-                _log.info(f"writing TXT output to {fname}")
+                fname = output_dir / f'{doc_filename}.txt'
+                _log.info(f'writing TXT output to {fname}')
                 conv_res.document.save_as_markdown(
                     filename=fname,
                     strict_text=True,
                     image_mode=ImageRefMode.PLACEHOLDER,
                 )
 
-            # Export Markdown format:
             if export_md:
-                fname = output_dir / f"{doc_filename}.md"
-                _log.info(f"writing Markdown output to {fname}")
+                fname = output_dir / f'{doc_filename}.md'
+                _log.info(f'writing Markdown output to {fname}')
                 conv_res.document.save_as_markdown(
                     filename=fname,
                     artifacts_dir=artifacts_dir,
@@ -137,14 +221,13 @@ def _export_documents_as_files(
                     page_break_placeholder=md_page_break_placeholder or None,
                 )
 
-            # Export Document Tags format:
             if export_doctags:
-                fname = output_dir / f"{doc_filename}.doctags"
-                _log.info(f"writing Doc Tags output to {fname}")
+                fname = output_dir / f'{doc_filename}.doctags'
+                _log.info(f'writing Doc Tags output to {fname}')
                 conv_res.document.save_as_doctags(filename=fname)
 
         else:
-            _log.warning(f"Document {conv_res.input.file} failed to convert.")
+            _log.warning(f'Document {conv_res.input.file} failed to convert.')
             failure_count += 1
 
     conv_result = (
@@ -152,8 +235,8 @@ def _export_documents_as_files(
     )
 
     _log.info(
-        f"Processed {success_count + failure_count} docs, "
-        f"of which {failure_count} failed"
+        f'Processed {success_count + failure_count} docs, '
+        f'of which {failure_count} failed'
     )
     return success_count, failure_count, conv_result
 
@@ -162,16 +245,13 @@ def process_export_results(
     task: Task,
     conv_results: Iterable[ConversionResult],
     work_dir: Path,
-    callback_invoker: Optional["CallbackInvoker"] = None,
+    callback_invoker: Optional['CallbackInvoker'] = None,
 ) -> DoclingTaskResult:
     conversion_options = task.convert_options
     if conversion_options is None:
-        raise RuntimeError("process_export_results called without task.convert_options")
+        raise RuntimeError('process_export_results called without task.convert_options')
 
-    # Let's start by processing the documents
     start_time = time.monotonic()
-
-    # 1. Send ProgressSetNumDocs at start
     total_docs = len(task.sources)
     if callback_invoker and task.callbacks and total_docs:
         callback_invoker.invoke_callbacks_async(
@@ -180,29 +260,21 @@ def process_export_results(
             progress=ProgressSetNumDocs(num_docs=total_docs),
         )
 
-    # 2. Process documents and send ProgressDocumentCompleted for each
-    # IMPORTANT: conv_results is a lazy iterator from convert_documents()
-    # The actual conversion happens as we iterate through it
     conv_results_list = []
     docs_succeeded: list[SucceededDocsItem] = []
     docs_failed: list[FailedDocsItem] = []
 
     for idx, conv_res in enumerate(conv_results):
-        # Document has JUST been converted (lazy evaluation triggered here)
         conv_results_list.append(conv_res)
-
-        # Track for final summary
         if conv_res.status == ConversionStatus.SUCCESS:
             docs_succeeded.append(SucceededDocsItem(source=str(conv_res.input.file)))
         else:
             docs_failed.append(
                 FailedDocsItem(
                     source=str(conv_res.input.file),
-                    error=str(conv_res.errors) if conv_res.errors else "Unknown error",
+                    error=str(conv_res.errors) if conv_res.errors else 'Unknown error',
                 )
             )
-
-        # Send per-document callback (non-blocking)
         if callback_invoker and task.callbacks:
             document_info = DocumentCompletedItem(
                 source=str(conv_res.input.file),
@@ -210,13 +282,11 @@ def process_export_results(
                 num_pages=(len(conv_res.document.pages) if conv_res.document else None),
                 processing_time=(
                     sum(sum(item.times) for item in conv_res.timings.values())
-                    if conv_res.timings
-                    else None
+                    if conv_res.timings else None
                 ),
                 doc_hash=conv_res.input.document_hash,
                 error=str(conv_res.errors) if conv_res.errors else None,
             )
-
             callback_invoker.invoke_callbacks_async(
                 callbacks=task.callbacks,
                 task_id=task.task_id,
@@ -230,12 +300,9 @@ def process_export_results(
     conv_results = conv_results_list
     processing_time = time.monotonic() - start_time
 
-    _log.info(f"Processed {len(conv_results)} docs in {processing_time:.2f} seconds.")
-
     if len(conv_results) == 0:
-        raise RuntimeError("No documents were generated by Docling.")
+        raise RuntimeError('No documents were generated by Docling.')
 
-    # 3. Send ProgressUpdateProcessed at end with final summary
     if callback_invoker and task.callbacks:
         callback_invoker.invoke_callbacks_async(
             callbacks=task.callbacks,
@@ -249,22 +316,18 @@ def process_export_results(
             ),
         )
 
-    # We have some results, let's prepare the response
     task_result: ResultType
     num_succeeded = 0
     num_failed = 0
 
-    # Booleans to know what to export
     export_json = OutputFormat.JSON in conversion_options.to_formats
     export_html = OutputFormat.HTML in conversion_options.to_formats
     export_md = OutputFormat.MARKDOWN in conversion_options.to_formats
     export_txt = OutputFormat.TEXT in conversion_options.to_formats
     export_doctags = OutputFormat.DOCTAGS in conversion_options.to_formats
 
-    # Only 1 document was processed, and we are not returning it as a file
     if len(conv_results) == 1 and isinstance(task.target, InBodyTarget):
         conv_res = conv_results[0]
-
         content = _export_document_as_content(
             conv_res,
             export_json=export_json,
@@ -274,25 +337,19 @@ def process_export_results(
             export_doctags=export_doctags,
             image_mode=conversion_options.image_export_mode,
             md_page_break_placeholder=conversion_options.md_page_break_placeholder,
+            work_dir=work_dir,
         )
         task_result = ExportResult(
             content=content,
             status=conv_res.status,
-            # processing_time=processing_time,
             timings=conv_res.timings,
             errors=conv_res.errors,
         )
-
         num_succeeded = 1 if conv_res.status == ConversionStatus.SUCCESS else 0
         num_failed = 1 if conv_res.status != ConversionStatus.SUCCESS else 0
-
-    # Multiple documents were processed, or we are forced returning as a file
     else:
-        # Temporary directory to store the outputs
-        output_dir = work_dir / "output"
+        output_dir = work_dir / 'output'
         output_dir.mkdir(parents=True, exist_ok=True)
-
-        # Export the documents
         num_succeeded, num_failed, _conv_result = _export_documents_as_files(
             conv_results=conv_results,
             output_dir=output_dir,
@@ -302,32 +359,26 @@ def process_export_results(
             export_txt=export_txt,
             export_doctags=export_doctags,
             image_export_mode=conversion_options.image_export_mode,
-            md_page_break_placeholder=conversion_options.md_page_break_placeholder,
+            md_page_break_placeholder=md_page_break_placeholder,
         )
-
         files = os.listdir(output_dir)
         if len(files) == 0:
-            raise RuntimeError("No documents were exported.")
-
-        file_path = work_dir / "converted_docs.zip"
+            raise RuntimeError('No documents were exported.')
+        file_path = work_dir / 'converted_docs.zip'
         shutil.make_archive(
-            base_name=str(file_path.with_suffix("")),
-            format="zip",
+            base_name=str(file_path.with_suffix('')),
+            format='zip',
             root_dir=output_dir,
         )
-
         if isinstance(task.target, PutTarget):
             try:
-                with file_path.open("rb") as file_data:
-                    r = httpx.put(str(task.target.url), files={"file": file_data})
+                with file_path.open('rb') as file_data:
+                    r = httpx.put(str(task.target.url), files={'file': file_data})
                     r.raise_for_status()
                 task_result = RemoteTargetResult()
             except Exception as exc:
-                _log.error("An error occour while uploading zip to s3", exc_info=exc)
-                raise RuntimeError(
-                    "An error occour while uploading zip to the target url."
-                )
-
+                _log.error('An error occour while uploading zip to s3', exc_info=exc)
+                raise RuntimeError('An error occour while uploading zip to the target url.')
         else:
             task_result = ZipArchiveResult(content=file_path.read_bytes())
 

--- a/docling_jobkit/datamodel/result.py
+++ b/docling_jobkit/datamodel/result.py
@@ -1,23 +1,115 @@
-from docling.datamodel.service.responses import (
-    ChunkedDocumentResult,
-    ChunkedDocumentResultItem,
-    ConvertDocumentResult,
-    DoclingTaskResult,
-    ExportDocumentResponse,
-    ExportResult,
-    RemoteTargetResult,
-    ResultType,
-    ZipArchiveResult,
-)
+import warnings
+from typing import Annotated, Literal, Optional
 
-__all__ = [
-    "ChunkedDocumentResult",
-    "ChunkedDocumentResultItem",
-    "ConvertDocumentResult",
-    "DoclingTaskResult",
-    "ExportDocumentResponse",
-    "ExportResult",
-    "RemoteTargetResult",
-    "ResultType",
-    "ZipArchiveResult",
+from pydantic import BaseModel, Field
+
+from docling.datamodel.base_models import ConversionStatus, ErrorItem
+from docling.utils.profiling import ProfilingItem
+from docling_core.types.doc.document import DoclingDocument
+
+
+class ExportDocumentResponse(BaseModel):
+    filename: str
+    output_dir: Optional[str] = None
+    md_content: Optional[str] = None
+    json_content: Optional[DoclingDocument] = None
+    html_content: Optional[str] = None
+    text_content: Optional[str] = None
+    doctags_content: Optional[str] = None
+
+
+class ExportResult(BaseModel):
+    """Container of all exported content."""
+
+    kind: Literal["ExportResult"] = "ExportResult"
+    content: ExportDocumentResponse
+    status: ConversionStatus
+    errors: list[ErrorItem] = []
+    timings: dict[str, ProfilingItem] = {}
+
+
+class ZipArchiveResult(BaseModel):
+    """Container for a zip archive of the conversion."""
+
+    kind: Literal["ZipArchiveResult"] = "ZipArchiveResult"
+    content: bytes
+
+
+class RemoteTargetResult(BaseModel):
+    """No content, the result has been pushed to a remote target."""
+
+    kind: Literal["RemoteTargetResult"] = "RemoteTargetResult"
+
+
+class ChunkedDocumentResultItem(BaseModel):
+    """A single chunk of a document with its metadata and content."""
+
+    filename: str
+    chunk_index: int
+    text: Annotated[
+        str,
+        Field(
+            description="The chunk text with structural context (headers, formatting)"
+        ),
+    ]
+    raw_text: Annotated[
+        str | None,
+        Field(
+            description="Raw chunk text without additional formatting or context",
+        ),
+    ] = None
+    num_tokens: Annotated[
+        int | None,
+        Field(
+            description="Number of tokens in the text, if the chunker is aware of tokens"
+        ),
+    ] = None
+    headings: Annotated[
+        list[str] | None, Field(description="List of headings for this chunk")
+    ] = None
+    captions: Annotated[
+        list[str] | None,
+        Field(
+            description="List of captions for this chunk (e.g. for pictures and tables)",
+        ),
+    ] = None
+    doc_items: Annotated[list[str], Field(description="List of doc items references")]
+    page_numbers: Annotated[
+        list[int] | None,
+        Field(description="Page numbers where this chunk content appears"),
+    ] = None
+    metadata: Annotated[
+        dict | None, Field(description="Additional metadata associated with this chunk")
+    ] = None
+
+
+class ChunkedDocumentResult(BaseModel):
+    kind: Literal["ChunkedDocumentResponse"] = "ChunkedDocumentResponse"
+    chunks: list[ChunkedDocumentResultItem]
+    documents: list[ExportResult]
+    chunking_info: Optional[dict] = None
+
+
+ResultType = Annotated[
+    ExportResult | ZipArchiveResult | RemoteTargetResult | ChunkedDocumentResult,
+    Field(discriminator="kind"),
 ]
+
+
+class DoclingTaskResult(BaseModel):
+    result: ResultType
+    processing_time: float
+    num_converted: int
+    num_succeeded: int
+    num_failed: int
+
+
+class ConvertDocumentResult(DoclingTaskResult):
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            "ConvertDocumentResult is deprecated and will be removed in a future version. "
+            "Use DoclingTaskResult instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)


### PR DESCRIPTION
## Summary\n- normalize broken Chinese spacing in exported JSON, Markdown, TXT, and HTML content\n- rewrite persisted export files after generation so downloaded artifacts and in-body responses stay consistent\n- preserve common English and numeric spacing while merging obvious broken Chinese line fragments\n\n## Validation\n- reproduced the issue with Chinese PDF exports in both the official image and local image\n- verified the hotfix inside the running container resolved the Chinese pseudo-space issue for the target sample\n