### PR TITLE
fix: Image export mode embedded

### DIFF
--- a/docling_jobkit/convert/manager.py
+++ b/docling_jobkit/convert/manager.py
@@ -1481,7 +1481,7 @@ class DoclingConverterManager:
 
         if request.image_export_mode != ImageRefMode.PLACEHOLDER:
             pipeline_options.generate_page_images = True
-            if request.image_export_mode == ImageRefMode.REFERENCED:
+            if request.image_export_mode == ImageRefMode.REFERENCED or request.image_export_mode == ImageRefMode.EMBEDDED:
                 pipeline_options.generate_picture_images = True
             if request.images_scale:
                 pipeline_options.images_scale = request.images_scale


### PR DESCRIPTION
# fix: embedded image export producing null pictures[].image

## Summary

This PR fixes an issue where requesting `image_export_mode: "embedded"` during document conversion results in missing image data (`pictures[].image` is `null`) in the exported document.

The expected behavior is for embedded mode to include actual image content (e.g., base64 or binary), consistent with other export paths such as the `/convert` endpoint.

---

## Problem Description

When using:

```
convert_options.image_export_mode = "embedded"
```

The exported document incorrectly returns:

```json
"pictures": [
  {
    "image": null
  }
]
```

### Expected Behavior

```json
"pictures": [
  {
    "image": "<base64_or_binary_data>"
  }
]
```

---

## Root Cause

During conversion options parsing, the flag:

```
pipeline_options.generate_picture_images
```

was only enabled for:

```
ImageRefMode.REFERENCED
```

and **not for**:

```
ImageRefMode.EMBEDDED
```

As a result, no image data was generated for embedded mode, leading to `null` values in the output.

---

##  Solution

Ensure that `generate_picture_images` is enabled for both:

* `ImageRefMode.REFERENCED`
* `ImageRefMode.EMBEDDED`
---

##  Reproduction Steps
See https://github.com/docling-project/docling-serve/issues/576
---

##  Notes

* This change is backward-compatible
* No API contract changes
* Only affects behavior when `image_export_mode="embedded"`