### PR TITLE
feat: RQOrchestrator support for shared Redis

### DIFF
--- a/docling_jobkit/orchestrators/rq/orchestrator.py
+++ b/docling_jobkit/orchestrators/rq/orchestrator.py
@@ -39,6 +39,7 @@ _log = logging.getLogger(__name__)
 
 class RQOrchestratorConfig(BaseModel):
     redis_url: str = "redis://localhost:6379/"
+    queue_name: str = "convert"
     results_ttl: int = 3_600 * 4
     failure_ttl: int = 3_600 * 4
     results_prefix: str = "docling:results"
@@ -99,7 +100,7 @@ class RQOrchestrator(BaseOrchestrator):
         )
         conn = redis.Redis(connection_pool=pool)
         rq_queue = Queue(
-            "convert",
+            config.queue_name,
             connection=conn,
             default_timeout=14400,
             result_ttl=config.results_ttl,

--- a/tests/test_failure_ttl.py
+++ b/tests/test_failure_ttl.py
@@ -1,6 +1,9 @@
 """Tests for RQ failure_ttl configuration."""
 
-from docling_jobkit.orchestrators.rq.orchestrator import RQOrchestratorConfig
+from docling_jobkit.orchestrators.rq.orchestrator import (
+    RQOrchestrator,
+    RQOrchestratorConfig,
+)
 
 
 class TestFailureTTLConfig:
@@ -23,3 +26,18 @@ class TestFailureTTLConfig:
         except Exception:
             pass
         assert config.failure_ttl == 1800
+
+
+class TestQueueNameConfig:
+    def test_default_queue_name_preserves_existing_behavior(self):
+        config = RQOrchestratorConfig()
+        _, rq_queue = RQOrchestrator.make_rq_queue(config)
+
+        assert config.queue_name == "convert"
+        assert rq_queue.name == "convert"
+
+    def test_custom_queue_name_is_used_for_rq_queue(self):
+        config = RQOrchestratorConfig(queue_name="staging-convert")
+        _, rq_queue = RQOrchestrator.make_rq_queue(config)
+
+        assert rq_queue.name == "staging-convert"

--- a/tests/test_rq_orchestrator_config.py
+++ b/tests/test_rq_orchestrator_config.py
@@ -1,4 +1,6 @@
-"""Tests for RQ failure_ttl configuration."""
+"""Tests for RQ orchestrator configuration."""
+
+from unittest.mock import patch
 
 from docling_jobkit.orchestrators.rq.orchestrator import (
     RQOrchestrator,
@@ -31,13 +33,17 @@ class TestFailureTTLConfig:
 class TestQueueNameConfig:
     def test_default_queue_name_preserves_existing_behavior(self):
         config = RQOrchestratorConfig()
-        _, rq_queue = RQOrchestrator.make_rq_queue(config)
+
+        with patch("docling_jobkit.orchestrators.rq.orchestrator.Queue") as queue_cls:
+            RQOrchestrator.make_rq_queue(config)
 
         assert config.queue_name == "convert"
-        assert rq_queue.name == "convert"
+        assert queue_cls.call_args.args[0] == "convert"
 
     def test_custom_queue_name_is_used_for_rq_queue(self):
         config = RQOrchestratorConfig(queue_name="staging-convert")
-        _, rq_queue = RQOrchestrator.make_rq_queue(config)
 
-        assert rq_queue.name == "staging-convert"
+        with patch("docling_jobkit.orchestrators.rq.orchestrator.Queue") as queue_cls:
+            RQOrchestrator.make_rq_queue(config)
+
+        assert queue_cls.call_args.args[0] == "staging-convert"


### PR DESCRIPTION
**Summary**

Adds a backwards-compatible solution for configurable RQ queue names. The driver for this feature is supporting multiple Docling deployments that share a common Redis database without mixing jobs in the same hardcoded `convert` queue.

**Changes**

- Added queue_name to RQOrchestratorConfig, defaulting to "convert" to preserve current behavior.
- Updated RQOrchestrator.make_rq_queue() to use config.queue_name instead of the hardcoded queue name.
- Renamed existing RQ config tests `test_failure_ttl.py` to `test_rq_orchestrator_config.py` to reflect its new scope.
- Added tests for default and custom RQ queue names.

**Issue resolved by this Pull Request:**

Resolves #156
