### PR TITLE
feat: Add Image Position References to Document Chunks

### DIFF
--- a/docling_jobkit/convert/chunking.py
+++ b/docling_jobkit/convert/chunking.py
@@ -2,9 +2,13 @@ import hashlib
 import logging
 import threading
 import time
+import os
+import shutil
 from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional
+
+import httpx
 
 from pydantic import BaseModel, Field
 
@@ -24,13 +28,15 @@ from docling.datamodel.service.chunking import (
     HybridChunkerOptions,
 )
 from docling.datamodel.service.options import ConvertDocumentsOptions
-from docling.datamodel.service.targets import InBodyTarget
+from docling.datamodel.service.targets import InBodyTarget, PutTarget
 from docling_core.transforms.chunker import BaseChunker
 from docling_core.transforms.chunker.hierarchical_chunker import (
     ChunkingSerializerProvider,
     DocChunk,
     HierarchicalChunker,
 )
+from docling.datamodel.base_models import OutputFormat
+
 from docling_core.transforms.chunker.hybrid_chunker import HybridChunker
 from docling_core.transforms.chunker.tokenizer.huggingface import (
     HuggingFaceTokenizer,
@@ -44,9 +50,11 @@ from docling_jobkit.datamodel.result import (
     DoclingTaskResult,
     ExportDocumentResponse,
     ExportResult,
+    RemoteTargetResult,
+    ZipArchiveResult
 )
 from docling_jobkit.datamodel.task import Task
-
+from docling_jobkit.convert.results import _export_documents_as_files
 if TYPE_CHECKING:
     from docling_jobkit.orchestrators.callback_invoker import CallbackInvoker
 
@@ -238,7 +246,7 @@ def process_chunk_results(
     start_time = time.monotonic()
     chunking_options = task.chunking_options or HybridChunkerOptions()
     conversion_options = task.convert_options or ConvertDocumentsOptions()
-
+    _log.debug(f"Starting chunking for task {task.task_id} with options: {conversion_options}")
     # 1. Send ProgressSetNumDocs at start
     total_docs = len(task.sources)
     if callback_invoker and task.callbacks and total_docs:
@@ -250,6 +258,7 @@ def process_chunk_results(
 
     # We have some results, let's prepare the response
     task_result: ChunkedDocumentResult
+    conv_results_list = []
     chunks: list[ChunkedDocumentResultItem] = []
     documents: list[ExportResult] = []
     num_succeeded = 0
@@ -260,7 +269,9 @@ def process_chunk_results(
     # TODO: DocumentChunkerManager should be initialized outside for really working as a cache
     chunker_manager = chunker_manager or DocumentChunkerManager()
     for idx, conv_res in enumerate(conv_results):
-        errors = conv_res.errors
+        # Document has JUST been converted (lazy evaluation triggered here)
+        conv_results_list.append(conv_res)
+        errors = conv_res.errors        
         filename = conv_res.input.file.name
         if conv_res.status == ConversionStatus.SUCCESS:
             try:
@@ -357,6 +368,7 @@ def process_chunk_results(
 
         documents.append(doc_result)
 
+    conv_results = conv_results_list  
     num_total = num_succeeded + num_failed
     processing_time = time.monotonic() - start_time
     _log.info(
@@ -376,7 +388,14 @@ def process_chunk_results(
                 docs_failed=docs_failed,
             ),
         )
-
+    
+    # Export results based on target type and options
+    # Booleans to know what to export
+    export_json = OutputFormat.JSON in conversion_options.to_formats
+    export_html = OutputFormat.HTML in conversion_options.to_formats
+    export_md = OutputFormat.MARKDOWN in conversion_options.to_formats
+    export_txt = OutputFormat.TEXT in conversion_options.to_formats
+    export_doctags = OutputFormat.DOCTAGS in conversion_options.to_formats
     if isinstance(task.target, InBodyTarget):
         task_result = ChunkedDocumentResult(
             chunks=chunks,
@@ -387,7 +406,48 @@ def process_chunk_results(
 
     # Multiple documents were processed, or we are forced returning as a file
     else:
-        raise NotImplementedError("Saving chunks to a file is not yet supported.")
+        # Temporary directory to store the outputs
+        output_dir = work_dir / "output"
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        # Export the documents
+        num_succeeded, num_failed, _conv_result = _export_documents_as_files(
+            conv_results=conv_results,
+            output_dir=output_dir,
+            export_json=export_json,
+            export_html=export_html,
+            export_md=export_md,
+            export_txt=export_txt,
+            export_doctags=export_doctags,
+            image_export_mode=conversion_options.image_export_mode,
+            md_page_break_placeholder=conversion_options.md_page_break_placeholder,
+        )
+
+        files = os.listdir(output_dir)
+        if len(files) == 0:
+            raise RuntimeError("No documents were exported.")
+
+        file_path = work_dir / "converted_docs.zip"
+        shutil.make_archive(
+            base_name=str(file_path.with_suffix("")),
+            format="zip",
+            root_dir=output_dir,
+        )
+
+        if isinstance(task.target, PutTarget):
+            try:
+                with file_path.open("rb") as file_data:
+                    r = httpx.put(str(task.target.url), files={"file": file_data})
+                    r.raise_for_status()
+                task_result = RemoteTargetResult()
+            except Exception as exc:
+                _log.error("An error occour while uploading zip to s3", exc_info=exc)
+                raise RuntimeError(
+                    "An error occour while uploading zip to the target url."
+                )
+
+        else:
+            task_result = ZipArchiveResult(content=file_path.read_bytes())
 
     return DoclingTaskResult(
         result=task_result,

--- a/docling_jobkit/convert/chunking.py
+++ b/docling_jobkit/convert/chunking.py
@@ -1,4 +1,6 @@
+import base64
 import hashlib
+from io import BytesIO
 import logging
 import threading
 import time
@@ -6,7 +8,7 @@ import os
 import shutil
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, override
 
 import httpx
 
@@ -31,6 +33,7 @@ from docling.datamodel.service.options import ConvertDocumentsOptions
 from docling.datamodel.service.targets import InBodyTarget, PutTarget
 from docling_core.transforms.chunker import BaseChunker
 from docling_core.transforms.chunker.hierarchical_chunker import (
+    ChunkingDocSerializer,
     ChunkingSerializerProvider,
     DocChunk,
     HierarchicalChunker,
@@ -38,11 +41,21 @@ from docling_core.transforms.chunker.hierarchical_chunker import (
 from docling.datamodel.base_models import OutputFormat
 
 from docling_core.transforms.chunker.hybrid_chunker import HybridChunker
+from docling_core.transforms.serializer.markdown import MarkdownPictureSerializer , MarkdownTableSerializer
 from docling_core.transforms.chunker.tokenizer.huggingface import (
     HuggingFaceTokenizer,
 )
-from docling_core.types.doc.document import DoclingDocument, ImageRefMode
+from docling_core.types.doc.document import DoclingDocument, ImageRefMode, PictureItem
 
+import uuid
+from pathlib import Path
+from typing import Any
+
+
+from docling_core.transforms.serializer.base import BaseDocSerializer, SerializationResult
+from docling_core.transforms.serializer.common import create_ser_result
+from docling_core.types.doc.document import DoclingDocument, PictureItem
+from typing_extensions import override
 from docling_jobkit.convert.results import _export_document_as_content
 from docling_jobkit.datamodel.result import (
     ChunkedDocumentResult,
@@ -55,26 +68,53 @@ from docling_jobkit.datamodel.result import (
 )
 from docling_jobkit.datamodel.task import Task
 from docling_jobkit.convert.results import _export_documents_as_files
+
 if TYPE_CHECKING:
     from docling_jobkit.orchestrators.callback_invoker import CallbackInvoker
 
 _log = logging.getLogger(__name__)
 
 
-class MarkdownTableSerializerProvider(ChunkingSerializerProvider):
-    """Serializer provider that uses markdown table format for table serialization."""
-
-    def get_serializer(self, doc):
-        """Get a serializer that uses markdown table format."""
-        from docling_core.transforms.chunker.hierarchical_chunker import (
-            ChunkingDocSerializer,
+# This class will be used to handle including references to where the images was exactly inside the document chunks that way we can reference images with theire exact position in the document.
+class PictureSerializer(MarkdownPictureSerializer):
+    """Custom picture serializer that includes a placeholder in the text and metadata for the image reference."""
+    @override
+    def serialize(
+        self,
+        *,
+        item: PictureItem,
+        doc_serializer: BaseDocSerializer,
+        doc: DoclingDocument,
+        **kwargs: Any,
+    ) -> SerializationResult:
+        return create_ser_result(
+            text=doc_serializer.post_process(text="![Picture]"),
+            span_source=item,
         )
-        from docling_core.transforms.serializer.markdown import MarkdownTableSerializer
+    
+class SerializerProviderFactory:
+    """Factory for creating serializer providers based on chunking options."""
 
-        return ChunkingDocSerializer(
-            doc=doc,
-            table_serializer=MarkdownTableSerializer(),
-        )
+    @staticmethod
+    def create_serializer_provider(**kwargs: Any) -> ChunkingSerializerProvider:
+        """Create a serializer provider based on chunking options."""
+        use_markdown_tables = bool(kwargs.get("use_markdown_tables"))
+        use_markdown_images = bool(kwargs.get("use_markdown_images"))
+
+        if not use_markdown_tables and not use_markdown_images:
+            return ChunkingSerializerProvider()
+
+        class CustomSerializerProvider(ChunkingSerializerProvider):
+            def get_serializer(self, doc: DoclingDocument):
+                serializers: dict[str, Any] = {}
+                if use_markdown_tables:
+                    serializers["table_serializer"] = MarkdownTableSerializer()
+                if use_markdown_images:
+                    serializers["picture_serializer"] = PictureSerializer()
+                return ChunkingDocSerializer(doc=doc, **serializers)
+
+        return CustomSerializerProvider()
+        
 
 
 class DocumentChunkerConfig(BaseModel):
@@ -91,8 +131,9 @@ class DocumentChunkerConfig(BaseModel):
 class DocumentChunkerManager:
     """Handles document chunking for RAG workflows using chunkers from docling-core."""
 
-    def __init__(self, config: Optional[DocumentChunkerConfig] = None):
+    def __init__(self, config: Optional[DocumentChunkerConfig] = None , conversion_options: Optional[ConvertDocumentsOptions] = None):
         self.config = config or DocumentChunkerConfig()
+        self.conversion_options = conversion_options
         self._cache_lock = threading.Lock()
         self._options_map: dict[bytes, BaseChunkerOptions] = {}
         self._get_chunker_from_cache = self._create_chunker_cache()
@@ -105,13 +146,16 @@ class DocumentChunkerManager:
             try:
                 options = self._options_map[cache_key]
 
+                use_markdown_tables = options.use_markdown_tables if hasattr(options, "use_markdown_tables") else False
+                use_markdown_images = False
+                if self.conversion_options and self.conversion_options.image_export_mode is not None and self.conversion_options.image_export_mode != ImageRefMode.PLACEHOLDER:
+                    use_markdown_images = True
+                _log.debug(f"Using serializer options - Markdown Tables: {use_markdown_tables}, Markdown Images: {use_markdown_images}")
                 # Create serializer provider based on markdown table option
-                if options.use_markdown_tables:
-                    serializer_provider: ChunkingSerializerProvider = (
-                        MarkdownTableSerializerProvider()
-                    )
-                else:
-                    serializer_provider = ChunkingSerializerProvider()
+                serializer_provider = SerializerProviderFactory.create_serializer_provider(
+                    use_markdown_tables= use_markdown_tables,
+                    use_markdown_images= use_markdown_images
+                )
 
                 if isinstance(options, HybridChunkerOptions):
                     # Create tokenizer
@@ -208,6 +252,8 @@ class DocumentChunkerManager:
             # Store additional metadata
             if doc_chunk.meta.origin:
                 metadata["origin"] = doc_chunk.meta.origin
+            if "![Picture]" in doc_chunk.text:
+                metadata["has_image"] = True
 
             # Get the text
             text = chunker.contextualize(doc_chunk)
@@ -267,7 +313,7 @@ def process_chunk_results(
     docs_failed: list[FailedDocsItem] = []
 
     # TODO: DocumentChunkerManager should be initialized outside for really working as a cache
-    chunker_manager = chunker_manager or DocumentChunkerManager()
+    chunker_manager = chunker_manager or DocumentChunkerManager(conversion_options=conversion_options)
     for idx, conv_res in enumerate(conv_results):
         # Document has JUST been converted (lazy evaluation triggered here)
         conv_results_list.append(conv_res)

--- a/docling_jobkit/convert/manager.py
+++ b/docling_jobkit/convert/manager.py
@@ -1465,7 +1465,7 @@ class DoclingConverterManager:
 
         if request.image_export_mode != ImageRefMode.PLACEHOLDER:
             pipeline_options.generate_page_images = True
-            if request.image_export_mode == ImageRefMode.REFERENCED:
+            if request.image_export_mode == ImageRefMode.REFERENCED or request.image_export_mode == ImageRefMode.EMBEDDED:
                 pipeline_options.generate_picture_images = True
             if request.images_scale:
                 pipeline_options.images_scale = request.images_scale

--- a/docling_jobkit/datamodel/task.py
+++ b/docling_jobkit/datamodel/task.py
@@ -68,7 +68,7 @@ class Task(BaseModel):
                 DeprecationWarning,
                 stacklevel=2,
             )
-            values["conversion_options"] = values["options"]
+            values["convert_options"] = values["options"]
         return values
 
     def set_status(self, status: TaskStatus):

--- a/docling_jobkit/orchestrators/local/worker.py
+++ b/docling_jobkit/orchestrators/local/worker.py
@@ -105,7 +105,7 @@ class AsyncLocalWorker:
                             task=task,
                             conv_results=conv_results,
                             work_dir=workdir,
-                            chunker_manager=self.orchestrator.chunker_manager,
+                            chunker_manager=None,
                             callback_invoker=callback_invoker,
                         )
 


### PR DESCRIPTION
## Summary

Enhance the chunking pipeline to include precise image-to-chunk mapping metadata, enabling accurate tracking of image positions within documents. This addresses current limitations where image presence is not indicated within the chunks and so we can't exactly know where that image live inside the document.

---

## Current Limitation

In the existing implementation :

* Images are not present in the chunks part of the output, they are only present in the documents.content.type_content.pictures

### There is no precise information about:

-   Where the image lives exactly in the document.
-   Which chunk come before and after the image.
-   Limitation concerning handling image in a RAG pipeline.

---

## Impact

This lack of granularity prevents:

* Accurate image-to-chunk association
* Reconstruction of documents with correct image placement
* Effective use in RAG pipelines where contextual alignment matters
* Downstream processing requiring image provenance or positioning

---


## Proposed Enhancement

* Images are serialized using a static placeholder:
```markdown
chunk_i-1  ![Picture] chunk_i+1
```
* Chunk metadata includes :

  ```json
  {
    "has_image": true
  }
  ```
* And so the output will look like this : 

```json
    {
      "text": "text \n![Picture]\n text",
      "headings": [
        "heading"
      ],   
     "page_numbers": [2],
      "metadata": {
        "origin": {
          "mimetype": "application/pdf",
          "binary_hash": 16467438883613526983,
          "filename": "file.pdf",
          "uri": null
        },
        "has_image": true
      }
    }
```
* Like this we made sure we have enough information about our chunk images.

---
## Benefits

* Enables precise multimodal alignment in RAG systems
* Supports document reconstruction with layout fidelity
---