### PR TITLE
feat: Support S3 source input across orchestrators

### DIFF
--- a/docling_jobkit/cli/local.py
+++ b/docling_jobkit/cli/local.py
@@ -7,6 +7,11 @@ from pydantic import BaseModel, Field, ValidationError
 from rich.console import Console
 
 from docling.datamodel.service.options import ConvertDocumentsOptions
+from docling.datamodel.service.requests import (
+    FileSourceRequest,
+    HttpSourceRequest,
+    S3SourceRequest,
+)
 from docling.datamodel.service.targets import S3Target, ZipTarget
 
 from docling_jobkit.connectors.source_processor_factory import get_source_processor
@@ -17,11 +22,8 @@ from docling_jobkit.convert.manager import (
 )
 from docling_jobkit.convert.results_processor import ResultsProcessor
 from docling_jobkit.datamodel.task_sources import (
-    TaskFileSource,
     TaskGoogleDriveSource,
-    TaskHttpSource,
     TaskLocalPathSource,
-    TaskS3Source,
 )
 from docling_jobkit.datamodel.task_targets import (
     GoogleDriveTarget,
@@ -40,10 +42,10 @@ app = typer.Typer(
 )
 
 JobTaskSource = Annotated[
-    TaskFileSource
-    | TaskHttpSource
+    FileSourceRequest
+    | HttpSourceRequest
     | TaskLocalPathSource
-    | TaskS3Source
+    | S3SourceRequest
     | TaskGoogleDriveSource,
     Field(discriminator="kind"),
 ]

--- a/docling_jobkit/cli/multiproc.py
+++ b/docling_jobkit/cli/multiproc.py
@@ -18,6 +18,11 @@ from rich.progress import (
 )
 
 from docling.datamodel.service.options import ConvertDocumentsOptions
+from docling.datamodel.service.requests import (
+    FileSourceRequest,
+    HttpSourceRequest,
+    S3SourceRequest,
+)
 from docling.datamodel.service.targets import S3Target, ZipTarget
 
 from docling_jobkit.connectors.source_processor_factory import get_source_processor
@@ -28,11 +33,8 @@ from docling_jobkit.convert.manager import (
 )
 from docling_jobkit.convert.results_processor import ResultsProcessor
 from docling_jobkit.datamodel.task_sources import (
-    TaskFileSource,
     TaskGoogleDriveSource,
-    TaskHttpSource,
     TaskLocalPathSource,
-    TaskS3Source,
 )
 from docling_jobkit.datamodel.task_targets import (
     GoogleDriveTarget,
@@ -51,10 +53,10 @@ app = typer.Typer(
 )
 
 JobTaskSource = Annotated[
-    TaskFileSource
-    | TaskHttpSource
+    FileSourceRequest
+    | HttpSourceRequest
     | TaskLocalPathSource
-    | TaskS3Source
+    | S3SourceRequest
     | TaskGoogleDriveSource,
     Field(discriminator="kind"),
 ]

--- a/docling_jobkit/connectors/source_processor_factory.py
+++ b/docling_jobkit/connectors/source_processor_factory.py
@@ -1,23 +1,25 @@
+from docling.datamodel.service.sources import FileSource, HttpSource, S3Coordinates
+
 from docling_jobkit.connectors.http_source_processor import HttpSourceProcessor
 from docling_jobkit.connectors.local_path_source_processor import (
     LocalPathSourceProcessor,
 )
 from docling_jobkit.connectors.s3_source_processor import S3SourceProcessor
 from docling_jobkit.connectors.source_processor import BaseSourceProcessor
+from docling_jobkit.datamodel.task import TaskSource as RuntimeTaskSource
 from docling_jobkit.datamodel.task_sources import (
-    TaskFileSource,
     TaskGoogleDriveSource,
-    TaskHttpSource,
     TaskLocalPathSource,
-    TaskS3Source,
-    TaskSource,
+    TaskSource as CliTaskSource,
 )
 
 
-def get_source_processor(source: TaskSource) -> BaseSourceProcessor:
-    if isinstance(source, (TaskFileSource, TaskHttpSource)):
+def get_source_processor(
+    source: RuntimeTaskSource | CliTaskSource,
+) -> BaseSourceProcessor:
+    if isinstance(source, (FileSource, HttpSource)):
         return HttpSourceProcessor(source)
-    elif isinstance(source, TaskS3Source):
+    elif isinstance(source, S3Coordinates):
         return S3SourceProcessor(source)
     elif isinstance(source, TaskGoogleDriveSource):
         from docling_jobkit.connectors.google_drive_source_processor import (

--- a/docling_jobkit/connectors/source_processor_factory.py
+++ b/docling_jobkit/connectors/source_processor_factory.py
@@ -6,16 +6,20 @@ from docling_jobkit.connectors.local_path_source_processor import (
 )
 from docling_jobkit.connectors.s3_source_processor import S3SourceProcessor
 from docling_jobkit.connectors.source_processor import BaseSourceProcessor
-from docling_jobkit.datamodel.task import TaskSource as RuntimeTaskSource
 from docling_jobkit.datamodel.task_sources import (
     TaskGoogleDriveSource,
     TaskLocalPathSource,
-    TaskSource as CliTaskSource,
 )
 
 
 def get_source_processor(
-    source: RuntimeTaskSource | CliTaskSource,
+    source: (
+        FileSource
+        | HttpSource
+        | S3Coordinates
+        | TaskGoogleDriveSource
+        | TaskLocalPathSource
+    ),
 ) -> BaseSourceProcessor:
     if isinstance(source, (FileSource, HttpSource)):
         return HttpSourceProcessor(source)

--- a/docling_jobkit/convert/source_expansion.py
+++ b/docling_jobkit/convert/source_expansion.py
@@ -1,0 +1,33 @@
+from typing import Any, Optional, Union
+
+from docling.datamodel.base_models import DocumentStream
+from docling.datamodel.service.sources import FileSource, HttpSource, S3Coordinates
+
+from docling_jobkit.connectors.source_processor_factory import get_source_processor
+from docling_jobkit.datamodel.task import Task
+
+
+def expand_task_sources(
+    task: Task,
+) -> tuple[list[Union[str, DocumentStream]], Optional[dict[str, Any]]]:
+    """Expand task sources into converter inputs and optional HTTP headers."""
+    convert_sources: list[Union[str, DocumentStream]] = []
+    headers: Optional[dict[str, Any]] = None
+
+    for source in task.sources:
+        if isinstance(source, DocumentStream):
+            convert_sources.append(source)
+        elif isinstance(source, FileSource):
+            convert_sources.append(source.to_document_stream())
+        elif isinstance(source, HttpSource):
+            convert_sources.append(str(source.url))
+            if headers is None and source.headers:
+                headers = source.headers
+        elif isinstance(source, S3Coordinates):
+            with get_source_processor(source) as source_processor:
+                for document_stream in source_processor.iterate_documents():
+                    convert_sources.append(document_stream)
+        else:
+            raise RuntimeError(f"Unsupported runtime task source: {type(source)!r}")
+
+    return convert_sources, headers

--- a/docling_jobkit/convert/source_expansion.py
+++ b/docling_jobkit/convert/source_expansion.py
@@ -24,6 +24,10 @@ def expand_task_sources(
             if headers is None and source.headers:
                 headers = source.headers
         elif isinstance(source, S3Coordinates):
+            # Orchestrators need converter-ready inputs for mixed runtime sources in a
+            # single task. Connector chunking is a CLI batching primitive and would
+            # change task/result semantics for DocumentStream/FileSource/HttpSource
+            # inputs, so the runtime path expands sources directly here instead.
             with get_source_processor(source) as source_processor:
                 for document_stream in source_processor.iterate_documents():
                     convert_sources.append(document_stream)

--- a/docling_jobkit/datamodel/task_sources.py
+++ b/docling_jobkit/datamodel/task_sources.py
@@ -11,12 +11,6 @@ from docling.datamodel.service.requests import (
 
 from docling_jobkit.datamodel.google_drive_coords import GoogleDriveCoordinates
 
-# Compatibility aliases for historical jobkit imports. The shared request
-# models in `docling` are the source-kind boundary types for file/http/s3.
-TaskFileSource = FileSourceRequest
-TaskHttpSource = HttpSourceRequest
-TaskS3Source = S3SourceRequest
-
 
 class TaskGoogleDriveSource(GoogleDriveCoordinates):
     kind: Literal["google_drive"] = "google_drive"
@@ -73,19 +67,16 @@ class TaskLocalPathSource(BaseModel):
 
 
 TaskSource = Annotated[
-    TaskFileSource
-    | TaskHttpSource
-    | TaskS3Source
+    FileSourceRequest
+    | HttpSourceRequest
+    | S3SourceRequest
     | TaskGoogleDriveSource
     | TaskLocalPathSource,
     Field(discriminator="kind"),
 ]
 
 __all__ = [
-    "TaskFileSource",
     "TaskGoogleDriveSource",
-    "TaskHttpSource",
     "TaskLocalPathSource",
-    "TaskS3Source",
     "TaskSource",
 ]

--- a/docling_jobkit/datamodel/task_sources.py
+++ b/docling_jobkit/datamodel/task_sources.py
@@ -3,21 +3,19 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, Field
 
-from docling.datamodel.service.sources import FileSource, HttpSource, S3Coordinates
+from docling.datamodel.service.requests import (
+    FileSourceRequest,
+    HttpSourceRequest,
+    S3SourceRequest,
+)
 
 from docling_jobkit.datamodel.google_drive_coords import GoogleDriveCoordinates
 
-
-class TaskFileSource(FileSource):
-    kind: Literal["file"] = "file"
-
-
-class TaskHttpSource(HttpSource):
-    kind: Literal["http"] = "http"
-
-
-class TaskS3Source(S3Coordinates):
-    kind: Literal["s3"] = "s3"
+# Compatibility aliases for historical jobkit imports. The shared request
+# models in `docling` are the source-kind boundary types for file/http/s3.
+TaskFileSource = FileSourceRequest
+TaskHttpSource = HttpSourceRequest
+TaskS3Source = S3SourceRequest
 
 
 class TaskGoogleDriveSource(GoogleDriveCoordinates):
@@ -81,4 +79,13 @@ TaskSource = Annotated[
     | TaskGoogleDriveSource
     | TaskLocalPathSource,
     Field(discriminator="kind"),
+]
+
+__all__ = [
+    "TaskFileSource",
+    "TaskGoogleDriveSource",
+    "TaskHttpSource",
+    "TaskLocalPathSource",
+    "TaskS3Source",
+    "TaskSource",
 ]

--- a/docling_jobkit/orchestrators/local/worker.py
+++ b/docling_jobkit/orchestrators/local/worker.py
@@ -2,15 +2,14 @@ import asyncio
 import logging
 import shutil
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING
 
-from docling.datamodel.base_models import DocumentStream
-from docling.datamodel.service.sources import FileSource, HttpSource
 from docling.datamodel.service.tasks import TaskType
 
 from docling_jobkit.convert.chunking import process_chunkable_results
 from docling_jobkit.convert.manager import DoclingConverterManager
 from docling_jobkit.convert.results import process_exportable_results
+from docling_jobkit.convert.source_expansion import expand_task_sources
 from docling_jobkit.datamodel.exportable_document import ExportableDocument
 from docling_jobkit.datamodel.result import DoclingTaskResult
 from docling_jobkit.datamodel.task_meta import TaskStatus
@@ -66,18 +65,7 @@ class AsyncLocalWorker:
 
                 # Define a callback function to send progress updates to the client.
                 def run_task() -> DoclingTaskResult:
-                    convert_sources: list[Union[str, DocumentStream]] = []
-                    headers: Optional[dict[str, Any]] = None
-                    for source in task.sources:
-                        if isinstance(source, DocumentStream):
-                            convert_sources.append(source)
-                        elif isinstance(source, FileSource):
-                            convert_sources.append(source.to_document_stream())
-                        elif isinstance(source, HttpSource):
-                            convert_sources.append(str(source.url))
-                            if headers is None and source.headers:
-                                headers = source.headers
-
+                    convert_sources, headers = expand_task_sources(task)
                     # Note: results are only an iterator->lazy evaluation
                     conv_results = cm.convert_documents(
                         sources=convert_sources,
@@ -106,6 +94,8 @@ class AsyncLocalWorker:
                             chunker_manager=self.orchestrator.chunker_manager,
                             callback_invoker=callback_invoker,
                         )
+                    else:
+                        raise RuntimeError(f"Unsupported task type: {task.task_type}")
 
                     return processed_results
 

--- a/docling_jobkit/orchestrators/ray/serve_deployment.py
+++ b/docling_jobkit/orchestrators/ray/serve_deployment.py
@@ -23,7 +23,7 @@ from docling.datamodel.base_models import (
 )
 from docling.datamodel.document import ConversionResult
 from docling.datamodel.service.options import ConvertDocumentsOptions
-from docling.datamodel.service.sources import FileSource, HttpSource, S3Coordinates
+from docling.datamodel.service.sources import FileSource, HttpSource
 from docling.datamodel.service.tasks import TaskType
 from docling.utils.profiling import ProfilingItem
 from docling_core.types.doc.document import DoclingDocument
@@ -657,6 +657,11 @@ class DoclingProcessorCoordinatorDeployment:
         materialized_start_time = time.monotonic()
 
         if self._should_materialize_pdf(task):
+            # "Passthrough" keeps the original task sources intact and lets the
+            # converter expand or fetch them when it executes the task. We only
+            # materialize for the single-PDF fanout path, where the coordinator
+            # must read one PDF up front to enforce preflight limits, determine
+            # page count, and share the same bytes across slice requests.
             source = task.sources[0]
             if not isinstance(source, (FileSource, HttpSource)):
                 raise TypeError(
@@ -732,14 +737,11 @@ class DoclingProcessorCoordinatorDeployment:
         return converter_result.task_result
 
     def _should_materialize_pdf(self, task: Task) -> bool:
-        has_s3_source = any(
-            isinstance(source, S3Coordinates) for source in task.sources
-        )
         return (
-            not has_s3_source
-            and self.config.enable_pdf_page_slice_fanout
+            self.config.enable_pdf_page_slice_fanout
             and task.task_type == TaskType.CONVERT
             and len(task.sources) == 1
+            and isinstance(task.sources[0], (FileSource, HttpSource))
             and _is_pdf_source(task.sources[0])
         )
 

--- a/docling_jobkit/orchestrators/ray/serve_deployment.py
+++ b/docling_jobkit/orchestrators/ray/serve_deployment.py
@@ -12,7 +12,7 @@ import time
 from copy import deepcopy
 from io import BytesIO
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Optional
 
 import ray
 from ray import serve
@@ -23,7 +23,7 @@ from docling.datamodel.base_models import (
 )
 from docling.datamodel.document import ConversionResult
 from docling.datamodel.service.options import ConvertDocumentsOptions
-from docling.datamodel.service.sources import FileSource, HttpSource
+from docling.datamodel.service.sources import FileSource, HttpSource, S3Coordinates
 from docling.datamodel.service.tasks import TaskType
 from docling.utils.profiling import ProfilingItem
 from docling_core.types.doc.document import DoclingDocument
@@ -44,6 +44,7 @@ from docling_jobkit.convert.results import (
     _is_exportable_status,
     process_exportable_results,
 )
+from docling_jobkit.convert.source_expansion import expand_task_sources
 from docling_jobkit.datamodel.exportable_document import ExportableDocument
 from docling_jobkit.datamodel.result import DoclingTaskResult
 from docling_jobkit.datamodel.task import Task
@@ -89,25 +90,6 @@ def _is_pdf_source(source: Any) -> bool:
     if isinstance(source, HttpSource):
         return str(source.url).lower().split("?", 1)[0].endswith(".pdf")
     return False
-
-
-def _build_convert_sources(
-    task: Task,
-) -> tuple[list[Union[str, DocumentStream]], Optional[dict[str, Any]]]:
-    convert_sources: list[Union[str, DocumentStream]] = []
-    headers: Optional[dict[str, Any]] = None
-
-    for source in task.sources:
-        if isinstance(source, DocumentStream):
-            convert_sources.append(source)
-        elif isinstance(source, FileSource):
-            convert_sources.append(source.to_document_stream())
-        elif isinstance(source, HttpSource):
-            convert_sources.append(str(source.url))
-            if headers is None and source.headers:
-                headers = source.headers
-
-    return convert_sources, headers
 
 
 def _build_slice_plan(
@@ -390,7 +372,7 @@ class DoclingProcessorConverterDeployment:
         return ConverterTaskResult(task_result=task_result)
 
     def _convert_passthrough_task(self, task: Task) -> list[ConversionResult]:
-        convert_sources, headers = _build_convert_sources(task)
+        convert_sources, headers = expand_task_sources(task)
         convert_opts = task.convert_options or ConvertDocumentsOptions()
         return list(
             self.cm.convert_documents(
@@ -750,8 +732,12 @@ class DoclingProcessorCoordinatorDeployment:
         return converter_result.task_result
 
     def _should_materialize_pdf(self, task: Task) -> bool:
+        has_s3_source = any(
+            isinstance(source, S3Coordinates) for source in task.sources
+        )
         return (
-            self.config.enable_pdf_page_slice_fanout
+            not has_s3_source
+            and self.config.enable_pdf_page_slice_fanout
             and task.task_type == TaskType.CONVERT
             and len(task.sources) == 1
             and _is_pdf_source(task.sources[0])

--- a/docling_jobkit/orchestrators/rq/orchestrator.py
+++ b/docling_jobkit/orchestrators/rq/orchestrator.py
@@ -21,7 +21,7 @@ from docling.datamodel.base_models import DocumentStream
 from docling.datamodel.service.callbacks import CallbackSpec
 from docling.datamodel.service.chunking import BaseChunkerOptions
 from docling.datamodel.service.options import ConvertDocumentsOptions
-from docling.datamodel.service.sources import FileSource, HttpSource
+from docling.datamodel.service.sources import FileSource, HttpSource, S3Coordinates
 from docling.datamodel.service.tasks import TaskProcessingMeta, TaskType
 
 from docling_jobkit.datamodel.chunking import ChunkingExportOptions
@@ -85,6 +85,24 @@ _WATCHDOG_GRACE_PERIOD = (
 )
 _RQ_JOB_GONE = _RQJobGone()
 _TASK_METADATA_PREFIX = "docling:tasks:"
+
+
+def _normalize_runtime_source(
+    source: HttpSource | FileSource | S3Coordinates,
+) -> HttpSource | FileSource | S3Coordinates:
+    if isinstance(source, FileSource):
+        if type(source) is FileSource:
+            return source
+        return FileSource.model_validate(source.model_dump())
+    if isinstance(source, HttpSource):
+        if type(source) is HttpSource:
+            return source
+        return HttpSource.model_validate(source.model_dump())
+    if isinstance(source, S3Coordinates):
+        if type(source) is S3Coordinates:
+            return source
+        return S3Coordinates.model_validate(source.model_dump())
+    raise RuntimeError(f"Unsupported runtime source: {type(source)!r}")
 
 
 class RQOrchestrator(BaseOrchestrator):
@@ -165,15 +183,15 @@ class RQOrchestrator(BaseOrchestrator):
                     stacklevel=2,
                 )
             task_id = str(uuid.uuid4())
-            rq_sources: list[HttpSource | FileSource] = []
+            rq_sources: list[HttpSource | FileSource | S3Coordinates] = []
             for source in sources:
                 if isinstance(source, DocumentStream):
                     encoded_doc = base64.b64encode(source.stream.read()).decode()
                     rq_sources.append(
                         FileSource(filename=source.name, base64_string=encoded_doc)
                     )
-                elif isinstance(source, (HttpSource | FileSource)):
-                    rq_sources.append(source)
+                elif isinstance(source, (HttpSource, FileSource, S3Coordinates)):
+                    rq_sources.append(_normalize_runtime_source(source))
             chunking_export_options = chunking_export_options or ChunkingExportOptions()
             task = Task(
                 task_id=task_id,

--- a/docling_jobkit/orchestrators/rq/orchestrator.py
+++ b/docling_jobkit/orchestrators/rq/orchestrator.py
@@ -87,24 +87,6 @@ _RQ_JOB_GONE = _RQJobGone()
 _TASK_METADATA_PREFIX = "docling:tasks:"
 
 
-def _normalize_runtime_source(
-    source: HttpSource | FileSource | S3Coordinates,
-) -> HttpSource | FileSource | S3Coordinates:
-    if isinstance(source, FileSource):
-        if type(source) is FileSource:
-            return source
-        return FileSource.model_validate(source.model_dump())
-    if isinstance(source, HttpSource):
-        if type(source) is HttpSource:
-            return source
-        return HttpSource.model_validate(source.model_dump())
-    if isinstance(source, S3Coordinates):
-        if type(source) is S3Coordinates:
-            return source
-        return S3Coordinates.model_validate(source.model_dump())
-    raise RuntimeError(f"Unsupported runtime source: {type(source)!r}")
-
-
 class RQOrchestrator(BaseOrchestrator):
     @staticmethod
     def make_rq_queue(config: RQOrchestratorConfig) -> tuple[redis.Redis, Queue]:
@@ -191,7 +173,7 @@ class RQOrchestrator(BaseOrchestrator):
                         FileSource(filename=source.name, base64_string=encoded_doc)
                     )
                 elif isinstance(source, (HttpSource, FileSource, S3Coordinates)):
-                    rq_sources.append(_normalize_runtime_source(source))
+                    rq_sources.append(source)
             chunking_export_options = chunking_export_options or ChunkingExportOptions()
             task = Task(
                 task_id=task_id,

--- a/docling_jobkit/orchestrators/rq/worker.py
+++ b/docling_jobkit/orchestrators/rq/worker.py
@@ -4,7 +4,6 @@ import shutil
 import tempfile
 import threading
 from contextlib import nullcontext
-from io import BytesIO
 from pathlib import Path
 from typing import Any, Callable, ContextManager, Optional, Union
 
@@ -13,7 +12,7 @@ import redis as sync_redis
 from rq import SimpleWorker, get_current_job
 
 from docling.datamodel.base_models import DocumentStream
-from docling.datamodel.service.sources import FileSource, HttpSource
+from docling.datamodel.service.sources import FileSource, HttpSource, S3Coordinates
 from docling.datamodel.service.tasks import TaskType
 
 from docling_jobkit.convert.chunking import process_chunkable_results
@@ -22,6 +21,7 @@ from docling_jobkit.convert.manager import (
     DoclingConverterManagerConfig,
 )
 from docling_jobkit.convert.results import process_exportable_results
+from docling_jobkit.convert.source_expansion import expand_task_sources
 from docling_jobkit.datamodel.exportable_document import ExportableDocument
 from docling_jobkit.datamodel.result import DoclingTaskResult
 from docling_jobkit.datamodel.task import Task
@@ -58,28 +58,26 @@ def _prepare_convert_sources(
     Optional[dict[str, Any]],
     list[dict[str, str]],
 ]:
-    convert_sources: list[Union[str, DocumentStream]] = []
-    headers: Optional[dict[str, Any]] = None
+    convert_sources, headers = expand_task_sources(task)
     source_info: list[dict[str, str]] = []
 
     for idx, source in enumerate(task.sources):
         raw_bytes: Optional[bytes] = None
         if isinstance(source, DocumentStream):
-            convert_sources.append(source)
             info = {"type": "DocumentStream", "name": source.name}
         elif isinstance(source, FileSource):
             raw_bytes = base64.b64decode(source.base64_string)
-            convert_sources.append(
-                DocumentStream(stream=BytesIO(raw_bytes), name=source.filename)
-            )
             info = {"type": "FileSource", "filename": source.filename}
         elif isinstance(source, HttpSource):
-            convert_sources.append(str(source.url))
             info = {"type": "HttpSource", "url": str(source.url)}
-            if headers is None and source.headers:
-                headers = source.headers
+        elif isinstance(source, S3Coordinates):
+            info = {
+                "type": "S3Coordinates",
+                "bucket": source.bucket,
+                "key_prefix": source.key_prefix,
+            }
         else:
-            continue
+            raise RuntimeError(f"Unsupported runtime task source: {type(source)!r}")
 
         source_info.append(info)
         if on_source_prepared:

--- a/tests/test_s3_source_orchestrators.py
+++ b/tests/test_s3_source_orchestrators.py
@@ -1,0 +1,192 @@
+import base64
+from io import BytesIO
+
+import pytest
+from pydantic import SecretStr
+
+from docling.datamodel.base_models import DocumentStream
+from docling.datamodel.service.requests import (
+    FileSourceRequest,
+    HttpSourceRequest,
+    S3SourceRequest,
+)
+from docling.datamodel.service.sources import FileSource, HttpSource, S3Coordinates
+from docling.datamodel.service.tasks import TaskType
+
+from docling_jobkit.cli.local import JobConfig as LocalJobConfig
+from docling_jobkit.cli.multiproc import JobConfig as MultiprocJobConfig
+from docling_jobkit.connectors.s3_source_processor import S3SourceProcessor
+from docling_jobkit.connectors.source_processor_factory import get_source_processor
+from docling_jobkit.convert.source_expansion import expand_task_sources
+from docling_jobkit.datamodel.task import Task
+from docling_jobkit.datamodel.task_targets import InBodyTarget
+from docling_jobkit.orchestrators.rq.orchestrator import (
+    RQOrchestrator,
+    RQOrchestratorConfig,
+    _normalize_runtime_source,
+)
+
+
+def _make_s3_source() -> S3Coordinates:
+    return S3Coordinates(
+        endpoint="127.0.0.1:9000",
+        verify_ssl=False,
+        access_key=SecretStr("minioadmin"),
+        secret_key=SecretStr("minioadmin"),
+        bucket="test-bucket",
+        key_prefix="incoming/",
+    )
+
+
+def test_expand_task_sources_materializes_s3(monkeypatch: pytest.MonkeyPatch):
+    s3_source = _make_s3_source()
+    task = Task(
+        task_id="task-1",
+        task_type=TaskType.CONVERT,
+        sources=[s3_source],
+        target=InBodyTarget(),
+    )
+    expected_docs = [
+        DocumentStream(name="a.pdf", stream=BytesIO(b"a")),
+        DocumentStream(name="b.pdf", stream=BytesIO(b"b")),
+    ]
+
+    class FakeSourceProcessor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def iterate_documents(self):
+            return iter(expected_docs)
+
+    monkeypatch.setattr(
+        "docling_jobkit.convert.source_expansion.get_source_processor",
+        lambda source: FakeSourceProcessor(),
+    )
+
+    convert_sources, headers = expand_task_sources(task)
+
+    assert headers is None
+    assert convert_sources == expected_docs
+
+
+def test_get_source_processor_accepts_s3coordinates():
+    processor = get_source_processor(_make_s3_source())
+    assert isinstance(processor, S3SourceProcessor)
+
+
+def test_normalize_runtime_source_keeps_base_instances():
+    file_source = FileSource(
+        filename="doc.pdf",
+        base64_string=base64.b64encode(b"pdf-bytes").decode(),
+    )
+    http_source = HttpSource(url="https://example.com/doc.pdf")
+    s3_source = _make_s3_source()
+
+    assert _normalize_runtime_source(file_source) is file_source
+    assert _normalize_runtime_source(http_source) is http_source
+    assert _normalize_runtime_source(s3_source) is s3_source
+
+
+@pytest.mark.asyncio
+async def test_rq_enqueue_preserves_s3coordinates(monkeypatch: pytest.MonkeyPatch):
+    orchestrator = RQOrchestrator(config=RQOrchestratorConfig())
+    captured: dict[str, object] = {}
+
+    class FakeQueue:
+        def enqueue(self, *args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+
+    async def _noop(*args, **kwargs):
+        return None
+
+    orchestrator._rq_queue = FakeQueue()
+    monkeypatch.setattr(orchestrator, "init_task_tracking", _noop)
+    monkeypatch.setattr(orchestrator, "_store_task_in_redis", _noop)
+
+    s3_source = _make_s3_source()
+    task = await orchestrator.enqueue(
+        sources=[s3_source],
+        convert_options=None,
+        target=InBodyTarget(),
+    )
+
+    assert len(task.sources) == 1
+    assert isinstance(task.sources[0], S3Coordinates)
+
+    task_data = captured["kwargs"]["kwargs"]["task_data"]
+    assert len(task_data["sources"]) == 1
+    assert task_data["sources"][0]["bucket"] == s3_source.bucket
+    assert task_data["sources"][0]["key_prefix"] == s3_source.key_prefix
+
+
+@pytest.mark.parametrize("job_config_cls", [LocalJobConfig, MultiprocJobConfig])
+@pytest.mark.parametrize(
+    ("source_payload", "expected_type"),
+    [
+        (
+            {
+                "kind": "file",
+                "filename": "doc.pdf",
+                "base64_string": base64.b64encode(b"pdf-bytes").decode(),
+            },
+            FileSourceRequest,
+        ),
+        (
+            {
+                "kind": "http",
+                "url": "https://example.com/doc.pdf",
+            },
+            HttpSourceRequest,
+        ),
+        (
+            {
+                "kind": "s3",
+                "endpoint": "127.0.0.1:9000",
+                "verify_ssl": False,
+                "access_key": "minioadmin",
+                "secret_key": "minioadmin",
+                "bucket": "test-bucket",
+                "key_prefix": "incoming/",
+            },
+            S3SourceRequest,
+        ),
+    ],
+)
+def test_cli_config_parsing_keeps_kind_compatibility(
+    job_config_cls, source_payload, expected_type
+):
+    config = job_config_cls.model_validate(
+        {
+            "sources": [source_payload],
+            "target": {"kind": "local_path", "path": "."},
+        }
+    )
+
+    assert isinstance(config.sources[0], expected_type)
+
+
+def test_expand_task_sources_preserves_file_and_headers():
+    encoded = base64.b64encode(b"pdf-bytes").decode()
+    file_source = FileSource(filename="doc.pdf", base64_string=encoded)
+    http_source = HttpSource(
+        url="https://example.com/doc.pdf",
+        headers={"Authorization": "Bearer test-token"},
+    )
+    task = Task(
+        task_id="task-1",
+        task_type=TaskType.CONVERT,
+        sources=[file_source, http_source],
+        target=InBodyTarget(),
+    )
+
+    convert_sources, headers = expand_task_sources(task)
+
+    assert headers == {"Authorization": "Bearer test-token"}
+    assert len(convert_sources) == 2
+    assert isinstance(convert_sources[0], DocumentStream)
+    assert convert_sources[0].name == "doc.pdf"
+    assert convert_sources[1] == "https://example.com/doc.pdf"

--- a/tests/test_s3_source_orchestrators.py
+++ b/tests/test_s3_source_orchestrators.py
@@ -23,7 +23,6 @@ from docling_jobkit.datamodel.task_targets import InBodyTarget
 from docling_jobkit.orchestrators.rq.orchestrator import (
     RQOrchestrator,
     RQOrchestratorConfig,
-    _normalize_runtime_source,
 )
 
 
@@ -77,17 +76,34 @@ def test_get_source_processor_accepts_s3coordinates():
     assert isinstance(processor, S3SourceProcessor)
 
 
-def test_normalize_runtime_source_keeps_base_instances():
-    file_source = FileSource(
-        filename="doc.pdf",
-        base64_string=base64.b64encode(b"pdf-bytes").decode(),
+def test_task_roundtrip_accepts_request_subclasses_without_normalization():
+    task = Task(
+        task_id="task-1",
+        task_type=TaskType.CONVERT,
+        sources=[
+            FileSourceRequest(
+                filename="doc.pdf",
+                base64_string=base64.b64encode(b"pdf-bytes").decode(),
+            ),
+            HttpSourceRequest(url="https://example.com/doc.pdf"),
+            S3SourceRequest(
+                endpoint="127.0.0.1:9000",
+                verify_ssl=False,
+                access_key=SecretStr("minioadmin"),
+                secret_key=SecretStr("minioadmin"),
+                bucket="test-bucket",
+                key_prefix="incoming/",
+            ),
+        ],
+        target=InBodyTarget(),
     )
-    http_source = HttpSource(url="https://example.com/doc.pdf")
-    s3_source = _make_s3_source()
 
-    assert _normalize_runtime_source(file_source) is file_source
-    assert _normalize_runtime_source(http_source) is http_source
-    assert _normalize_runtime_source(s3_source) is s3_source
+    task_data = task.model_dump(mode="json", serialize_as_any=True)
+    rebuilt_task = Task.model_validate(task_data)
+
+    assert isinstance(rebuilt_task.sources[0], FileSource)
+    assert isinstance(rebuilt_task.sources[1], HttpSource)
+    assert isinstance(rebuilt_task.sources[2], S3Coordinates)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This PR fixes S3-backed task sources across `docling-jobkit`’s async orchestrators by consolidating source expansion onto the runtime/base models already stored in `Task.sources`. Before this change, Ray, Local, and RQ each had separate inline source handling, and S3 sources were either skipped during execution or dropped before reaching the worker. With this change, S3-backed tasks are handled consistently across the async execution paths.

- add a shared runtime source expansion helper, `convert/source_expansion.py`, that expands `DocumentStream`, `FileSource`, `HttpSource`, and `S3Coordinates` into converter inputs and is now used by Ray, Local, and RQ workers
- broaden source processor dispatch to accept runtime/base S3 models directly, and keep CLI/config compatibility by switching the `file/http/s3` boundary types in `task_sources.py` to the upstream `docling.datamodel.service.requests` models
- fix the RQ path end-to-end so `S3Coordinates` survive enqueueing and are materialized in the worker instead of being dropped before execution
- add focused regression tests covering shared S3 expansion, direct `S3Coordinates` processor dispatch, RQ enqueue preservation, CLI `kind: file/http/s3` compatibility, and the base-instance fast path in runtime normalization

<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->
