### PR TITLE
fix(ray): shutdown Ray client when runtime init fails

### DIFF
--- a/docling_jobkit/orchestrators/ray/orchestrator.py
+++ b/docling_jobkit/orchestrators/ray/orchestrator.py
@@ -313,6 +313,18 @@ class RayOrchestrator(BaseOrchestrator):
         except BaseException as exc:
             self.dispatcher = None
             self.deployment_handle = None
+            # Best-effort cleanup of the half-initialized Ray client. If
+            # ray.init() succeeded but a later step (serve.start,
+            # deploy_processor, _bind_dispatcher) raised, the underlying
+            # Ray client connection stays registered. Without shutdown,
+            # the supervisor's next iteration calls ray.init() again and
+            # fails permanently with "client has already connected to
+            # the cluster with allow_multiple=True". The shutdown is
+            # wrapped so it cannot mask the original failure.
+            try:
+                ray.shutdown()
+            except Exception:
+                pass
             raise DispatcherUnavailableError(
                 f"Ray runtime initialization failed: {exc}"
             ) from exc

--- a/tests/test_ray_orchestrator_init_recovery.py
+++ b/tests/test_ray_orchestrator_init_recovery.py
@@ -1,0 +1,119 @@
+"""Unit tests for RayOrchestrator._initialize_ray_runtime recovery semantics.
+
+Mock-based — does not require a live Ray cluster or Redis instance, so
+unlike tests/test_ray_orchestrator.py these run in CI.
+
+Regression coverage for https://github.com/docling-project/docling-jobkit/issues/160.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("ray")
+pytest.importorskip("redis")
+
+from docling_jobkit.orchestrators.ray.config import RayOrchestratorConfig
+from docling_jobkit.orchestrators.ray.orchestrator import (
+    DispatcherUnavailableError,
+    RayOrchestrator,
+)
+
+
+def _build_orchestrator() -> RayOrchestrator:
+    """Construct an orchestrator with mocked dependencies (no real Ray/Redis)."""
+    config = RayOrchestratorConfig()
+    cm = MagicMock()
+    cm.config = MagicMock()
+    return RayOrchestrator(config=config, converter_manager=cm)
+
+
+async def test_initialize_ray_runtime_calls_shutdown_when_mid_init_fails() -> None:
+    """If init fails after ray.init() succeeded, ray.shutdown() must be called.
+
+    Otherwise the half-initialized Ray client stays registered and the
+    supervisor's retry loop wedges on `client has already connected to
+    the cluster with allow_multiple=True`.
+    """
+    orchestrator = _build_orchestrator()
+
+    with (
+        patch("docling_jobkit.orchestrators.ray.orchestrator.ray") as mock_ray,
+        patch("docling_jobkit.orchestrators.ray.orchestrator.serve") as mock_serve,
+        patch(
+            "docling_jobkit.orchestrators.ray.orchestrator.deploy_processor"
+        ) as mock_deploy,
+    ):
+        mock_ray.is_initialized.return_value = False
+        mock_ray.__version__ = "test"
+        mock_ray.get_dashboard_url.return_value = None
+        mock_serve.start.return_value = None
+        # Simulate mid-init failure — ray.init() succeeded, then a later
+        # step raises. deploy_processor is the most realistic candidate
+        # because it goes through Ray Serve which exercises the client
+        # data channel.
+        mock_deploy.side_effect = RuntimeError("simulated mid-init failure")
+
+        with pytest.raises(DispatcherUnavailableError):
+            await orchestrator._initialize_ray_runtime()
+
+        # The critical assertion: ray.shutdown was called so the next
+        # supervisor iteration starts from a clean Ray client state.
+        mock_ray.shutdown.assert_called_once()
+
+        # State is cleared so the supervisor's `deployment_handle is None`
+        # check triggers a retry.
+        assert orchestrator.dispatcher is None
+        assert orchestrator.deployment_handle is None
+
+
+async def test_initialize_ray_runtime_shutdown_does_not_mask_original_error() -> None:
+    """If ray.shutdown() itself raises, the original init error still propagates."""
+    orchestrator = _build_orchestrator()
+
+    with (
+        patch("docling_jobkit.orchestrators.ray.orchestrator.ray") as mock_ray,
+        patch("docling_jobkit.orchestrators.ray.orchestrator.serve") as mock_serve,
+        patch(
+            "docling_jobkit.orchestrators.ray.orchestrator.deploy_processor"
+        ) as mock_deploy,
+    ):
+        mock_ray.is_initialized.return_value = False
+        mock_ray.__version__ = "test"
+        mock_ray.get_dashboard_url.return_value = None
+        mock_serve.start.return_value = None
+        mock_deploy.side_effect = RuntimeError("original failure")
+        mock_ray.shutdown.side_effect = RuntimeError("shutdown also failed")
+
+        with pytest.raises(DispatcherUnavailableError) as exc_info:
+            await orchestrator._initialize_ray_runtime()
+
+        # The DispatcherUnavailableError carries the original cause, not
+        # the shutdown failure.
+        assert "original failure" in str(exc_info.value)
+        mock_ray.shutdown.assert_called_once()
+
+
+async def test_initialize_ray_runtime_does_not_shutdown_on_success() -> None:
+    """Happy-path: shutdown must NOT be called when init succeeds."""
+    orchestrator = _build_orchestrator()
+
+    with (
+        patch("docling_jobkit.orchestrators.ray.orchestrator.ray") as mock_ray,
+        patch("docling_jobkit.orchestrators.ray.orchestrator.serve") as mock_serve,
+        patch(
+            "docling_jobkit.orchestrators.ray.orchestrator.deploy_processor"
+        ) as mock_deploy,
+        patch.object(orchestrator, "_bind_dispatcher", return_value=MagicMock()),
+    ):
+        mock_ray.is_initialized.return_value = False
+        mock_ray.__version__ = "test"
+        mock_ray.get_dashboard_url.return_value = None
+        mock_serve.start.return_value = None
+        mock_deploy.return_value = MagicMock()  # deployment_handle
+
+        await orchestrator._initialize_ray_runtime()
+
+        mock_ray.shutdown.assert_not_called()
+        assert orchestrator.deployment_handle is not None
+        assert orchestrator.dispatcher is not None


### PR DESCRIPTION
Closes #160

## Problem

When `_initialize_ray_runtime` raises after `ray.init()` has succeeded but before `_bind_dispatcher` completes, the half-initialized Ray client stays registered. The dispatcher supervisor's retry loop (from #122) then calls `ray.init()` again on every iteration and fails permanently with `The client has already connected to the cluster with allow_multiple=True`.

## Repro

1. Run the Ray orchestrator against a remote cluster (`ray://...:10001`).
2. Inject a failure between `ray.init` and `_bind_dispatcher` — e.g. data-channel hiccup that makes `serve.start` or `deploy_processor` raise.
3. The `except BaseException` block at `orchestrator.py:313-318` clears `dispatcher`/`deployment_handle` but doesn't shut down Ray.
4. The supervisor retries `_initialize_ray_runtime`. `ray.is_initialized()` returns False; `ray.init()` is called again and fails. Every subsequent retry fails identically.

Observed on a KubeRay deployment: a Ray client data-channel reconnect wedged the orchestrator for hours until manual pod restart.

## Fix

Best-effort `ray.shutdown()` in the exception handler so the next supervisor iteration starts from a clean Ray client state. Wrapped in `try/except Exception` so it cannot mask the original error.

## Tests

`tests/test_ray_orchestrator_init_recovery.py` — three mock-based unit tests (CI-runnable):

- `test_initialize_ray_runtime_calls_shutdown_when_mid_init_fails` — `deploy_processor` raises mid-init → assert `ray.shutdown()` called once + state cleared.
- `test_initialize_ray_runtime_shutdown_does_not_mask_original_error` — `ray.shutdown()` itself raises → original `DispatcherUnavailableError` still propagates with the right cause.
- `test_initialize_ray_runtime_does_not_shutdown_on_success` — happy path → `ray.shutdown()` NOT called.

All pass locally; pre-commit (ruff-format, ruff, mypy) clean.
