### PR TITLE
feat: implement file/ZIP export for chunking pipeline (support to_formats + ZipTarget)

### DIFF
--- a/docling_jobkit/convert/chunking.py
+++ b/docling_jobkit/convert/chunking.py
@@ -1,9 +1,9 @@
 import hashlib
 import logging
-import threading
-import time
 import os
 import shutil
+import threading
+import time
 from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional
@@ -40,7 +40,10 @@ from docling_core.transforms.chunker.tokenizer.huggingface import (
 )
 from docling_core.types.doc.document import DoclingDocument, ImageRefMode
 
-from docling_jobkit.convert.results import _export_document_as_content, _export_documents_as_files
+from docling_jobkit.convert.results import (
+    _export_document_as_content,
+    _export_documents_as_files,
+)
 from docling_jobkit.datamodel.result import (
     ChunkedDocumentResult,
     ChunkedDocumentResultItem,
@@ -48,7 +51,8 @@ from docling_jobkit.datamodel.result import (
     ExportDocumentResponse,
     ExportResult,
     RemoteTargetResult,
-    ZipArchiveResult
+    ResultType,
+    ZipArchiveResult,
 )
 from docling_jobkit.datamodel.task import Task
 
@@ -254,7 +258,7 @@ def process_chunk_results(
         )
 
     # We have some results, let's prepare the response
-    task_result: ChunkedDocumentResult
+    task_result: ResultType
     chunks: list[ChunkedDocumentResultItem] = []
     conv_results_list = []
     documents: list[ExportResult] = []

--- a/docling_jobkit/convert/chunking.py
+++ b/docling_jobkit/convert/chunking.py
@@ -321,6 +321,12 @@ def process_chunk_results(
 
     # TODO: DocumentChunkerManager should be initialized outside for really working as a cache
     chunker_manager = chunker_manager or DocumentChunkerManager()
+
+    output_dir: Optional[Path] = None
+    if not isinstance(task.target, InBodyTarget):
+        output_dir = work_dir / "output"
+        output_dir.mkdir(parents=True, exist_ok=True)
+
     for idx, conv_res in enumerate(conv_results):
         errors = conv_res.errors
         # Document has JUST been converted (lazy evaluation triggered here)
@@ -410,10 +416,7 @@ def process_chunk_results(
                     image_mode=conversion_options.image_export_mode,
                     md_page_break_placeholder=conversion_options.md_page_break_placeholder,
                 )
-            else:
-                # Temporary directory to store the outputs
-                output_dir = work_dir / "output"
-                output_dir.mkdir(parents=True, exist_ok=True)
+            elif output_dir is not None:
                 doc_content = _export_document_for_chunking(
                     conv_res,
                     output_dir=output_dir,
@@ -463,7 +466,7 @@ def process_chunk_results(
         )
 
     # Multiple documents were processed, or we are forced returning as a file
-    else:
+    elif output_dir is not None:
         # Export the consolidated chunking result (including artifacts)
         chunked_result = ChunkedDocumentResult(
             chunks=chunks,

--- a/docling_jobkit/convert/chunking.py
+++ b/docling_jobkit/convert/chunking.py
@@ -2,13 +2,16 @@ import hashlib
 import logging
 import threading
 import time
+import os
+import shutil
 from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional
 
+import httpx
 from pydantic import BaseModel, Field
 
-from docling.datamodel.base_models import ConversionStatus
+from docling.datamodel.base_models import ConversionStatus, OutputFormat
 from docling.datamodel.document import ConversionResult
 from docling.datamodel.service.callbacks import (
     DocumentCompletedItem,
@@ -24,7 +27,7 @@ from docling.datamodel.service.chunking import (
     HybridChunkerOptions,
 )
 from docling.datamodel.service.options import ConvertDocumentsOptions
-from docling.datamodel.service.targets import InBodyTarget
+from docling.datamodel.service.targets import InBodyTarget, PutTarget
 from docling_core.transforms.chunker import BaseChunker
 from docling_core.transforms.chunker.hierarchical_chunker import (
     ChunkingSerializerProvider,
@@ -37,13 +40,15 @@ from docling_core.transforms.chunker.tokenizer.huggingface import (
 )
 from docling_core.types.doc.document import DoclingDocument, ImageRefMode
 
-from docling_jobkit.convert.results import _export_document_as_content
+from docling_jobkit.convert.results import _export_document_as_content, _export_documents_as_files
 from docling_jobkit.datamodel.result import (
     ChunkedDocumentResult,
     ChunkedDocumentResultItem,
     DoclingTaskResult,
     ExportDocumentResponse,
     ExportResult,
+    RemoteTargetResult,
+    ZipArchiveResult
 )
 from docling_jobkit.datamodel.task import Task
 
@@ -251,6 +256,7 @@ def process_chunk_results(
     # We have some results, let's prepare the response
     task_result: ChunkedDocumentResult
     chunks: list[ChunkedDocumentResultItem] = []
+    conv_results_list = []
     documents: list[ExportResult] = []
     num_succeeded = 0
     num_failed = 0
@@ -261,6 +267,8 @@ def process_chunk_results(
     chunker_manager = chunker_manager or DocumentChunkerManager()
     for idx, conv_res in enumerate(conv_results):
         errors = conv_res.errors
+        # Document has JUST been converted (lazy evaluation triggered here)
+        conv_results_list.append(conv_res)
         filename = conv_res.input.file.name
         if conv_res.status == ConversionStatus.SUCCESS:
             try:
@@ -357,6 +365,7 @@ def process_chunk_results(
 
         documents.append(doc_result)
 
+    conv_results = conv_results_list
     num_total = num_succeeded + num_failed
     processing_time = time.monotonic() - start_time
     _log.info(
@@ -377,6 +386,13 @@ def process_chunk_results(
             ),
         )
 
+    # Export results based on target type and options
+    # Booleans to know what to export
+    export_json = OutputFormat.JSON in conversion_options.to_formats
+    export_html = OutputFormat.HTML in conversion_options.to_formats
+    export_md = OutputFormat.MARKDOWN in conversion_options.to_formats
+    export_txt = OutputFormat.TEXT in conversion_options.to_formats
+    export_doctags = OutputFormat.DOCTAGS in conversion_options.to_formats
     if isinstance(task.target, InBodyTarget):
         task_result = ChunkedDocumentResult(
             chunks=chunks,
@@ -387,7 +403,43 @@ def process_chunk_results(
 
     # Multiple documents were processed, or we are forced returning as a file
     else:
-        raise NotImplementedError("Saving chunks to a file is not yet supported.")
+        # Temporary directory to store the outputs
+        output_dir = work_dir / "output"
+        output_dir.mkdir(parents=True, exist_ok=True)
+        # Export the documents
+        num_succeeded, num_failed, _conv_result = _export_documents_as_files(
+            conv_results=conv_results,
+            output_dir=output_dir,
+            export_json=export_json,
+            export_html=export_html,
+            export_md=export_md,
+            export_txt=export_txt,
+            export_doctags=export_doctags,
+            image_export_mode=conversion_options.image_export_mode,
+            md_page_break_placeholder=conversion_options.md_page_break_placeholder,
+        )
+        files = os.listdir(output_dir)
+        if len(files) == 0:
+            raise RuntimeError("No documents were exported.")
+        file_path = work_dir / "converted_docs.zip"
+        shutil.make_archive(
+            base_name=str(file_path.with_suffix("")),
+            format="zip",
+            root_dir=output_dir,
+        )
+        if isinstance(task.target, PutTarget):
+            try:
+                with file_path.open("rb") as file_data:
+                    r = httpx.put(str(task.target.url), files={"file": file_data})
+                    r.raise_for_status()
+                task_result = RemoteTargetResult()
+            except Exception as exc:
+                _log.error("An error occour while uploading zip to s3", exc_info=exc)
+                raise RuntimeError(
+                    "An error occour while uploading zip to the target url."
+                )
+        else:
+            task_result = ZipArchiveResult(content=file_path.read_bytes())
 
     return DoclingTaskResult(
         result=task_result,

--- a/docling_jobkit/convert/chunking.py
+++ b/docling_jobkit/convert/chunking.py
@@ -1,4 +1,5 @@
 import hashlib
+import json
 import logging
 import os
 import shutil
@@ -11,7 +12,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional
 import httpx
 from pydantic import BaseModel, Field
 
-from docling.datamodel.base_models import ConversionStatus, OutputFormat
+from docling.datamodel.base_models import ConversionStatus
 from docling.datamodel.document import ConversionResult
 from docling.datamodel.service.callbacks import (
     DocumentCompletedItem,
@@ -42,7 +43,6 @@ from docling_core.types.doc.document import DoclingDocument, ImageRefMode
 
 from docling_jobkit.convert.results import (
     _export_document_as_content,
-    _export_documents_as_files,
 )
 from docling_jobkit.datamodel.result import (
     ChunkedDocumentResult,
@@ -236,6 +236,58 @@ class DocumentChunkerManager:
         return chunk_items
 
 
+def _export_document_for_chunking(
+    conv_res: ConversionResult,
+    output_dir: Path,
+    image_mode: ImageRefMode,
+) -> ExportDocumentResponse:
+    """Extract document content for chunking and ensure artifacts are on disk.
+
+    If ``image_mode`` is ``REFERENCED``, a temporary JSON export is performed
+    so that the ``artifacts/`` directory is created as a side-effect; the
+    temporary file is then removed because the converted content is already
+    embedded inside ``chunked_result.json``.
+    """
+    document = ExportDocumentResponse(filename=conv_res.input.file.name)
+
+    if conv_res.status == ConversionStatus.SUCCESS:
+        artifacts_dir = output_dir / "artifacts"
+        new_doc = conv_res.document._make_copy_with_refmode(
+            artifacts_dir,
+            image_mode,
+            page_no=None,
+            reference_path=output_dir,
+        )
+        document.json_content = new_doc
+
+        if image_mode == ImageRefMode.REFERENCED:
+            temp_fname = output_dir / f"{conv_res.input.file.stem}.json"
+            conv_res.document.save_as_json(
+                filename=temp_fname,
+                image_mode=image_mode,
+                artifacts_dir=artifacts_dir,
+            )
+            temp_fname.unlink(missing_ok=True)
+
+    return document
+
+
+def _export_chunking_result(
+    result: ChunkedDocumentResult,
+    output_dir: Path,
+) -> None:
+    """Write the consolidated chunking result as ``chunked_result.json``."""
+    fname = output_dir / "chunked_result.json"
+    _log.info(f"writing chunk output to {fname}")
+    with fname.open("w", encoding="utf-8") as f:
+        json.dump(
+            result.model_dump(mode="json"),
+            f,
+            ensure_ascii=False,
+            indent=2,
+        )
+
+
 def process_chunk_results(
     task: Task,
     conv_results: Iterable[ConversionResult],
@@ -340,23 +392,33 @@ def process_chunk_results(
                 ),
             )
 
-        if (
-            isinstance(task.target, InBodyTarget)
-            and task.chunking_export_options.include_converted_doc
-        ):
-            if conversion_options.image_export_mode == ImageRefMode.REFERENCED:
+        if task.chunking_export_options.include_converted_doc:
+            if (
+                isinstance(task.target, InBodyTarget)
+                and conversion_options.image_export_mode == ImageRefMode.REFERENCED
+            ):
                 raise RuntimeError("InBodyTarget cannot use REFERENCED image mode.")
 
-            doc_content = _export_document_as_content(
-                conv_res,
-                export_json=True,
-                export_doctags=False,
-                export_html=False,
-                export_md=False,
-                export_txt=False,
-                image_mode=conversion_options.image_export_mode,
-                md_page_break_placeholder=conversion_options.md_page_break_placeholder,
-            )
+            if isinstance(task.target, InBodyTarget):
+                doc_content = _export_document_as_content(
+                    conv_res,
+                    export_json=True,
+                    export_doctags=False,
+                    export_html=False,
+                    export_md=False,
+                    export_txt=False,
+                    image_mode=conversion_options.image_export_mode,
+                    md_page_break_placeholder=conversion_options.md_page_break_placeholder,
+                )
+            else:
+                # Temporary directory to store the outputs
+                output_dir = work_dir / "output"
+                output_dir.mkdir(parents=True, exist_ok=True)
+                doc_content = _export_document_for_chunking(
+                    conv_res,
+                    output_dir=output_dir,
+                    image_mode=conversion_options.image_export_mode,
+                )
         else:
             doc_content = ExportDocumentResponse(filename=filename)
 
@@ -392,11 +454,6 @@ def process_chunk_results(
 
     # Export results based on target type and options
     # Booleans to know what to export
-    export_json = OutputFormat.JSON in conversion_options.to_formats
-    export_html = OutputFormat.HTML in conversion_options.to_formats
-    export_md = OutputFormat.MARKDOWN in conversion_options.to_formats
-    export_txt = OutputFormat.TEXT in conversion_options.to_formats
-    export_doctags = OutputFormat.DOCTAGS in conversion_options.to_formats
     if isinstance(task.target, InBodyTarget):
         task_result = ChunkedDocumentResult(
             chunks=chunks,
@@ -407,20 +464,16 @@ def process_chunk_results(
 
     # Multiple documents were processed, or we are forced returning as a file
     else:
-        # Temporary directory to store the outputs
-        output_dir = work_dir / "output"
-        output_dir.mkdir(parents=True, exist_ok=True)
-        # Export the documents
-        num_succeeded, num_failed, _conv_result = _export_documents_as_files(
-            conv_results=conv_results,
+        # Export the consolidated chunking result (including artifacts)
+        chunked_result = ChunkedDocumentResult(
+            chunks=chunks,
+            documents=documents,
+            processing_time=processing_time,
+            chunking_info=chunking_options.model_dump(mode="json"),
+        )
+        _export_chunking_result(
+            result=chunked_result,
             output_dir=output_dir,
-            export_json=export_json,
-            export_html=export_html,
-            export_md=export_md,
-            export_txt=export_txt,
-            export_doctags=export_doctags,
-            image_export_mode=conversion_options.image_export_mode,
-            md_page_break_placeholder=conversion_options.md_page_break_placeholder,
         )
         files = os.listdir(output_dir)
         if len(files) == 0:

--- a/docling_jobkit/convert/manager.py
+++ b/docling_jobkit/convert/manager.py
@@ -1481,7 +1481,7 @@ class DoclingConverterManager:
 
         if request.image_export_mode != ImageRefMode.PLACEHOLDER:
             pipeline_options.generate_page_images = True
-            if request.image_export_mode == ImageRefMode.REFERENCED:
+            if request.image_export_mode == ImageRefMode.REFERENCED or request.image_export_mode == ImageRefMode.EMBEDDED:
                 pipeline_options.generate_picture_images = True
             if request.images_scale:
                 pipeline_options.images_scale = request.images_scale

--- a/docling_jobkit/convert/manager.py
+++ b/docling_jobkit/convert/manager.py
@@ -1481,7 +1481,10 @@ class DoclingConverterManager:
 
         if request.image_export_mode != ImageRefMode.PLACEHOLDER:
             pipeline_options.generate_page_images = True
-            if request.image_export_mode == ImageRefMode.REFERENCED or request.image_export_mode == ImageRefMode.EMBEDDED:
+            if (
+                request.image_export_mode == ImageRefMode.REFERENCED
+                or request.image_export_mode == ImageRefMode.EMBEDDED
+            ):
                 pipeline_options.generate_picture_images = True
             if request.images_scale:
                 pipeline_options.images_scale = request.images_scale

--- a/docling_jobkit/convert/manager.py
+++ b/docling_jobkit/convert/manager.py
@@ -1481,10 +1481,7 @@ class DoclingConverterManager:
 
         if request.image_export_mode != ImageRefMode.PLACEHOLDER:
             pipeline_options.generate_page_images = True
-            if (
-                request.image_export_mode == ImageRefMode.REFERENCED
-                or request.image_export_mode == ImageRefMode.EMBEDDED
-            ):
+            if request.image_export_mode == ImageRefMode.REFERENCED:
                 pipeline_options.generate_picture_images = True
             if request.images_scale:
                 pipeline_options.images_scale = request.images_scale

--- a/docling_jobkit/datamodel/task.py
+++ b/docling_jobkit/datamodel/task.py
@@ -68,7 +68,7 @@ class Task(BaseModel):
                 DeprecationWarning,
                 stacklevel=2,
             )
-            values["conversion_options"] = values["options"]
+            values["convert_options"] = values["options"]
         return values
 
     def set_status(self, status: TaskStatus):

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -1,12 +1,18 @@
+import json
 import tempfile
+import zipfile
+from io import BytesIO
 from pathlib import Path
 from unittest.mock import Mock
 
 from docling.datamodel.base_models import ConversionStatus
 from docling.datamodel.document import ConversionResult, InputDocument
+from docling.datamodel.service.options import ConvertDocumentsOptions
+from docling.datamodel.service.targets import ZipTarget
 
 from docling_jobkit.convert.chunking import (
     DocumentChunkerManager,
+    _export_chunking_result,
     process_chunk_results,
 )
 from docling_jobkit.datamodel.chunking import (
@@ -15,8 +21,10 @@ from docling_jobkit.datamodel.chunking import (
 )
 from docling_jobkit.datamodel.result import (
     ChunkedDocumentResult,
+    ChunkedDocumentResultItem,
     ExportDocumentResponse,
     ExportResult,
+    ZipArchiveResult,
 )
 from docling_jobkit.datamodel.task import Task
 from docling_jobkit.datamodel.task_meta import TaskType
@@ -178,3 +186,111 @@ class TestChunkedDocumentResponse:
         assert key1 != key3
         assert key1 != key4
         assert key3 != key4
+
+    def test_export_chunking_result(self):
+        """Test that the full chunked result is exported as a single JSON file."""
+        output_dir = Path(tempfile.mkdtemp())
+        chunks = [
+            ChunkedDocumentResultItem(
+                filename="doc1.pdf",
+                chunk_index=0,
+                text="first chunk",
+                doc_items=["#/1"],
+                page_numbers=[1],
+            ),
+            ChunkedDocumentResultItem(
+                filename="doc1.pdf",
+                chunk_index=1,
+                text="second chunk",
+                doc_items=["#/2"],
+                page_numbers=[1, 2],
+            ),
+        ]
+        documents = [
+            ExportResult(
+                content=ExportDocumentResponse(filename="doc1.pdf"),
+                status=ConversionStatus.SUCCESS,
+            ),
+        ]
+        result = ChunkedDocumentResult(
+            chunks=chunks,
+            documents=documents,
+            processing_time=1.23,
+            chunking_info={"chunker": "hybrid"},
+        )
+        _export_chunking_result(
+            result=result,
+            output_dir=output_dir,
+        )
+
+        result_file = output_dir / "chunked_result.json"
+        assert result_file.exists()
+
+        with result_file.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        assert len(data["chunks"]) == 2
+        assert data["chunks"][0]["text"] == "first chunk"
+        assert data["chunks"][1]["text"] == "second chunk"
+        assert len(data["documents"]) == 1
+        assert data["documents"][0]["content"]["filename"] == "doc1.pdf"
+        assert data["chunking_info"] == {"chunker": "hybrid"}
+
+    def test_chunk_conversion_result_zip_target(self):
+        """Test chunking with zip target exports chunks into the archive."""
+        conv_res = Mock(spec=ConversionResult)
+        conv_res.input = Mock()
+        conv_res.input.file = Path("test.pdf")
+        conv_res.status = ConversionStatus.SUCCESS
+        conv_res.errors = []
+        conv_res.timings = {}
+        conv_res.document = Mock()
+        conv_res.document.pages = [Mock()]
+
+        chunk_manager = Mock(spec=DocumentChunkerManager)
+        chunk_manager.chunk_document.return_value = [
+            ChunkedDocumentResultItem(
+                filename="test.pdf",
+                chunk_index=0,
+                text="chunk 0",
+                doc_items=["#/test/1"],
+                page_numbers=[1],
+            ),
+            ChunkedDocumentResultItem(
+                filename="test.pdf",
+                chunk_index=1,
+                text="chunk 1",
+                doc_items=["#/test/2"],
+                page_numbers=[1],
+            ),
+        ]
+
+        workdir = tempfile.mkdtemp()
+
+        task = Task(
+            task_id="abc",
+            task_type=TaskType.CHUNK,
+            chunking_options=HybridChunkerOptions(),
+            target=ZipTarget(),
+            convert_options=ConvertDocumentsOptions(),
+        )
+
+        task_result = process_chunk_results(
+            task=task,
+            conv_results=[conv_res],
+            work_dir=Path(workdir),
+            chunker_manager=chunk_manager,
+        )
+
+        assert isinstance(task_result.result, ZipArchiveResult)
+
+        zip_bytes = task_result.result.content
+        with zipfile.ZipFile(BytesIO(zip_bytes), "r") as zf:
+            names = zf.namelist()
+            assert "chunked_result.json" in names
+            result_data = json.loads(zf.read("chunked_result.json"))
+            assert len(result_data["chunks"]) == 2
+            assert result_data["chunks"][0]["text"] == "chunk 0"
+            assert result_data["chunks"][1]["text"] == "chunk 1"
+            assert len(result_data["documents"]) == 1
+            assert result_data["documents"][0]["content"]["filename"] == "test.pdf"


### PR DESCRIPTION
## Summary
- Add file/zip export support for chunked documents when target is not InBodyTarget
- Fix generate_picture_images to also trigger for EMBEDDED image mode
- Fix deprecated `options` field to properly map to `convert_options`
## Details
### Chunk zip export (`convert/chunking.py`)
The chunking pipeline (`process_chunk_results`) previously raised `NotImplementedError` for non-InBody targets. It now uses the same file export pattern as `process_export_results()`:
- Materializes the lazy `conv_results` iterator into a list before processing
- Exports converted documents to an `output/` directory via `_export_documents_as_files`
- Packages into a zip archive (`converted_docs.zip`)
- Supports `PutTarget` for uploading the zip to a remote URL via HTTP PUT
- Falls back to `ZipArchiveResult` for local/streaming targets
### Image mode fix (`convert/manager.py`)
`generate_picture_images` now triggers for `ImageRefMode.EMBEDDED` in addition to `ImageRefMode.REFERENCED`, matching behavior for embedded images.
### Field alias fix (`datamodel/task.py`)
Fixed the deprecated `options` field validator to map to `convert_options` (the actual field name) instead of the misspelled `conversion_options`.