### PR TITLE
fix: declare variable before opening image.

### DIFF
--- a/docling_jobkit/convert/results_processor.py
+++ b/docling_jobkit/convert/results_processor.py
@@ -180,9 +180,9 @@ class ResultsProcessor:
         doc_hash: str,
     ):
         for page_no, page in pages.items():
+            page_hash = create_hash(f"{doc_hash}_page_no_{page_no}")
             try:
                 if page.image and page.image.pil_image:
-                    page_hash = create_hash(f"{doc_hash}_page_no_{page_no}")
                     page_dpi = page.image.dpi
                     page_path_suffix = f"pages/{page_hash}_{page_dpi}.png"
                     buf = BytesIO()


### PR DESCRIPTION
fix access to local variable 'page_hash'  when opening image raise an error.

<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->
