### PR TITLE
fix: respect include_images during conversion

### DIFF
--- a/docling_jobkit/convert/manager.py
+++ b/docling_jobkit/convert/manager.py
@@ -1484,7 +1484,7 @@ class DoclingConverterManager:
                 picture_classification_options
             )
 
-        if request.image_export_mode != ImageRefMode.PLACEHOLDER:
+        if request.include_images and request.image_export_mode != ImageRefMode.PLACEHOLDER:
             pipeline_options.generate_page_images = True
             if request.image_export_mode == ImageRefMode.REFERENCED:
                 pipeline_options.generate_picture_images = True

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -99,6 +99,23 @@ def test_options_validator():
         )
 
 
+@pytest.mark.parametrize(
+    "image_export_mode",
+    [ImageRefMode.EMBEDDED, ImageRefMode.REFERENCED],
+)
+def test_include_images_false_disables_image_generation(image_export_mode):
+    m = DoclingConverterManager(config=DoclingConverterManagerConfig())
+
+    opts = ConvertDocumentsOptions(
+        include_images=False,
+        image_export_mode=image_export_mode,
+    )
+    pipeline_opts = m.get_pdf_pipeline_opts(opts)
+
+    assert pipeline_opts.pipeline_options.generate_page_images is False
+    assert pipeline_opts.pipeline_options.generate_picture_images is False
+
+
 def test_options_cache_key():
     """Test cache key generation with deprecated picture_description_api field.
 


### PR DESCRIPTION
## Summary

- respect `include_images=false` when translating conversion requests to PDF pipeline options
- add coverage for `embedded` and `referenced` export modes with images disabled

Closes #150.

## Rationale

`include_images` is the high-level request flag for generated image assets. Before this change, `image_export_mode=referenced` still enabled page and picture image generation even when `include_images=false`, so callers could receive image assets they explicitly disabled.

## Tests

- `uv run ruff check docling_jobkit/convert/manager.py tests/test_options.py`
- `uv run pytest tests/test_options.py::test_include_images_false_disables_image_generation -q`
- `uv run pytest tests/test_pipeline_options_translation.py::TestPipelineOptionsTranslation::test_pdf_pipeline_options_flags -q`

Note: `uv run pytest tests/test_options.py -q` passes the new image-generation coverage, but on my macOS environment it still has an unrelated existing VLM default preset equality failure in `test_options_validator`.
