### PR TITLE
feat: map OCR text-layer skip option

### DIFF
--- a/docling_jobkit/convert/manager.py
+++ b/docling_jobkit/convert/manager.py
@@ -1324,6 +1324,11 @@ class DoclingConverterManager:
 
     def _parse_ocr_options(self, request: ConvertDocumentsOptions) -> OcrOptions:
         """Parse OCR options - preset OR custom config."""
+        shared_ocr_options = {
+            "force_full_page_ocr": request.force_ocr,
+        }
+        if getattr(request, "ocr_skip_text_layer_pages", False):
+            shared_ocr_options["skip_text_layer_pages"] = True
 
         # Option 1: Preset (recommended, includes deprecated ocr_engine via validator)
         # "auto" is the default sentinel — if ocr_custom_config is also set, defer to Option 2.
@@ -1355,7 +1360,7 @@ class DoclingConverterManager:
                 try:
                     ocr_options = self.ocr_factory.create_options(  # type: ignore[assignment]
                         kind=kind,
-                        force_full_page_ocr=request.force_ocr,
+                        **shared_ocr_options,
                         **{k: v for k, v in config_dict.items() if k != "kind"},
                     )
                 except ImportError as err:
@@ -1381,7 +1386,7 @@ class DoclingConverterManager:
                 try:
                     ocr_options = self.ocr_factory.create_options(  # type: ignore[assignment]
                         kind=kind,
-                        force_full_page_ocr=request.force_ocr,
+                        **shared_ocr_options,
                     )
                 except ImportError as err:
                     raise ImportError(
@@ -1422,7 +1427,7 @@ class DoclingConverterManager:
             try:
                 return self.ocr_factory.create_options(  # type: ignore[return-value]
                     kind=kind_value,
-                    force_full_page_ocr=request.force_ocr,
+                    **shared_ocr_options,
                     **{k: v for k, v in config_dict.items() if k != "kind"},
                 )
             except ImportError as err:
@@ -1436,7 +1441,7 @@ class DoclingConverterManager:
         # Option 3: Use default (should not reach here due to default="auto")
         return self.ocr_factory.create_options(  # type: ignore[return-value]
             kind=self.config.default_ocr_kind,
-            force_full_page_ocr=request.force_ocr,
+            **shared_ocr_options,
         )
 
     def get_converter(self, pdf_format_option: PdfFormatOption) -> DocumentConverter:

--- a/tests/test_pipeline_options_translation.py
+++ b/tests/test_pipeline_options_translation.py
@@ -92,6 +92,21 @@ class TestPipelineOptionsTranslation:
         assert ocr_opts.transport == "grpc"
         assert ocr_opts.force_full_page_ocr is True  # from force_ocr=True in payload
 
+    def test_ocr_text_layer_skip_translated(self, manager, monkeypatch):
+        calls = []
+
+        def fake_create_options(**kwargs):
+            calls.append(kwargs)
+            return object()
+
+        options = ConvertDocumentsOptions.model_validate(PAYLOAD)
+        object.__setattr__(options, "ocr_skip_text_layer_pages", True)
+        monkeypatch.setattr(manager.ocr_factory, "create_options", fake_create_options)
+
+        manager._parse_ocr_options(options)
+
+        assert calls[0]["skip_text_layer_pages"] is True
+
     def test_pdf_pipeline_options_flags(self, manager):
         options = ConvertDocumentsOptions.model_validate(PAYLOAD)
         pdf_format_option = manager.get_pdf_pipeline_opts(options)


### PR DESCRIPTION
## Summary

This maps Docling's new service request option into OCR engine options:

```python
ConvertDocumentsOptions(ocr_skip_text_layer_pages=True)
```

When present, jobkit passes `skip_text_layer_pages=True` into the selected OCR options. The mapper reads the field with `getattr(..., False)` so this remains compatible with the current released Docling package until docling-project/docling#3465 is released.

Related to docling-project/docling#3464 and docling-project/docling#3465.

## Validation

- `uv run ruff check docling_jobkit/convert/manager.py tests/test_pipeline_options_translation.py`
- `uv run pytest tests/test_pipeline_options_translation.py`
- `git diff --check`