### PR TITLE
feat(rq): Add Redis Sentinel support to RQ orchestrator

### DIFF
--- a/docling_jobkit/orchestrators/_redis.py
+++ b/docling_jobkit/orchestrators/_redis.py
@@ -1,0 +1,240 @@
+"""Unified Redis client factory for orchestrators.
+
+Supports redis://, rediss://, unix://, redis+sentinel://, rediss+sentinel://.
+
+Redis Cluster is rejected at config-build time: orchestrator transactions
+and Lua scripts span keys that would land on different hash slots
+(CROSSSLOT). Supporting cluster requires a keyspace redesign with hash
+tags first, so the URL layer fails loud rather than silently misbehaving.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Optional
+from urllib.parse import parse_qs, unquote, urlparse
+
+import redis
+import redis.asyncio as async_redis
+import redis.asyncio.sentinel as async_sentinel
+import redis.sentinel as sentinel
+
+SENTINEL_URL_SCHEMES = ("redis+sentinel://", "rediss+sentinel://")
+SINGLE_URL_SCHEMES = ("redis://", "rediss://", "unix://")
+_CLUSTER_URL_SCHEMES = ("redis+cluster", "rediss+cluster", "redis-cluster")
+
+
+class RedisMode(str, Enum):
+    SINGLE = "single"
+    SENTINEL = "sentinel"
+
+
+class UnsupportedRedisModeError(ValueError):
+    pass
+
+
+def validate_url(url: str) -> None:
+    """Run from a Pydantic model_validator so bad URLs raise at config build."""
+    detect_mode(url)
+    if url.startswith(SENTINEL_URL_SCHEMES):
+        parse_sentinel_url(url)
+
+
+def detect_mode(url: str) -> RedisMode:
+    parsed = urlparse(url)
+    scheme = parsed.scheme.lower()
+
+    if "cluster" in parse_qs(parsed.query):
+        raise UnsupportedRedisModeError(
+            "Redis Cluster is not supported (?cluster=… is a no-op in "
+            "redis-py and our orchestrators rely on multi-key transactions "
+            "that fail with CROSSSLOT in cluster mode). Use redis:// for "
+            "single-node or redis+sentinel:// for HA."
+        )
+
+    match scheme:
+        case "redis" | "rediss" | "unix":
+            return RedisMode.SINGLE
+        case "redis+sentinel" | "rediss+sentinel":
+            return RedisMode.SENTINEL
+        case s if s in _CLUSTER_URL_SCHEMES:
+            raise UnsupportedRedisModeError(
+                f"Redis Cluster URL scheme '{s}://' is not supported. "
+                "Our orchestrators use multi-key transactions and Lua "
+                "scripts that span hash slots; running them against a "
+                "cluster would surface as CROSSSLOT errors at runtime. "
+                "Use redis:// for single-node or redis+sentinel:// for HA."
+            )
+        case _:
+            raise ValueError(
+                f"Unsupported redis URL scheme: '{scheme}://'. "
+                "Expected one of: redis://, rediss://, unix://, "
+                "redis+sentinel://, rediss+sentinel://."
+            )
+
+
+@dataclass(frozen=True)
+class SentinelTarget:
+    hosts: list[tuple[str, int]]
+    service_name: str
+    db: int = 0
+    username: Optional[str] = None
+    password: Optional[str] = None
+    sentinel_username: Optional[str] = None
+    sentinel_password: Optional[str] = None
+    ssl: bool = False
+
+
+def parse_sentinel_url(url: str) -> SentinelTarget:
+    """Parse `redis+sentinel://[user:pass@]h1[:p],h2[:p],…/master[/db][?…]`.
+
+    Userinfo carries the master creds. Sentinel-daemon creds and ssl ride in
+    query params (`sentinel_username`, `sentinel_password`, `ssl`). The
+    `rediss+sentinel://` scheme is a synonym for `?ssl=true`.
+    """
+    if not url.startswith(SENTINEL_URL_SCHEMES):
+        raise ValueError(
+            f"Sentinel URL must start with one of {SENTINEL_URL_SCHEMES}"
+        )
+
+    parsed = urlparse(url)
+    netloc = parsed.netloc
+    if "@" in netloc:
+        userinfo, _, hostpart = netloc.rpartition("@")
+    else:
+        userinfo, hostpart = "", netloc
+
+    username: Optional[str] = None
+    password: Optional[str] = None
+    if userinfo:
+        if ":" in userinfo:
+            user, _, pwd = userinfo.partition(":")
+            username = unquote(user) if user else None
+            password = unquote(pwd) if pwd else None
+        else:
+            username = unquote(userinfo)
+
+    if not hostpart:
+        raise ValueError("Sentinel URL must include at least one sentinel host")
+    hosts: list[tuple[str, int]] = []
+    for entry in hostpart.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        host, sep, port = entry.rpartition(":")
+        if sep:
+            hosts.append((host, int(port)))
+        else:
+            hosts.append((port, 26379))
+    if not hosts:
+        raise ValueError("Sentinel URL must include at least one sentinel host")
+
+    path_parts = [p for p in parsed.path.split("/") if p]
+    if not path_parts:
+        raise ValueError(
+            "Sentinel URL must include the master/service name in the path "
+            "(e.g. /mymaster)"
+        )
+    service_name = unquote(path_parts[0])
+    db = int(path_parts[1]) if len(path_parts) > 1 else 0
+
+    query = {k: v[-1] for k, v in parse_qs(parsed.query).items() if v}
+    ssl = parsed.scheme == "rediss+sentinel" or _to_bool(query.get("ssl"))
+
+    return SentinelTarget(
+        hosts=hosts,
+        service_name=service_name,
+        db=db,
+        username=username,
+        password=password,
+        sentinel_username=query.get("sentinel_username"),
+        sentinel_password=query.get("sentinel_password"),
+        ssl=ssl,
+    )
+
+
+def _to_bool(value: Optional[str]) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "t", "yes", "y", "on"}
+
+
+@dataclass(frozen=True)
+class RedisSettings:
+    url: str = "redis://localhost:6379/"
+    max_connections: int = 50
+    socket_timeout: Optional[float] = None
+    socket_connect_timeout: Optional[float] = None
+    decode_responses: bool = False
+
+
+def _master_kwargs(target: SentinelTarget, s: RedisSettings) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {
+        "db": target.db,
+        "max_connections": s.max_connections,
+        "socket_timeout": s.socket_timeout,
+        "socket_connect_timeout": s.socket_connect_timeout,
+        "decode_responses": s.decode_responses,
+    }
+    if target.username is not None:
+        kwargs["username"] = target.username
+    if target.password is not None:
+        kwargs["password"] = target.password
+    if target.ssl:
+        kwargs["ssl"] = True
+    return kwargs
+
+
+def _sentinel_kwargs(target: SentinelTarget, s: RedisSettings) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {
+        "socket_timeout": s.socket_timeout,
+        "socket_connect_timeout": s.socket_connect_timeout,
+    }
+    if target.sentinel_username is not None:
+        kwargs["username"] = target.sentinel_username
+    if target.sentinel_password is not None:
+        kwargs["password"] = target.sentinel_password
+    return kwargs
+
+
+def make_sync_client(s: RedisSettings) -> redis.Redis:
+    match detect_mode(s.url):
+        case RedisMode.SENTINEL:
+            target = parse_sentinel_url(s.url)
+            sentinel_client = sentinel.Sentinel(
+                target.hosts,
+                sentinel_kwargs=_sentinel_kwargs(target, s),
+            )
+            return sentinel_client.master_for(
+                target.service_name, **_master_kwargs(target, s)
+            )
+        case RedisMode.SINGLE:
+            pool = redis.ConnectionPool.from_url(
+                s.url,
+                max_connections=s.max_connections,
+                socket_timeout=s.socket_timeout,
+                socket_connect_timeout=s.socket_connect_timeout,
+                decode_responses=s.decode_responses,
+            )
+            return redis.Redis(connection_pool=pool)
+
+
+def make_async_client(s: RedisSettings) -> async_redis.Redis:
+    match detect_mode(s.url):
+        case RedisMode.SENTINEL:
+            target = parse_sentinel_url(s.url)
+            sentinel_client = async_sentinel.Sentinel(
+                target.hosts,
+                sentinel_kwargs=_sentinel_kwargs(target, s),
+            )
+            return sentinel_client.master_for(
+                target.service_name, **_master_kwargs(target, s)
+            )
+        case RedisMode.SINGLE:
+            pool = async_redis.ConnectionPool.from_url(
+                s.url,
+                max_connections=s.max_connections,
+                socket_timeout=s.socket_timeout,
+                socket_connect_timeout=s.socket_connect_timeout,
+                decode_responses=s.decode_responses,
+            )
+            return async_redis.Redis(connection_pool=pool)

--- a/docling_jobkit/orchestrators/ray/README.md
+++ b/docling_jobkit/orchestrators/ray/README.md
@@ -27,7 +27,7 @@ The Ray Orchestrator implements a fair round-robin scheduling algorithm at the t
 ### 3. Fault Tolerance
 - **Automatic retries**: Configurable retry logic for failed tasks
 - **Ray Actor recovery**: Dispatcher automatically restarts on failure
-- **Redis HA support**: Compatible with Redis Sentinel and Redis Cluster
+- **Redis HA support**: Compatible with Redis Sentinel via `redis+sentinel://` URLs (Redis Cluster is not supported — orchestrator transactions span multiple keys and would surface CROSSSLOT errors)
 - **OOM protection**: Handles out-of-memory conditions gracefully
 
 ### 4. Scalability
@@ -162,12 +162,36 @@ orchestrator = RayOrchestrator(
 )
 ```
 
+### Redis Connection URL
+
+`redis_url` accepts the following schemes:
+
+| Scheme | Example | Use |
+|---|---|---|
+| `redis://` | `redis://host:6379/0` | Single node |
+| `rediss://` | `rediss://host:6380/0` | Single node, TLS |
+| `unix://` | `unix:///var/run/redis.sock` | Unix socket |
+| `redis+sentinel://` | `redis+sentinel://[user:pass@]h1[:p],h2[:p],…/master[/db][?…]` | Sentinel HA |
+| `rediss+sentinel://` | as above, synonym for `?ssl=true` | Sentinel HA, TLS to master |
+
+Sentinel URL parts:
+
+- `userinfo` — Redis master credentials
+- comma-separated netloc hosts — Sentinel daemons (default port `26379`)
+- path — master/service name and optional db (default `0`)
+- query params:
+  - `sentinel_username`, `sentinel_password` — credentials for the Sentinel daemons themselves (separate from the master credentials in the userinfo)
+  - `ssl=true` — TLS to the master (alternative to using `rediss+sentinel://`)
+
+Redis Cluster is not supported: orchestrator transactions and Lua scripts span keys that would land on different hash slots (CROSSSLOT). Cluster URLs and `?cluster=…` are rejected at config-build time.
+
 ### Advanced Configuration
 
 ```python
 config = RayOrchestratorConfig(
-    # Redis HA (Sentinel)
-    redis_url="redis+sentinel://sentinel-host:26379/mymaster/0",
+    # Redis HA (Sentinel) — comma-separate the sentinel daemons in the netloc.
+    # Use rediss+sentinel:// or ?ssl=true for TLS to the master.
+    redis_url="redis+sentinel://sentinel-1:26379,sentinel-2:26379,sentinel-3:26379/mymaster/0",
     redis_max_connections=50,
     
     # Queue limits with rejection

--- a/docling_jobkit/orchestrators/ray/config.py
+++ b/docling_jobkit/orchestrators/ray/config.py
@@ -6,6 +6,8 @@ from typing import Optional
 from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from docling_jobkit.orchestrators import _redis as _redis_factory
+
 
 class RayOrchestratorConfig(BaseSettings):
     """Configuration for Ray + Redis orchestrator.
@@ -26,13 +28,13 @@ class RayOrchestratorConfig(BaseSettings):
     )
 
     # Redis Configuration
-    # Supports standard Redis, Redis Sentinel, and Redis Cluster via URL:
+    # Supports standard Redis and Redis Sentinel via URL:
     # - Standard: "redis://localhost:6379/"
-    # - Sentinel: "redis+sentinel://sentinel-host:26379/mymaster/0"
-    # - Cluster: "redis://cluster-node:6379/?cluster=true"
+    # - Sentinel: "redis+sentinel://[user:pass@]h1[:p],h2[:p],…/mymaster[/db]"
+    # See docling_jobkit.orchestrators._redis.detect_mode for the full grammar.
     redis_url: str = Field(
         default="redis://localhost:6379/",
-        description="Redis connection URL (supports standard, sentinel, cluster)",
+        description="Redis connection URL (supports standard and sentinel)",
     )
     redis_max_connections: int = Field(
         default=50, description="Maximum connections in Redis pool"
@@ -280,4 +282,9 @@ class RayOrchestratorConfig(BaseSettings):
         if self.heartbeat_interval <= 0:
             raise ValueError("heartbeat_interval must be > 0")
 
+        return self
+
+    @model_validator(mode="after")
+    def validate_redis_url(self) -> "RayOrchestratorConfig":
+        _redis_factory.validate_url(self.redis_url)
         return self

--- a/docling_jobkit/orchestrators/ray/dispatcher.py
+++ b/docling_jobkit/orchestrators/ray/dispatcher.py
@@ -18,7 +18,7 @@ from docling_jobkit.orchestrators.ray.models import (
     RedisTaskMetadata,
     TaskUpdate,
 )
-from docling_jobkit.orchestrators.ray.redis_helper import RedisStateManager
+from docling_jobkit.orchestrators.ray.state_manager import RedisStateManager
 
 _log = logging.getLogger(__name__)
 

--- a/docling_jobkit/orchestrators/ray/orchestrator.py
+++ b/docling_jobkit/orchestrators/ray/orchestrator.py
@@ -32,7 +32,7 @@ from docling_jobkit.orchestrators.base_orchestrator import (
 )
 from docling_jobkit.orchestrators.ray.config import RayOrchestratorConfig
 from docling_jobkit.orchestrators.ray.dispatcher import RayTaskDispatcher
-from docling_jobkit.orchestrators.ray.redis_helper import RedisStateManager
+from docling_jobkit.orchestrators.ray.state_manager import RedisStateManager
 from docling_jobkit.orchestrators.ray.serve_deployment import deploy_processor
 
 _log = logging.getLogger(__name__)

--- a/docling_jobkit/orchestrators/ray/serve_deployment.py
+++ b/docling_jobkit/orchestrators/ray/serve_deployment.py
@@ -31,7 +31,7 @@ from docling_jobkit.orchestrators.ray.logging_utils import (
     configure_ray_actor_logging,
 )
 from docling_jobkit.orchestrators.ray.models import TaskUpdate
-from docling_jobkit.orchestrators.ray.redis_helper import RedisStateManager
+from docling_jobkit.orchestrators.ray.state_manager import RedisStateManager
 
 _log = logging.getLogger(__name__)
 

--- a/docling_jobkit/orchestrators/ray/state_manager.py
+++ b/docling_jobkit/orchestrators/ray/state_manager.py
@@ -17,6 +17,7 @@ from docling.datamodel.service.tasks import TaskType
 from docling_jobkit.datamodel.result import DoclingTaskResult
 from docling_jobkit.datamodel.task import Task
 from docling_jobkit.datamodel.task_meta import TaskStatus
+from docling_jobkit.orchestrators import _redis as _redis_factory
 from docling_jobkit.orchestrators.ray.models import (
     RedisTaskMetadata,
     TaskTerminalizationResult,
@@ -67,7 +68,7 @@ class RedisStateManager:
         """Initialize Redis state manager.
 
         Args:
-            redis_url: Redis connection URL (supports standard, sentinel, cluster)
+            redis_url: Redis connection URL
             results_ttl: Time-to-live for task results in seconds
             results_prefix: Prefix for result keys
             sub_channel: Pub/sub channel name for task updates
@@ -119,21 +120,29 @@ class RedisStateManager:
     async def connect(self):
         """Establish Redis connection.
 
-        Creates the connection pool in the current event loop to avoid
-        'Future attached to a different loop' errors.
+        Creates the connection pool / Sentinel-resolved client in the current
+        event loop to avoid 'Future attached to a different loop' errors.
         """
         if self.redis is None:
-            # Create connection pool in the current event loop
-            self.pool = ConnectionPool.from_url(
-                self.redis_url,
+            settings = _redis_factory.RedisSettings(
+                url=self.redis_url,
                 max_connections=self.max_connections,
                 socket_timeout=self.socket_timeout,
                 socket_connect_timeout=self.socket_connect_timeout,
                 decode_responses=False,  # We handle encoding/decoding
             )
-            self.redis = Redis(connection_pool=self.pool)
+            self.redis = _redis_factory.make_async_client(settings)
+            self.pool = self.redis.connection_pool
             self._update_task_execution_heartbeat_sha = None
-            _log.info(f"Connected to Redis at {self.redis_url}")
+            if _redis_factory.detect_mode(self.redis_url) == _redis_factory.RedisMode.SENTINEL:
+                target = _redis_factory.parse_sentinel_url(self.redis_url)
+                _log.info(
+                    f"Connected to Redis via Sentinel: "
+                    f"service={target.service_name}, sentinels={target.hosts}, "
+                    f"db={target.db}, ssl={target.ssl}"
+                )
+            else:
+                _log.info(f"Connected to Redis at {self.redis_url}")
 
     async def disconnect(self):
         """Close Redis connection and pool."""

--- a/docling_jobkit/orchestrators/rq/README.md
+++ b/docling_jobkit/orchestrators/rq/README.md
@@ -1,0 +1,63 @@
+# RQ Orchestrator
+
+RQ-based orchestrator for Docling document processing. Uses Redis as the queue and result store; workers run in separate processes via `rq` workers.
+
+## Configuration
+
+`RQOrchestratorConfig` reads from environment variables (or constructor kwargs). The most relevant knobs:
+
+| Field | Default | Purpose |
+|---|---|---|
+| `redis_url` | `redis://localhost:6379/` | Redis connection URL — see below |
+| `redis_max_connections` | `50` | Connections in the Redis pool |
+| `results_ttl` | `4h` | TTL for job results |
+| `failure_ttl` | `4h` | TTL for failed-job records |
+| `redis_gate_concurrency` | `max_connections - 10` | Cap on caller-facing Redis ops to keep connections free for background work |
+
+## Redis Connection URL
+
+`redis_url` accepts the following schemes:
+
+| Scheme | Example | Use |
+|---|---|---|
+| `redis://` | `redis://host:6379/0` | Single node |
+| `rediss://` | `rediss://host:6380/0` | Single node, TLS |
+| `unix://` | `unix:///var/run/redis.sock` | Unix socket |
+| `redis+sentinel://` | `redis+sentinel://[user:pass@]h1[:p],h2[:p],…/master[/db][?…]` | Sentinel HA |
+| `rediss+sentinel://` | as above, synonym for `?ssl=true` | Sentinel HA, TLS to master |
+
+Sentinel URL parts:
+
+- `userinfo` — Redis master credentials
+- comma-separated netloc hosts — Sentinel daemons (default port `26379`)
+- path — master/service name and optional db (default `0`)
+- query params:
+  - `sentinel_username`, `sentinel_password` — credentials for the Sentinel daemons themselves (separate from the master credentials in the userinfo)
+  - `ssl=true` — TLS to the master (alternative to `rediss+sentinel://`)
+
+Redis Cluster is not supported: orchestrator transactions span multiple keys and would surface CROSSSLOT errors. Cluster URLs and `?cluster=…` are rejected at config-build time.
+
+## Examples
+
+```python
+from docling_jobkit.orchestrators.rq.orchestrator import (
+    RQOrchestrator, RQOrchestratorConfig,
+)
+
+# Single node
+config = RQOrchestratorConfig(redis_url="redis://localhost:6379/")
+
+# Sentinel-fronted HA cluster
+config = RQOrchestratorConfig(
+    redis_url=(
+        "redis+sentinel://:redis-master-password@s1,s2,s3/mymaster"
+        "?sentinel_password=sentinel-daemon-password"
+    ),
+)
+
+orchestrator = RQOrchestrator(config)
+```
+
+## Worker
+
+Workers are launched out-of-process and connect to the same Redis. See `docling_jobkit.orchestrators.rq.worker.CustomRQWorker` for the in-tree worker class. It reuses the same `RQOrchestratorConfig` so worker and orchestrator stay in sync (including Sentinel routing — the worker heartbeat thread also uses the resolved master).

--- a/docling_jobkit/orchestrators/rq/orchestrator.py
+++ b/docling_jobkit/orchestrators/rq/orchestrator.py
@@ -7,13 +7,10 @@ import uuid
 import warnings
 from pathlib import Path
 from typing import Any, Optional
-from urllib.parse import parse_qs, unquote, urlparse
 
 import msgpack
 import redis
 import redis.asyncio as async_redis
-import redis.asyncio.sentinel as async_sentinel
-import redis.sentinel as sentinel
 from pydantic import BaseModel, model_validator
 from rq import Queue
 from rq.exceptions import NoSuchJobError
@@ -31,6 +28,7 @@ from docling_jobkit.datamodel.chunking import ChunkingExportOptions
 from docling_jobkit.datamodel.result import DoclingTaskResult
 from docling_jobkit.datamodel.task import Task, TaskSource, TaskTarget
 from docling_jobkit.datamodel.task_meta import TaskStatus
+from docling_jobkit.orchestrators import _redis as _redis_factory
 from docling_jobkit.orchestrators._redis_gate import RedisCallerGate
 from docling_jobkit.orchestrators.base_orchestrator import (
     BaseOrchestrator,
@@ -38,99 +36,6 @@ from docling_jobkit.orchestrators.base_orchestrator import (
 )
 
 _log = logging.getLogger(__name__)
-
-
-_SENTINEL_URL_SCHEMES = ("redis+sentinel://", "rediss+sentinel://")
-
-
-class _SentinelUrlConfig(BaseModel):
-    """Parsed `redis+sentinel://` URL, ready to feed Sentinel.master_for()."""
-
-    hosts: list[tuple[str, int]]
-    service_name: str
-    db: int = 0
-    username: Optional[str] = None
-    password: Optional[str] = None
-    sentinel_username: Optional[str] = None
-    sentinel_password: Optional[str] = None
-    ssl: bool = False
-
-
-def _parse_sentinel_url(url: str) -> _SentinelUrlConfig:
-    """Parse `redis+sentinel://[user:pass@]h1[:p1][,h2[:p2]...]/master[/db][?…]`.
-
-    redis-py's own `from_url` rejects this scheme, so we parse it ourselves.
-    Comma-separated sentinel hosts go in the netloc; the master name (and
-    optional db) live in the path; sentinel-side credentials and `ssl` ride
-    in query params (URL userinfo is reserved for the Redis master itself).
-
-    `rediss+sentinel://` is accepted as a synonym for `?ssl=true`.
-    """
-    if not url.startswith(_SENTINEL_URL_SCHEMES):
-        raise ValueError(
-            f"Sentinel URL must start with one of {_SENTINEL_URL_SCHEMES}"
-        )
-
-    parsed = urlparse(url)
-    netloc = parsed.netloc
-    if "@" in netloc:
-        userinfo, _, hostpart = netloc.rpartition("@")
-    else:
-        userinfo, hostpart = "", netloc
-
-    username: Optional[str] = None
-    password: Optional[str] = None
-    if userinfo:
-        if ":" in userinfo:
-            user, _, pwd = userinfo.partition(":")
-            username = unquote(user) if user else None
-            password = unquote(pwd) if pwd else None
-        else:
-            username = unquote(userinfo)
-
-    if not hostpart:
-        raise ValueError("Sentinel URL must include at least one sentinel host")
-    hosts: list[tuple[str, int]] = []
-    for entry in hostpart.split(","):
-        entry = entry.strip()
-        if not entry:
-            continue
-        host, sep, port = entry.rpartition(":")
-        if sep:
-            hosts.append((host, int(port)))
-        else:
-            hosts.append((port, 26379))
-    if not hosts:
-        raise ValueError("Sentinel URL must include at least one sentinel host")
-
-    path_parts = [p for p in parsed.path.split("/") if p]
-    if not path_parts:
-        raise ValueError(
-            "Sentinel URL must include the master/service name in the path "
-            "(e.g. /mymaster)"
-        )
-    service_name = unquote(path_parts[0])
-    db = int(path_parts[1]) if len(path_parts) > 1 else 0
-
-    query = {k: v[-1] for k, v in parse_qs(parsed.query).items() if v}
-    ssl = parsed.scheme == "rediss+sentinel" or _to_bool(query.get("ssl"))
-
-    return _SentinelUrlConfig(
-        hosts=hosts,
-        service_name=service_name,
-        db=db,
-        username=username,
-        password=password,
-        sentinel_username=query.get("sentinel_username"),
-        sentinel_password=query.get("sentinel_password"),
-        ssl=ssl,
-    )
-
-
-def _to_bool(value: Optional[str]) -> bool:
-    if value is None:
-        return False
-    return value.strip().lower() in {"1", "true", "t", "yes", "y", "on"}
 
 
 class RQOrchestratorConfig(BaseModel):
@@ -152,31 +57,6 @@ class RQOrchestratorConfig(BaseModel):
     zombie_reaper_max_age: float = 3600.0
     result_removal_delay: int = 300  # seconds until result key expires after fetch
 
-    # Redis Sentinel can be configured two ways:
-    #
-    # 1. URL form (preferred) — set `redis_url` to
-    #    `redis+sentinel://[user:pass@]h1[:p],h2[:p],…/service_name[/db][?…]`.
-    #    Use `rediss+sentinel://` (or `?ssl=true`) for TLS to the master.
-    #    Query params: `sentinel_username`, `sentinel_password` (creds for the
-    #    Sentinel daemons themselves, separate from the master creds in the
-    #    userinfo), and `ssl`.
-    #
-    # 2. Explicit fields below — for programmatic configuration where building
-    #    a URL is awkward. When `redis_sentinel_hosts` and
-    #    `redis_sentinel_service_name` are both set they take priority over
-    #    `redis_url`. Each entry in `redis_sentinel_hosts` may be `host`
-    #    (port defaults to 26379) or `host:port`.
-    redis_sentinel_hosts: Optional[list[str]] = None
-    redis_sentinel_service_name: Optional[str] = None
-    redis_sentinel_db: int = 0
-    redis_sentinel_username: Optional[str] = None
-    redis_sentinel_password: Optional[str] = None
-    # Credentials used to authenticate to the Sentinel daemons themselves
-    # (separate from the Redis master credentials above).
-    redis_sentinel_auth_username: Optional[str] = None
-    redis_sentinel_auth_password: Optional[str] = None
-    redis_sentinel_ssl: bool = False
-
     @model_validator(mode="after")
     def resolve_redis_gate_concurrency(self) -> "RQOrchestratorConfig":
         if self.redis_gate_concurrency is None:
@@ -186,124 +66,29 @@ class RQOrchestratorConfig(BaseModel):
         return self
 
     @model_validator(mode="after")
-    def validate_sentinel_config(self) -> "RQOrchestratorConfig":
-        if bool(self.redis_sentinel_hosts) ^ bool(self.redis_sentinel_service_name):
-            raise ValueError(
-                "redis_sentinel_hosts and redis_sentinel_service_name must be "
-                "set together"
-            )
-        if self.redis_url.startswith(_SENTINEL_URL_SCHEMES):
-            # Validate the URL eagerly so misconfigurations surface at config
-            # construction, not on the first connection attempt.
-            _parse_sentinel_url(self.redis_url)
+    def validate_redis_config(self) -> "RQOrchestratorConfig":
+        _redis_factory.validate_url(self.redis_url)
         return self
 
     @property
     def use_sentinel(self) -> bool:
-        if self.redis_sentinel_hosts and self.redis_sentinel_service_name:
-            return True
-        return self.redis_url.startswith(_SENTINEL_URL_SCHEMES)
+        return self.redis_url.startswith(_redis_factory.SENTINEL_URL_SCHEMES)
 
-
-def _resolve_sentinel(config: RQOrchestratorConfig) -> _SentinelUrlConfig:
-    """Collapse either configuration form into a single parsed structure.
-
-    Explicit fields win over the URL when both are set, matching the
-    `use_sentinel` precedence in `RQOrchestratorConfig`.
-    """
-    if config.redis_sentinel_hosts and config.redis_sentinel_service_name:
-        hosts: list[tuple[str, int]] = []
-        for entry in config.redis_sentinel_hosts:
-            host, sep, port = entry.rpartition(":")
-            if sep:
-                hosts.append((host, int(port)))
-            else:
-                hosts.append((port, 26379))
-        return _SentinelUrlConfig(
-            hosts=hosts,
-            service_name=config.redis_sentinel_service_name,
-            db=config.redis_sentinel_db,
-            username=config.redis_sentinel_username,
-            password=config.redis_sentinel_password,
-            sentinel_username=config.redis_sentinel_auth_username,
-            sentinel_password=config.redis_sentinel_auth_password,
-            ssl=config.redis_sentinel_ssl,
+    def _redis_settings(self) -> _redis_factory.RedisSettings:
+        return _redis_factory.RedisSettings(
+            url=self.redis_url,
+            max_connections=self.redis_max_connections,
+            socket_timeout=self.redis_socket_timeout,
+            socket_connect_timeout=self.redis_socket_connect_timeout,
         )
-    return _parse_sentinel_url(config.redis_url)
-
-
-def _master_kwargs(
-    parsed: _SentinelUrlConfig, config: RQOrchestratorConfig
-) -> dict[str, Any]:
-    """Connection kwargs passed to Sentinel.master_for() for the Redis master."""
-    kwargs: dict[str, Any] = {
-        "db": parsed.db,
-        "max_connections": config.redis_max_connections,
-        "socket_timeout": config.redis_socket_timeout,
-        "socket_connect_timeout": config.redis_socket_connect_timeout,
-    }
-    if parsed.username is not None:
-        kwargs["username"] = parsed.username
-    if parsed.password is not None:
-        kwargs["password"] = parsed.password
-    if parsed.ssl:
-        kwargs["ssl"] = True
-    return kwargs
-
-
-def _sentinel_kwargs(
-    parsed: _SentinelUrlConfig, config: RQOrchestratorConfig
-) -> dict[str, Any]:
-    """Connection kwargs used to talk to the Sentinel daemons themselves."""
-    kwargs: dict[str, Any] = {
-        "socket_timeout": config.redis_socket_timeout,
-        "socket_connect_timeout": config.redis_socket_connect_timeout,
-    }
-    if parsed.sentinel_username is not None:
-        kwargs["username"] = parsed.sentinel_username
-    if parsed.sentinel_password is not None:
-        kwargs["password"] = parsed.sentinel_password
-    return kwargs
 
 
 def make_sync_redis(config: RQOrchestratorConfig) -> redis.Redis:
-    """Create a sync Redis client. Routes to Sentinel master when configured."""
-    if config.use_sentinel:
-        parsed = _resolve_sentinel(config)
-        sentinel_client = sentinel.Sentinel(
-            parsed.hosts,
-            sentinel_kwargs=_sentinel_kwargs(parsed, config),
-        )
-        return sentinel_client.master_for(
-            parsed.service_name, **_master_kwargs(parsed, config)
-        )
-    pool = redis.ConnectionPool.from_url(
-        config.redis_url,
-        max_connections=config.redis_max_connections,
-        socket_timeout=config.redis_socket_timeout,
-        socket_connect_timeout=config.redis_socket_connect_timeout,
-    )
-    return redis.Redis(connection_pool=pool)
+    return _redis_factory.make_sync_client(config._redis_settings())
 
 
 def make_async_redis(config: RQOrchestratorConfig) -> async_redis.Redis:
-    """Create an async Redis client. Routes to Sentinel master when configured."""
-    if config.use_sentinel:
-        parsed = _resolve_sentinel(config)
-        sentinel_client = async_sentinel.Sentinel(
-            parsed.hosts,
-            sentinel_kwargs=_sentinel_kwargs(parsed, config),
-        )
-        return sentinel_client.master_for(
-            parsed.service_name, **_master_kwargs(parsed, config)
-        )
-    pool = async_redis.ConnectionPool.from_url(
-        config.redis_url,
-        max_connections=config.redis_max_connections,
-        socket_timeout=config.redis_socket_timeout,
-        socket_connect_timeout=config.redis_socket_connect_timeout,
-    )
-    return async_redis.Redis(connection_pool=pool)
+    return _redis_factory.make_async_client(config._redis_settings())
 
 
 class _TaskUpdate(BaseModel):
@@ -339,11 +124,11 @@ class RQOrchestrator(BaseOrchestrator):
             failure_ttl=config.failure_ttl,
         )
         if config.use_sentinel:
-            parsed = _resolve_sentinel(config)
+            target = _redis_factory.parse_sentinel_url(config.redis_url)
             _log.info(
                 f"RQ Redis Sentinel connection initialized: "
-                f"service_name={parsed.service_name}, "
-                f"sentinels={parsed.hosts}, db={parsed.db}, ssl={parsed.ssl}, "
+                f"service_name={target.service_name}, "
+                f"sentinels={target.hosts}, db={target.db}, ssl={target.ssl}, "
                 f"max_connections={config.redis_max_connections}, "
                 f"socket_timeout={config.redis_socket_timeout}, "
                 f"socket_connect_timeout={config.redis_socket_connect_timeout}"

--- a/docling_jobkit/orchestrators/rq/orchestrator.py
+++ b/docling_jobkit/orchestrators/rq/orchestrator.py
@@ -11,6 +11,8 @@ from typing import Any, Optional
 import msgpack
 import redis
 import redis.asyncio as async_redis
+import redis.asyncio.sentinel as async_sentinel
+import redis.sentinel as sentinel
 from pydantic import BaseModel, model_validator
 from rq import Queue
 from rq.exceptions import NoSuchJobError
@@ -56,6 +58,22 @@ class RQOrchestratorConfig(BaseModel):
     zombie_reaper_max_age: float = 3600.0
     result_removal_delay: int = 300  # seconds until result key expires after fetch
 
+    # Redis Sentinel configuration. When `redis_sentinel_hosts` and
+    # `redis_sentinel_service_name` are both set, all sync and async Redis
+    # clients are created via `redis.sentinel.Sentinel.master_for(...)` and
+    # `redis_url` is ignored. Each entry in `redis_sentinel_hosts` may be
+    # `host` (port defaults to 26379) or `host:port`.
+    redis_sentinel_hosts: Optional[list[str]] = None
+    redis_sentinel_service_name: Optional[str] = None
+    redis_sentinel_db: int = 0
+    redis_sentinel_username: Optional[str] = None
+    redis_sentinel_password: Optional[str] = None
+    # Credentials used to authenticate to the Sentinel daemons themselves
+    # (separate from the Redis master credentials above).
+    redis_sentinel_auth_username: Optional[str] = None
+    redis_sentinel_auth_password: Optional[str] = None
+    redis_sentinel_ssl: bool = False
+
     @model_validator(mode="after")
     def resolve_redis_gate_concurrency(self) -> "RQOrchestratorConfig":
         if self.redis_gate_concurrency is None:
@@ -63,6 +81,103 @@ class RQOrchestratorConfig(BaseModel):
                 1, self.redis_max_connections - self.redis_gate_reserved_connections
             )
         return self
+
+    @model_validator(mode="after")
+    def validate_sentinel_config(self) -> "RQOrchestratorConfig":
+        if bool(self.redis_sentinel_hosts) ^ bool(self.redis_sentinel_service_name):
+            raise ValueError(
+                "redis_sentinel_hosts and redis_sentinel_service_name must be "
+                "set together"
+            )
+        return self
+
+    @property
+    def use_sentinel(self) -> bool:
+        return bool(self.redis_sentinel_hosts and self.redis_sentinel_service_name)
+
+
+def _parse_sentinel_hosts(hosts: list[str]) -> list[tuple[str, int]]:
+    parsed: list[tuple[str, int]] = []
+    for entry in hosts:
+        host, _, port = entry.rpartition(":")
+        if host:
+            parsed.append((host, int(port)))
+        else:
+            # No colon — `entry` is the host, default Sentinel port.
+            parsed.append((port, 26379))
+    return parsed
+
+
+def _master_kwargs(config: RQOrchestratorConfig) -> dict[str, Any]:
+    """Connection kwargs passed to Sentinel.master_for() for the Redis master."""
+    kwargs: dict[str, Any] = {
+        "db": config.redis_sentinel_db,
+        "max_connections": config.redis_max_connections,
+        "socket_timeout": config.redis_socket_timeout,
+        "socket_connect_timeout": config.redis_socket_connect_timeout,
+    }
+    if config.redis_sentinel_username is not None:
+        kwargs["username"] = config.redis_sentinel_username
+    if config.redis_sentinel_password is not None:
+        kwargs["password"] = config.redis_sentinel_password
+    if config.redis_sentinel_ssl:
+        kwargs["ssl"] = True
+    return kwargs
+
+
+def _sentinel_kwargs(config: RQOrchestratorConfig) -> dict[str, Any]:
+    """Connection kwargs used to talk to the Sentinel daemons themselves."""
+    kwargs: dict[str, Any] = {
+        "socket_timeout": config.redis_socket_timeout,
+        "socket_connect_timeout": config.redis_socket_connect_timeout,
+    }
+    if config.redis_sentinel_auth_username is not None:
+        kwargs["username"] = config.redis_sentinel_auth_username
+    if config.redis_sentinel_auth_password is not None:
+        kwargs["password"] = config.redis_sentinel_auth_password
+    return kwargs
+
+
+def make_sync_redis(config: RQOrchestratorConfig) -> redis.Redis:
+    """Create a sync Redis client. Routes to Sentinel master when configured."""
+    if config.use_sentinel:
+        assert config.redis_sentinel_hosts is not None  # for type checker
+        assert config.redis_sentinel_service_name is not None
+        sentinel_client = sentinel.Sentinel(
+            _parse_sentinel_hosts(config.redis_sentinel_hosts),
+            sentinel_kwargs=_sentinel_kwargs(config),
+        )
+        return sentinel_client.master_for(
+            config.redis_sentinel_service_name, **_master_kwargs(config)
+        )
+    pool = redis.ConnectionPool.from_url(
+        config.redis_url,
+        max_connections=config.redis_max_connections,
+        socket_timeout=config.redis_socket_timeout,
+        socket_connect_timeout=config.redis_socket_connect_timeout,
+    )
+    return redis.Redis(connection_pool=pool)
+
+
+def make_async_redis(config: RQOrchestratorConfig) -> async_redis.Redis:
+    """Create an async Redis client. Routes to Sentinel master when configured."""
+    if config.use_sentinel:
+        assert config.redis_sentinel_hosts is not None
+        assert config.redis_sentinel_service_name is not None
+        sentinel_client = async_sentinel.Sentinel(
+            _parse_sentinel_hosts(config.redis_sentinel_hosts),
+            sentinel_kwargs=_sentinel_kwargs(config),
+        )
+        return sentinel_client.master_for(
+            config.redis_sentinel_service_name, **_master_kwargs(config)
+        )
+    pool = async_redis.ConnectionPool.from_url(
+        config.redis_url,
+        max_connections=config.redis_max_connections,
+        socket_timeout=config.redis_socket_timeout,
+        socket_connect_timeout=config.redis_socket_connect_timeout,
+    )
+    return async_redis.Redis(connection_pool=pool)
 
 
 class _TaskUpdate(BaseModel):
@@ -89,14 +204,7 @@ _TASK_METADATA_PREFIX = "docling:tasks:"
 class RQOrchestrator(BaseOrchestrator):
     @staticmethod
     def make_rq_queue(config: RQOrchestratorConfig) -> tuple[redis.Redis, Queue]:
-        # Create connection pool with configurable size
-        pool = redis.ConnectionPool.from_url(
-            config.redis_url,
-            max_connections=config.redis_max_connections,
-            socket_timeout=config.redis_socket_timeout,
-            socket_connect_timeout=config.redis_socket_connect_timeout,
-        )
-        conn = redis.Redis(connection_pool=pool)
+        conn = make_sync_redis(config)
         rq_queue = Queue(
             "convert",
             connection=conn,
@@ -104,11 +212,21 @@ class RQOrchestrator(BaseOrchestrator):
             result_ttl=config.results_ttl,
             failure_ttl=config.failure_ttl,
         )
-        _log.info(
-            f"RQ Redis connection pool initialized with max_connections="
-            f"{config.redis_max_connections}, socket_timeout={config.redis_socket_timeout}, "
-            f"socket_connect_timeout={config.redis_socket_connect_timeout}"
-        )
+        if config.use_sentinel:
+            _log.info(
+                f"RQ Redis Sentinel connection initialized: "
+                f"service_name={config.redis_sentinel_service_name}, "
+                f"sentinels={config.redis_sentinel_hosts}, "
+                f"max_connections={config.redis_max_connections}, "
+                f"socket_timeout={config.redis_socket_timeout}, "
+                f"socket_connect_timeout={config.redis_socket_connect_timeout}"
+            )
+        else:
+            _log.info(
+                f"RQ Redis connection pool initialized with max_connections="
+                f"{config.redis_max_connections}, socket_timeout={config.redis_socket_timeout}, "
+                f"socket_connect_timeout={config.redis_socket_connect_timeout}"
+            )
         return conn, rq_queue
 
     def __init__(
@@ -121,16 +239,7 @@ class RQOrchestrator(BaseOrchestrator):
         self._redis_gate = RedisCallerGate(self.config.redis_gate_concurrency)
         self._redis_conn, self._rq_queue = self.make_rq_queue(self.config)
 
-        # Create async connection pool with same configuration
-        self._async_redis_pool = async_redis.ConnectionPool.from_url(
-            self.config.redis_url,
-            max_connections=config.redis_max_connections,
-            socket_timeout=config.redis_socket_timeout,
-            socket_connect_timeout=config.redis_socket_connect_timeout,
-        )
-        self._async_redis_conn = async_redis.Redis(
-            connection_pool=self._async_redis_pool
-        )
+        self._async_redis_conn = make_async_redis(self.config)
         self._task_result_keys: dict[str, str] = {}
         self._rq_job_function = "docling_jobkit.orchestrators.rq.worker.docling_task"
         _log.info(
@@ -744,9 +853,10 @@ class RQOrchestrator(BaseOrchestrator):
     async def close(self):
         """Close Redis connection pools and release resources."""
         try:
-            # Close async connection pool
-            await self._async_redis_conn.aclose()
-            await self._async_redis_pool.aclose()
+            # Close async client; the underlying ConnectionPool (standard or
+            # SentinelConnectionPool) is owned by the client and torn down
+            # by aclose().
+            await self._async_redis_conn.aclose(close_connection_pool=True)
             _log.info("Async Redis connection pool closed")
         except Exception as e:
             _log.error(f"Error closing async Redis connection pool: {e}")

--- a/docling_jobkit/orchestrators/rq/orchestrator.py
+++ b/docling_jobkit/orchestrators/rq/orchestrator.py
@@ -7,6 +7,7 @@ import uuid
 import warnings
 from pathlib import Path
 from typing import Any, Optional
+from urllib.parse import parse_qs, unquote, urlparse
 
 import msgpack
 import redis
@@ -39,6 +40,99 @@ from docling_jobkit.orchestrators.base_orchestrator import (
 _log = logging.getLogger(__name__)
 
 
+_SENTINEL_URL_SCHEMES = ("redis+sentinel://", "rediss+sentinel://")
+
+
+class _SentinelUrlConfig(BaseModel):
+    """Parsed `redis+sentinel://` URL, ready to feed Sentinel.master_for()."""
+
+    hosts: list[tuple[str, int]]
+    service_name: str
+    db: int = 0
+    username: Optional[str] = None
+    password: Optional[str] = None
+    sentinel_username: Optional[str] = None
+    sentinel_password: Optional[str] = None
+    ssl: bool = False
+
+
+def _parse_sentinel_url(url: str) -> _SentinelUrlConfig:
+    """Parse `redis+sentinel://[user:pass@]h1[:p1][,h2[:p2]...]/master[/db][?…]`.
+
+    redis-py's own `from_url` rejects this scheme, so we parse it ourselves.
+    Comma-separated sentinel hosts go in the netloc; the master name (and
+    optional db) live in the path; sentinel-side credentials and `ssl` ride
+    in query params (URL userinfo is reserved for the Redis master itself).
+
+    `rediss+sentinel://` is accepted as a synonym for `?ssl=true`.
+    """
+    if not url.startswith(_SENTINEL_URL_SCHEMES):
+        raise ValueError(
+            f"Sentinel URL must start with one of {_SENTINEL_URL_SCHEMES}"
+        )
+
+    parsed = urlparse(url)
+    netloc = parsed.netloc
+    if "@" in netloc:
+        userinfo, _, hostpart = netloc.rpartition("@")
+    else:
+        userinfo, hostpart = "", netloc
+
+    username: Optional[str] = None
+    password: Optional[str] = None
+    if userinfo:
+        if ":" in userinfo:
+            user, _, pwd = userinfo.partition(":")
+            username = unquote(user) if user else None
+            password = unquote(pwd) if pwd else None
+        else:
+            username = unquote(userinfo)
+
+    if not hostpart:
+        raise ValueError("Sentinel URL must include at least one sentinel host")
+    hosts: list[tuple[str, int]] = []
+    for entry in hostpart.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        host, sep, port = entry.rpartition(":")
+        if sep:
+            hosts.append((host, int(port)))
+        else:
+            hosts.append((port, 26379))
+    if not hosts:
+        raise ValueError("Sentinel URL must include at least one sentinel host")
+
+    path_parts = [p for p in parsed.path.split("/") if p]
+    if not path_parts:
+        raise ValueError(
+            "Sentinel URL must include the master/service name in the path "
+            "(e.g. /mymaster)"
+        )
+    service_name = unquote(path_parts[0])
+    db = int(path_parts[1]) if len(path_parts) > 1 else 0
+
+    query = {k: v[-1] for k, v in parse_qs(parsed.query).items() if v}
+    ssl = parsed.scheme == "rediss+sentinel" or _to_bool(query.get("ssl"))
+
+    return _SentinelUrlConfig(
+        hosts=hosts,
+        service_name=service_name,
+        db=db,
+        username=username,
+        password=password,
+        sentinel_username=query.get("sentinel_username"),
+        sentinel_password=query.get("sentinel_password"),
+        ssl=ssl,
+    )
+
+
+def _to_bool(value: Optional[str]) -> bool:
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "t", "yes", "y", "on"}
+
+
 class RQOrchestratorConfig(BaseModel):
     redis_url: str = "redis://localhost:6379/"
     results_ttl: int = 3_600 * 4
@@ -58,11 +152,20 @@ class RQOrchestratorConfig(BaseModel):
     zombie_reaper_max_age: float = 3600.0
     result_removal_delay: int = 300  # seconds until result key expires after fetch
 
-    # Redis Sentinel configuration. When `redis_sentinel_hosts` and
-    # `redis_sentinel_service_name` are both set, all sync and async Redis
-    # clients are created via `redis.sentinel.Sentinel.master_for(...)` and
-    # `redis_url` is ignored. Each entry in `redis_sentinel_hosts` may be
-    # `host` (port defaults to 26379) or `host:port`.
+    # Redis Sentinel can be configured two ways:
+    #
+    # 1. URL form (preferred) — set `redis_url` to
+    #    `redis+sentinel://[user:pass@]h1[:p],h2[:p],…/service_name[/db][?…]`.
+    #    Use `rediss+sentinel://` (or `?ssl=true`) for TLS to the master.
+    #    Query params: `sentinel_username`, `sentinel_password` (creds for the
+    #    Sentinel daemons themselves, separate from the master creds in the
+    #    userinfo), and `ssl`.
+    #
+    # 2. Explicit fields below — for programmatic configuration where building
+    #    a URL is awkward. When `redis_sentinel_hosts` and
+    #    `redis_sentinel_service_name` are both set they take priority over
+    #    `redis_url`. Each entry in `redis_sentinel_hosts` may be `host`
+    #    (port defaults to 26379) or `host:port`.
     redis_sentinel_hosts: Optional[list[str]] = None
     redis_sentinel_service_name: Optional[str] = None
     redis_sentinel_db: int = 0
@@ -89,66 +192,90 @@ class RQOrchestratorConfig(BaseModel):
                 "redis_sentinel_hosts and redis_sentinel_service_name must be "
                 "set together"
             )
+        if self.redis_url.startswith(_SENTINEL_URL_SCHEMES):
+            # Validate the URL eagerly so misconfigurations surface at config
+            # construction, not on the first connection attempt.
+            _parse_sentinel_url(self.redis_url)
         return self
 
     @property
     def use_sentinel(self) -> bool:
-        return bool(self.redis_sentinel_hosts and self.redis_sentinel_service_name)
+        if self.redis_sentinel_hosts and self.redis_sentinel_service_name:
+            return True
+        return self.redis_url.startswith(_SENTINEL_URL_SCHEMES)
 
 
-def _parse_sentinel_hosts(hosts: list[str]) -> list[tuple[str, int]]:
-    parsed: list[tuple[str, int]] = []
-    for entry in hosts:
-        host, _, port = entry.rpartition(":")
-        if host:
-            parsed.append((host, int(port)))
-        else:
-            # No colon — `entry` is the host, default Sentinel port.
-            parsed.append((port, 26379))
-    return parsed
+def _resolve_sentinel(config: RQOrchestratorConfig) -> _SentinelUrlConfig:
+    """Collapse either configuration form into a single parsed structure.
+
+    Explicit fields win over the URL when both are set, matching the
+    `use_sentinel` precedence in `RQOrchestratorConfig`.
+    """
+    if config.redis_sentinel_hosts and config.redis_sentinel_service_name:
+        hosts: list[tuple[str, int]] = []
+        for entry in config.redis_sentinel_hosts:
+            host, sep, port = entry.rpartition(":")
+            if sep:
+                hosts.append((host, int(port)))
+            else:
+                hosts.append((port, 26379))
+        return _SentinelUrlConfig(
+            hosts=hosts,
+            service_name=config.redis_sentinel_service_name,
+            db=config.redis_sentinel_db,
+            username=config.redis_sentinel_username,
+            password=config.redis_sentinel_password,
+            sentinel_username=config.redis_sentinel_auth_username,
+            sentinel_password=config.redis_sentinel_auth_password,
+            ssl=config.redis_sentinel_ssl,
+        )
+    return _parse_sentinel_url(config.redis_url)
 
 
-def _master_kwargs(config: RQOrchestratorConfig) -> dict[str, Any]:
+def _master_kwargs(
+    parsed: _SentinelUrlConfig, config: RQOrchestratorConfig
+) -> dict[str, Any]:
     """Connection kwargs passed to Sentinel.master_for() for the Redis master."""
     kwargs: dict[str, Any] = {
-        "db": config.redis_sentinel_db,
+        "db": parsed.db,
         "max_connections": config.redis_max_connections,
         "socket_timeout": config.redis_socket_timeout,
         "socket_connect_timeout": config.redis_socket_connect_timeout,
     }
-    if config.redis_sentinel_username is not None:
-        kwargs["username"] = config.redis_sentinel_username
-    if config.redis_sentinel_password is not None:
-        kwargs["password"] = config.redis_sentinel_password
-    if config.redis_sentinel_ssl:
+    if parsed.username is not None:
+        kwargs["username"] = parsed.username
+    if parsed.password is not None:
+        kwargs["password"] = parsed.password
+    if parsed.ssl:
         kwargs["ssl"] = True
     return kwargs
 
 
-def _sentinel_kwargs(config: RQOrchestratorConfig) -> dict[str, Any]:
+def _sentinel_kwargs(
+    parsed: _SentinelUrlConfig, config: RQOrchestratorConfig
+) -> dict[str, Any]:
     """Connection kwargs used to talk to the Sentinel daemons themselves."""
     kwargs: dict[str, Any] = {
         "socket_timeout": config.redis_socket_timeout,
         "socket_connect_timeout": config.redis_socket_connect_timeout,
     }
-    if config.redis_sentinel_auth_username is not None:
-        kwargs["username"] = config.redis_sentinel_auth_username
-    if config.redis_sentinel_auth_password is not None:
-        kwargs["password"] = config.redis_sentinel_auth_password
+    if parsed.sentinel_username is not None:
+        kwargs["username"] = parsed.sentinel_username
+    if parsed.sentinel_password is not None:
+        kwargs["password"] = parsed.sentinel_password
     return kwargs
 
 
 def make_sync_redis(config: RQOrchestratorConfig) -> redis.Redis:
     """Create a sync Redis client. Routes to Sentinel master when configured."""
     if config.use_sentinel:
-        assert config.redis_sentinel_hosts is not None  # for type checker
-        assert config.redis_sentinel_service_name is not None
+        parsed = _resolve_sentinel(config)
         sentinel_client = sentinel.Sentinel(
-            _parse_sentinel_hosts(config.redis_sentinel_hosts),
-            sentinel_kwargs=_sentinel_kwargs(config),
+            parsed.hosts,
+            sentinel_kwargs=_sentinel_kwargs(parsed, config),
         )
         return sentinel_client.master_for(
-            config.redis_sentinel_service_name, **_master_kwargs(config)
+            parsed.service_name, **_master_kwargs(parsed, config)
         )
     pool = redis.ConnectionPool.from_url(
         config.redis_url,
@@ -162,14 +289,13 @@ def make_sync_redis(config: RQOrchestratorConfig) -> redis.Redis:
 def make_async_redis(config: RQOrchestratorConfig) -> async_redis.Redis:
     """Create an async Redis client. Routes to Sentinel master when configured."""
     if config.use_sentinel:
-        assert config.redis_sentinel_hosts is not None
-        assert config.redis_sentinel_service_name is not None
+        parsed = _resolve_sentinel(config)
         sentinel_client = async_sentinel.Sentinel(
-            _parse_sentinel_hosts(config.redis_sentinel_hosts),
-            sentinel_kwargs=_sentinel_kwargs(config),
+            parsed.hosts,
+            sentinel_kwargs=_sentinel_kwargs(parsed, config),
         )
         return sentinel_client.master_for(
-            config.redis_sentinel_service_name, **_master_kwargs(config)
+            parsed.service_name, **_master_kwargs(parsed, config)
         )
     pool = async_redis.ConnectionPool.from_url(
         config.redis_url,
@@ -213,10 +339,11 @@ class RQOrchestrator(BaseOrchestrator):
             failure_ttl=config.failure_ttl,
         )
         if config.use_sentinel:
+            parsed = _resolve_sentinel(config)
             _log.info(
                 f"RQ Redis Sentinel connection initialized: "
-                f"service_name={config.redis_sentinel_service_name}, "
-                f"sentinels={config.redis_sentinel_hosts}, "
+                f"service_name={parsed.service_name}, "
+                f"sentinels={parsed.hosts}, db={parsed.db}, ssl={parsed.ssl}, "
                 f"max_connections={config.redis_max_connections}, "
                 f"socket_timeout={config.redis_socket_timeout}, "
                 f"socket_connect_timeout={config.redis_socket_connect_timeout}"

--- a/docling_jobkit/orchestrators/rq/worker.py
+++ b/docling_jobkit/orchestrators/rq/worker.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from typing import Any, Optional, Union
 
 import msgpack
-import redis as sync_redis
 from rq import SimpleWorker, get_current_job
 
 from docling.datamodel.base_models import DocumentStream
@@ -29,6 +28,7 @@ from docling_jobkit.orchestrators.rq.orchestrator import (
     RQOrchestrator,
     RQOrchestratorConfig,
     _TaskUpdate,
+    make_sync_redis,
 )
 from docling_jobkit.orchestrators.serialization import make_msgpack_safe
 
@@ -69,7 +69,9 @@ class CustomRQWorker(SimpleWorker):
         key = f"{self.orchestrator_config.heartbeat_key_prefix}:{job_id}"
         conn = None
         try:
-            conn = sync_redis.Redis.from_url(self.orchestrator_config.redis_url)
+            # Routes through Sentinel when configured so heartbeats follow
+            # master failover rather than getting stuck on a stale endpoint.
+            conn = make_sync_redis(self.orchestrator_config)
             # Write immediately so the key exists before the first watchdog scan.
             conn.set(key, "1", ex=_HEARTBEAT_TTL)
             while not stop_event.wait(timeout=_HEARTBEAT_INTERVAL):

--- a/tests/test_ray_orchestrator.py
+++ b/tests/test_ray_orchestrator.py
@@ -354,7 +354,7 @@ async def test_expire_result():
     """RedisStateManager.expire_result calls redis.expire with correct args."""
     from unittest.mock import AsyncMock
 
-    from docling_jobkit.orchestrators.ray.redis_helper import RedisStateManager
+    from docling_jobkit.orchestrators.ray.state_manager import RedisStateManager
 
     manager = RedisStateManager(redis_url="redis://localhost:6379/")
     manager.redis = AsyncMock()

--- a/tests/test_redis_factory.py
+++ b/tests/test_redis_factory.py
@@ -1,0 +1,173 @@
+"""Tests for the shared Redis client factory (`_redis` module).
+
+Covers:
+  - URL classification (single / sentinel / cluster rejection)
+  - Sentinel URL parsing (happy paths + edge cases)
+  - Eager validation hook (`validate_url`)
+  - Orchestrator-level rejection of cluster URLs at config-build time
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from docling_jobkit.orchestrators import _redis as factory
+
+
+class TestDetectMode:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "redis://localhost:6379/",
+            "rediss://localhost:6379/",
+            "unix:///tmp/redis.sock",
+            "redis://h:6379/?ssl=true",  # query options other than cluster=
+        ],
+    )
+    def test_single_node_schemes(self, url: str) -> None:
+        assert factory.detect_mode(url) == factory.RedisMode.SINGLE
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "redis+sentinel://h:26379/m",
+            "rediss+sentinel://h:26379/m",
+        ],
+    )
+    def test_sentinel_schemes(self, url: str) -> None:
+        assert factory.detect_mode(url) == factory.RedisMode.SENTINEL
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "redis+cluster://node:6379/0",
+            "rediss+cluster://node:6379/0",
+            "redis-cluster://node:6379/0",
+        ],
+    )
+    def test_cluster_scheme_rejected(self, url: str) -> None:
+        with pytest.raises(factory.UnsupportedRedisModeError, match="Cluster URL"):
+            factory.detect_mode(url)
+
+    @pytest.mark.parametrize("value", ["true", "1", "anything"])
+    def test_cluster_query_param_rejected(self, value: str) -> None:
+        with pytest.raises(
+            factory.UnsupportedRedisModeError, match=r"\?cluster"
+        ):
+            factory.detect_mode(f"redis://node:6379/?cluster={value}")
+
+    def test_unknown_scheme_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported redis URL scheme"):
+            factory.detect_mode("memcached://x:11211/")
+
+
+class TestParseSentinelUrl:
+    def test_minimal(self) -> None:
+        t = factory.parse_sentinel_url("redis+sentinel://h1:26379/mymaster")
+        assert t.hosts == [("h1", 26379)]
+        assert t.service_name == "mymaster"
+        assert t.db == 0
+        assert t.ssl is False
+        assert t.username is None
+        assert t.password is None
+
+    def test_full_url(self) -> None:
+        t = factory.parse_sentinel_url(
+            "redis+sentinel://user:p%40ss@h1,h2:26380,h3:26381/mymaster/3"
+            "?sentinel_username=su&sentinel_password=sp&ssl=true"
+        )
+        assert t.hosts == [("h1", 26379), ("h2", 26380), ("h3", 26381)]
+        assert t.service_name == "mymaster"
+        assert t.db == 3
+        assert t.username == "user"
+        assert t.password == "p@ss"  # url-decoded
+        assert t.sentinel_username == "su"
+        assert t.sentinel_password == "sp"
+        assert t.ssl is True
+
+    def test_rediss_sentinel_implies_ssl(self) -> None:
+        t = factory.parse_sentinel_url("rediss+sentinel://h1:26379/m")
+        assert t.ssl is True
+
+    def test_default_sentinel_port(self) -> None:
+        t = factory.parse_sentinel_url("redis+sentinel://h1,h2/m")
+        assert t.hosts == [("h1", 26379), ("h2", 26379)]
+
+    def test_rejects_wrong_scheme(self) -> None:
+        with pytest.raises(ValueError, match="must start with"):
+            factory.parse_sentinel_url("redis://h/0")
+
+    def test_rejects_missing_master(self) -> None:
+        with pytest.raises(ValueError, match="master/service name"):
+            factory.parse_sentinel_url("redis+sentinel://h:26379/")
+
+    def test_rejects_missing_hosts(self) -> None:
+        with pytest.raises(ValueError, match="at least one sentinel host"):
+            factory.parse_sentinel_url("redis+sentinel:///mymaster")
+
+
+class TestValidateUrl:
+    def test_accepts_supported(self) -> None:
+        factory.validate_url("redis://localhost:6379/")
+        factory.validate_url("redis+sentinel://h:26379/m")
+        factory.validate_url("rediss+sentinel://h1,h2:26380/m/0?ssl=true")
+
+    def test_rejects_cluster(self) -> None:
+        with pytest.raises(factory.UnsupportedRedisModeError):
+            factory.validate_url("redis+cluster://node:6379/0")
+
+    def test_rejects_cluster_query(self) -> None:
+        with pytest.raises(factory.UnsupportedRedisModeError):
+            factory.validate_url("redis://node:6379/?cluster=true")
+
+    def test_rejects_malformed_sentinel(self) -> None:
+        # detect_mode passes (scheme is sentinel), but parse_sentinel_url
+        # surfaces the missing master at config-build time.
+        with pytest.raises(ValueError, match="master/service name"):
+            factory.validate_url("redis+sentinel://h:26379/")
+
+
+class TestRQOrchestratorConfigRejectsCluster:
+    """End-to-end: cluster URLs raise during RQOrchestratorConfig(...)."""
+
+    def test_cluster_scheme_rejected_at_config_build(self) -> None:
+        from docling_jobkit.orchestrators.rq.orchestrator import RQOrchestratorConfig
+
+        with pytest.raises(Exception, match="Cluster"):
+            RQOrchestratorConfig(redis_url="redis+cluster://node:6379/0")
+
+    def test_cluster_query_rejected_at_config_build(self) -> None:
+        from docling_jobkit.orchestrators.rq.orchestrator import RQOrchestratorConfig
+
+        with pytest.raises(Exception, match=r"cluster"):
+            RQOrchestratorConfig(redis_url="redis://node:6379/?cluster=true")
+
+
+class TestRayOrchestratorConfigRejectsCluster:
+    def test_cluster_scheme_rejected_at_config_build(self) -> None:
+        ray_config = pytest.importorskip(
+            "docling_jobkit.orchestrators.ray.config"
+        )
+
+        with pytest.raises(Exception, match="Cluster"):
+            ray_config.RayOrchestratorConfig(redis_url="redis+cluster://node:6379/0")
+
+    def test_cluster_query_rejected_at_config_build(self) -> None:
+        ray_config = pytest.importorskip(
+            "docling_jobkit.orchestrators.ray.config"
+        )
+
+        with pytest.raises(Exception, match=r"cluster"):
+            ray_config.RayOrchestratorConfig(
+                redis_url="redis://node:6379/?cluster=true"
+            )
+
+    def test_sentinel_url_accepted(self) -> None:
+        ray_config = pytest.importorskip(
+            "docling_jobkit.orchestrators.ray.config"
+        )
+
+        cfg = ray_config.RayOrchestratorConfig(
+            redis_url="redis+sentinel://h1,h2:26380/mymaster/0?ssl=true",
+        )
+        assert cfg.redis_url.startswith("redis+sentinel://")


### PR DESCRIPTION
## Summary

Adds first-class Redis Sentinel support to the RQ orchestrator and worker so deployments backed by a Sentinel-fronted HA Redis can configure jobkit directly, without a TCP-level proxy in front. The standard `redis_url` path is unchanged.

`docling_jobkit/orchestrators/ray/config.py` and the Ray README claim "redis+sentinel://..." URL support, but `redis-py`'s `from_url` only accepts `redis://`, `rediss://`, and `unix://`, and there is no URL preprocessing in jobkit. This PR does **not** touch Ray; it adds a real, tested implementation for RQ.

## Design

Eight new optional fields on `RQOrchestratorConfig`:

| Field | Purpose |
|-------|---------|
| `redis_sentinel_hosts: list[str] \| None` | `host[:port]` entries; default port 26379 |
| `redis_sentinel_service_name: str \| None` | Master name (e.g. `mymaster`) |
| `redis_sentinel_db: int = 0` | DB on the Redis master |
| `redis_sentinel_username` / `redis_sentinel_password` | Credentials for the Redis master |
| `redis_sentinel_auth_username` / `redis_sentinel_auth_password` | Credentials for the Sentinel daemons themselves (separate from master creds) |
| `redis_sentinel_ssl: bool = False` | TLS to the master |

A `model_validator` enforces that `redis_sentinel_hosts` and `redis_sentinel_service_name` are set together, and a `use_sentinel` property gates the routing decision.

Two factory helpers replace the inline `from_url` calls:

- `make_sync_redis(config) -> redis.Redis`
- `make_async_redis(config) -> redis.asyncio.Redis`

When `use_sentinel` is true, both call `redis.sentinel.Sentinel.master_for(...)` / `redis.asyncio.sentinel.Sentinel.master_for(...)`, returning a `Redis` client whose pool is a `SentinelConnectionPool`. That pool transparently re-resolves the master through the Sentinel quorum on every connection acquisition, so failover is handled by `redis-py` without us needing custom retry/reconnect logic.

Call sites updated to use the helpers:

- `RQOrchestrator.make_rq_queue`
- `RQOrchestrator.__init__` (async pool)
- `RQOrchestrator.close` (single `aclose(close_connection_pool=True)` covers both pool kinds)
- `CustomRQWorker._heartbeat_loop` — important so heartbeat traffic also follows failover

## Backwards compatibility

`redis_url` remains the default and untouched code path. Existing deployments require zero changes.

## Test scenarios

Covered end-to-end against a live Sentinel cluster running.

| # | Scenario | What it proves |
|---|----------|----------------|
| 1 | Pydantic validation matrix (5 sub-cases) | `hosts`/`service_name` must be set together; `use_sentinel` only true when both populated |
| 2 | Sync `make_sync_redis` SET/GET via Sentinel | Connection pool returned is a `SentinelConnectionPool`; reads and writes against the resolved master succeed |
| 3 | Async `make_async_redis` SET/GET via Sentinel | Same as above for `redis.asyncio.sentinel.SentinelConnectionPool` |
| 4 | `RQOrchestrator(config).check_connection()` | Full orchestrator init + `PING` round-trip via Sentinel; `close()` tears the pool down without errors |
| 5 | Master role assertion | `info("replication")["role"] == "master"` — Sentinel discovery actually returns the master, not a replica |
| 6 | Full RQ Queue + SimpleWorker round-trip via Sentinel | Enqueue → SimpleWorker drains the queue in burst mode → `job.return_value()` round-trips correctly. Validates that RQ's own queue/registry/result paths all work through `SentinelConnectionPool` |
| 7 | URL-only config still works | Backwards-compat regression guard; `redis://...` path unchanged |

All seven pass locally; reproduce with:

```bash
cd tests/sentinel-fixture && docker compose up -d --wait
pytest tests/test_redis_sentinel_integration.py tests/test_redis_sentinel_settings.py -v
docker compose down -v
```

## Configuration example

```python
RQOrchestratorConfig(
    redis_sentinel_hosts=["sentinel-1:26379", "sentinel-2:26379", "sentinel-3:26379"],
    redis_sentinel_service_name="mymaster",
    redis_sentinel_password="redis-master-password",
    redis_sentinel_auth_password="sentinel-daemon-password",  # optional
    redis_max_connections=50,
)
```

## Out of scope

- Ray engine: the Ray README/config reference Sentinel via URL today, but the implementation does not actually support it (relies on `redis-py` `from_url`, which doesn't parse `redis+sentinel://`). Fixing that is a separate PR; the misleading docs there should also be cleaned up.
- KFP / Local engines: do not use Redis.