### PR TITLE
fix: Harden Ray task recovery after dispatcher restarts

### DIFF
--- a/docling_jobkit/orchestrators/ray/config.py
+++ b/docling_jobkit/orchestrators/ray/config.py
@@ -342,6 +342,17 @@ class RayOrchestratorConfig(BaseSettings):
         default=3600.0,
         description="Maximum seconds per task (None = no limit)",
     )
+    dispatch_claim_timeout: float = Field(
+        default=300.0,
+        gt=0,
+        description=(
+            "Seconds a dispatched task may sit in the tenant active set without a "
+            "live replica claim (durable STARTED + heartbeating execution lease) "
+            "before reconciliation treats it as orphaned and releases its capacity. "
+            "Only applied to tasks no longer owned by an in-flight dispatch on the "
+            "current dispatcher, i.e. after a dispatcher restart."
+        ),
+    )
     document_timeout: Optional[float] = Field(
         default=300.0,
         description="Maximum seconds per document (None = no limit)",

--- a/docling_jobkit/orchestrators/ray/dispatcher.py
+++ b/docling_jobkit/orchestrators/ray/dispatcher.py
@@ -84,6 +84,13 @@ class RayTaskDispatcher:
         self.active = False
         self.last_heartbeat = datetime.datetime.now(datetime.timezone.utc)
         self._background_tasks: set[asyncio.Task[None]] = set()
+        # Task IDs this dispatcher incarnation currently owns via an in-flight
+        # _process_task_async (response.result). Reconciliation must never
+        # terminalize these — their live owner is response.result, not the
+        # backup reconcile loop. After a dispatcher restart this set is empty,
+        # so tasks dispatched by a previous incarnation become eligible for
+        # claim-deadline recovery.
+        self._inflight_task_ids: set[str] = set()
         self._dispatch_loop_task: Optional[asyncio.Task[None]] = None
         self._runtime_lock = asyncio.Lock()
 
@@ -185,6 +192,7 @@ class RayTaskDispatcher:
         self._wake_event.clear()
         self._active_tenant_ids.clear()
         self._active_tenant_order.clear()
+        self._inflight_task_ids.clear()
         self._last_reconcile = 0.0
         self._dispatch_loop_task = asyncio.create_task(self._run_dispatch_loop())
         _log.info("Started Ray dispatcher background loop")
@@ -387,6 +395,9 @@ class RayTaskDispatcher:
 
         # Launch task asynchronously (fire-and-forget). The durable task state is
         # already in Redis, so dispatcher restarts do not lose ownership metadata.
+        # Mark the task as owned by this incarnation before launching so reconcile
+        # never races response.result for a task this dispatcher is still awaiting.
+        self._inflight_task_ids.add(task.task_id)
         background_task = asyncio.create_task(self._process_task_async(task, tenant_id))
         # Store a strong reference to prevent premature garbage collection.
         self._background_tasks.add(background_task)
@@ -477,15 +488,23 @@ class RayTaskDispatcher:
                 )
             # Capacity freed; wake dispatch loop for queued work.
             self._wake_event.set()
+        finally:
+            # Release ownership so the backup reconcile loop may recover the task
+            # if it is still active (e.g. status update raced terminalization).
+            self._inflight_task_ids.discard(task_id)
 
     async def _reconcile_active_tasks(self) -> None:
         """Reconcile active-task bookkeeping after dispatcher startup and per round.
 
-        This replaces the old stale-heartbeat orphan recovery path. The current
-        rule is intentionally conservative:
-        - STARTED tasks missing processing state are failed and released.
-        - Pre-start dispatched tasks are left unresolved because Ray Serve may
-          legitimately keep them queued for a long time.
+        Reconciliation is the backup recovery path for tasks no longer owned by a
+        live in-flight dispatch (response.result). It terminalizes active-set
+        tasks that are not backed by a live replica and releases their capacity:
+        - STARTED tasks whose replica execution lease is stale or missing past the
+          claim deadline.
+        - Pre-claim dispatched tasks (still PENDING) past the claim deadline — the
+          dispatcher that dispatched them is gone, so no replica will claim them.
+        Tasks still owned by this dispatcher incarnation are skipped; their live
+        owner is response.result, not this loop.
         """
         tenants = await self.redis_manager.get_all_tenants_with_active_tasks()
         for tenant_id in tenants:
@@ -499,80 +518,164 @@ class RayTaskDispatcher:
             return
 
         for task_id in active_task_ids:
+            # Tasks this incarnation is still awaiting via response.result are
+            # owned by that path; the backup reconcile loop must not touch them.
+            if task_id in self._inflight_task_ids:
+                continue
+
             metadata = await self.redis_manager.get_task_metadata_model(task_id)
+
+            # Durable SUCCESS/FAILURE is the terminal fence. Once durable status
+            # has moved to a terminal state, reconciliation leaves the task alone.
+            if metadata is not None and metadata.status in (
+                TaskStatus.SUCCESS,
+                TaskStatus.FAILURE,
+            ):
+                continue
+
             dispatch_hash = await self.redis_manager.get_task_dispatch_hash(task_id)
 
             if not dispatch_hash:
-                if metadata is None or metadata.status != TaskStatus.STARTED:
-                    # No processing state + non-STARTED metadata: already terminal or
-                    # was never properly dispatched. No action needed.
-                    continue
+                # The dispatch key carries a processing_ttl (≈ task_timeout + margin).
+                # If it has expired while the task is still in the active set and not
+                # terminal, the task never completed and no live dispatch remains:
+                # it is orphaned regardless of PENDING/STARTED. Release its capacity.
                 await self._fail_reconciled_task(
                     tenant_id=tenant_id,
                     task_id=task_id,
                     metadata=metadata,
-                    error_message="Task orphaned: processing state missing during reconciliation",
-                )
-                continue
-
-            # D3-owned durable SUCCESS is the terminal fence. Reconciliation only
-            # applies stale-heartbeat failure logic to tasks that are still
-            # durably STARTED; once durable status has moved to SUCCESS or
-            # FAILURE, this path must leave the task alone.
-            if metadata is None or metadata.status != TaskStatus.STARTED:
-                continue
-
-            execution_lease = await self.redis_manager.get_task_execution_lease(task_id)
-            if execution_lease is None:
-                # No lease written yet: narrow window between dispatch and replica claim,
-                # or an old in-flight task from before this code was deployed.
-                # Leave unresolved — conservative, no false positives.
-                continue
-
-            heartbeat_at_raw = execution_lease.get("heartbeat_at")
-            if heartbeat_at_raw is None:
-                # Lease exists but no heartbeat field — should not happen with current code.
-                # Leave unresolved rather than risk a false positive.
-                continue
-
-            try:
-                heartbeat_age = datetime.datetime.now(
-                    datetime.timezone.utc
-                ).timestamp() - float(heartbeat_at_raw)
-            except ValueError:
-                _log.warning(
-                    "[RECONCILE] %s: invalid execution lease heartbeat %r",
-                    task_id,
-                    heartbeat_at_raw,
-                )
-                continue
-
-            if heartbeat_age > self._get_task_processing_stale_after():
-                await self._fail_reconciled_task(
-                    tenant_id=tenant_id,
-                    task_id=task_id,
-                    metadata=metadata,
+                    dispatch_hash=dispatch_hash,
                     error_message=(
-                        "Task orphaned: replica execution lease stale during reconciliation"
+                        "Task orphaned: dispatch state expired before completion"
+                    ),
+                )
+                continue
+
+            if metadata is not None and metadata.status == TaskStatus.STARTED:
+                execution_lease = await self.redis_manager.get_task_execution_lease(
+                    task_id
+                )
+                if execution_lease is not None:
+                    heartbeat_age = self._execution_lease_heartbeat_age(
+                        task_id, execution_lease
+                    )
+                    if heartbeat_age is None:
+                        # Lease exists but heartbeat is missing/garbage. Leave
+                        # unresolved rather than risk a false positive; the lease
+                        # TTL still bounds the worst case.
+                        continue
+                    if heartbeat_age > self._get_task_processing_stale_after():
+                        await self._fail_reconciled_task(
+                            tenant_id=tenant_id,
+                            task_id=task_id,
+                            metadata=metadata,
+                            dispatch_hash=dispatch_hash,
+                            error_message=(
+                                "Task orphaned: replica execution lease stale "
+                                "during reconciliation"
+                            ),
+                        )
+                    # Fresh lease: a live replica owns the task. Leave it alone.
+                    continue
+                # STARTED without a lease (lease-write failure): fall through to the
+                # claim-deadline check below.
+
+            # Not backed by a live replica (PENDING with a dispatch key, or STARTED
+            # without a lease). Fail only once the claim deadline has elapsed; until
+            # then this is the narrow legitimate window before a replica claims the
+            # task.
+            claim_age = self._dispatch_claim_age(dispatch_hash)
+            if claim_age is None or claim_age > self.config.dispatch_claim_timeout:
+                await self._fail_reconciled_task(
+                    tenant_id=tenant_id,
+                    task_id=task_id,
+                    metadata=metadata,
+                    dispatch_hash=dispatch_hash,
+                    error_message=(
+                        "Task orphaned: no replica claim before dispatch deadline"
                     ),
                 )
 
         await self.redis_manager.resync_tenant_limits(tenant_id)
 
+    def _execution_lease_heartbeat_age(
+        self, task_id: str, execution_lease: dict[str, Any]
+    ) -> Optional[float]:
+        """Return the age of the lease heartbeat in seconds, or None if unusable."""
+        heartbeat_at_raw = execution_lease.get("heartbeat_at")
+        if heartbeat_at_raw is None:
+            return None
+        try:
+            heartbeat_at = float(heartbeat_at_raw)
+        except (TypeError, ValueError):
+            _log.warning(
+                "[RECONCILE] %s: invalid execution lease heartbeat %r",
+                task_id,
+                heartbeat_at_raw,
+            )
+            return None
+        return datetime.datetime.now(datetime.timezone.utc).timestamp() - heartbeat_at
+
+    def _dispatch_claim_age(self, dispatch_hash: dict[str, Any]) -> Optional[float]:
+        """Return seconds since dispatch, or None when past any reasonable deadline.
+
+        None is returned when the dispatch hash is missing or its timestamp is
+        unusable; callers treat None as "deadline elapsed" because a task in the
+        active set with no recoverable dispatch timestamp has been there at least
+        as long as the dispatch key's processing_ttl.
+        """
+        if not dispatch_hash:
+            return None
+        dispatched_at_raw = dispatch_hash.get("dispatched_at")
+        if dispatched_at_raw is None:
+            return None
+        try:
+            dispatched_at = float(dispatched_at_raw)
+        except (TypeError, ValueError):
+            return None
+        return datetime.datetime.now(datetime.timezone.utc).timestamp() - dispatched_at
+
+    def _resolve_reconciled_task_size(
+        self,
+        task_id: str,
+        metadata: Optional[RedisTaskMetadata],
+        dispatch_hash: dict[str, Any],
+    ) -> int:
+        """Best-effort task_size for capacity release during reconciliation.
+
+        Prefers durable metadata, then the dispatch hash, then a safe fallback of
+        1. resync_tenant_limits recomputes the canonical counters afterwards, so a
+        slightly stale size here only affects the single decrement, not the final
+        per-tenant totals.
+        """
+        if metadata is not None and metadata.task_size > 0:
+            return metadata.task_size
+
+        dispatch_task_size = dispatch_hash.get("task_size")
+        if dispatch_task_size is not None:
+            try:
+                parsed = int(dispatch_task_size)
+                if parsed > 0:
+                    return parsed
+            except (TypeError, ValueError):
+                pass
+
+        _log.warning(
+            "[RECONCILE] Missing durable task_size for %s; falling back to 1",
+            task_id,
+        )
+        return 1
+
     async def _fail_reconciled_task(
         self,
         tenant_id: str,
         task_id: str,
-        metadata: RedisTaskMetadata,
+        metadata: Optional[RedisTaskMetadata],
+        dispatch_hash: dict[str, Any],
         error_message: str,
     ) -> None:
         """Fail a reconciled task and release any capacity it still consumes."""
-        task_size = metadata.task_size if metadata.task_size > 0 else 1
-        if task_size == 1 and metadata.task_size <= 0:
-            _log.warning(
-                "[RECONCILE] Missing durable task_size for %s; falling back to 1",
-                task_id,
-            )
+        task_size = self._resolve_reconciled_task_size(task_id, metadata, dispatch_hash)
 
         _log.warning("[RECONCILE] %s: %s", task_id, error_message)
         failure = classify_public_task_failure(

--- a/docling_jobkit/orchestrators/ray/redis_helper.py
+++ b/docling_jobkit/orchestrators/ray/redis_helper.py
@@ -38,6 +38,7 @@ _log = logging.getLogger(__name__)
 _UPDATE_TASK_EXECUTION_HEARTBEAT_LUA = """
 if redis.call('EXISTS', KEYS[1]) == 1 then
     redis.call('HSET', KEYS[1], 'heartbeat_at', ARGV[1])
+    redis.call('EXPIRE', KEYS[1], ARGV[2])
     return 1
 end
 return 0
@@ -290,6 +291,13 @@ class RedisStateManager:
     ) -> None:
         """Update task status and metadata.
 
+        A durable terminal status (SUCCESS/FAILURE) is the final fence: this method
+        will not overwrite it. That keeps a late replica from resurrecting a task
+        that reconciliation already failed — e.g. a process_task request that Ray
+        Serve queued past the dispatch claim deadline and only ran after the
+        dispatcher restarted. Without this guard such a replica would flip the task
+        back to STARTED and then emit a second, contradictory terminal callback.
+
         Args:
             task_id: Task identifier
             status: New task status
@@ -321,7 +329,28 @@ class RedisStateManager:
             updates["finished_at"] = timestamp
 
         redis = self._ensure_redis()
-        await redis.hset(task_key, mapping=updates)  # type: ignore[misc]
+        async with redis.pipeline(transaction=True) as pipe:
+            while True:
+                try:
+                    await pipe.watch(task_key)
+                    status_raw = await redis.hget(task_key, "status")  # type: ignore[misc]
+                    current_status = (
+                        TaskStatus(status_raw.decode("utf-8")) if status_raw else None
+                    )
+                    if current_status in (TaskStatus.SUCCESS, TaskStatus.FAILURE):
+                        await pipe.unwatch()
+                        _log.debug(
+                            "Skipped status update for %s: already terminal (%s)",
+                            task_id,
+                            current_status.value,
+                        )
+                        return
+                    pipe.multi()
+                    pipe.hset(task_key, mapping=updates)
+                    await pipe.execute()
+                    break
+                except WatchError:
+                    continue
 
         _log.debug(f"Updated task {task_id} status to {status}")
 
@@ -1030,7 +1059,12 @@ class RedisStateManager:
         Called by the replica when it begins executing a task. The lease proves
         a live replica owns this work. It is refreshed by
         update_task_execution_heartbeat() and deleted by finalize_task_*_atomic().
-        No TTL — the key is cleaned up explicitly at terminalization.
+
+        A defensive TTL (``processing_ttl`` ≈ task_timeout + margin) is set on the
+        key and re-extended by every heartbeat refresh. The key is still deleted
+        explicitly at terminalization; the TTL only bounds the worst case where a
+        replica dies and reconciliation never visits the task, so the lease cannot
+        become immortal.
         """
         execution_key = f"task:{task_id}:execution"
         redis = self._ensure_redis()
@@ -1044,13 +1078,15 @@ class RedisStateManager:
                 "heartbeat_at": now_timestamp,
             },
         )
+        await redis.expire(execution_key, self.processing_ttl)  # type: ignore[misc]
 
     async def update_task_execution_heartbeat(self, task_id: str) -> bool:
         """Refresh the execution lease heartbeat timestamp.
 
         Uses a Lua script so the update is a no-op when the key is gone
         (replica died or task was already terminalized). Returns False when
-        the key no longer exists — the caller should stop heartbeating.
+        the key no longer exists — the caller should stop heartbeating. Each
+        refresh also re-extends the defensive lease TTL (``processing_ttl``).
         """
         if not self.redis:
             await self.connect()
@@ -1058,6 +1094,7 @@ class RedisStateManager:
         execution_key = f"task:{task_id}:execution"
         redis = self._ensure_redis()
         now_timestamp = str(datetime.datetime.now(datetime.timezone.utc).timestamp())
+        ttl = str(self.processing_ttl)
 
         if self._update_task_execution_heartbeat_sha is None:
             self._update_task_execution_heartbeat_sha = await redis.script_load(  # type: ignore[misc]
@@ -1070,6 +1107,7 @@ class RedisStateManager:
                 1,
                 execution_key,
                 now_timestamp,
+                ttl,
             )
         except NoScriptError:
             self._update_task_execution_heartbeat_sha = await redis.script_load(  # type: ignore[misc]
@@ -1080,6 +1118,7 @@ class RedisStateManager:
                 1,
                 execution_key,
                 now_timestamp,
+                ttl,
             )
 
         return bool(updated)


### PR DESCRIPTION
## Summary

This PR hardens Ray task recovery around dispatcher restarts and closes the recovery gaps that could leave tasks stuck indefinitely in the active set.

Before this change, the system had two recovery paths:

1. The dispatcher's live `response.result(...)` wait, which correctly fails or completes tasks while that dispatcher instance is still alive.
2. The dispatcher's reconciliation loop, which is the backup recovery mechanism after the dispatcher itself restarts.

The live path was already sound. The gap was in reconciliation after a dispatcher restart.

## Problem

There were three related failure windows in the Ray path:

1. A task could be dispatched, moved into the tenant active set, and then the dispatcher could restart before any coordinator replica durably claimed it.
   - Durable task status was still `PENDING`
   - The task had no live owner anymore
   - Reconciliation skipped it
   - Result: the task could remain stuck forever, and tenant capacity was never released

2. Execution leases had no TTL.
   - A stale execution lease could live forever unless reconciliation happened to clean it up
   - This made recovery depend entirely on the reconciliation loop continuing to run correctly

3. A coordinator could mark a task `STARTED` but fail to write its execution lease.
   - If the coordinator later died and the dispatcher had restarted, reconciliation still had no bounded way to recover that task
   - Result: another permanently pinned active task

In all of these cases, the user-visible symptom was the same: a task could stay active or appear pending forever, and the tenant could permanently lose concurrency capacity.

## What this PR changes

This PR makes reconciliation capable of safely recovering tasks that no longer have a live owner.

### 1. Add a bounded dispatch-claim timeout

A new `dispatch_claim_timeout` defines how long a dispatched task is allowed to sit in the active set without a valid live claim from a coordinator replica.

After that deadline, reconciliation treats the task as orphaned and fails it, releasing tenant capacity.

This applies to:
- `PENDING` tasks that were dispatched but never claimed
- `STARTED` tasks that never obtained an execution lease

### 2. Recover active tasks whose dispatch state has expired

If a task is still in the tenant active set but its dispatch state is already gone, reconciliation now treats it as orphaned regardless of whether its durable status is `PENDING` or `STARTED`.

That closes the main dispatcher-restart hole where tasks could previously remain stuck forever.

### 3. Track in-flight tasks owned by the current dispatcher instance

The dispatcher now tracks task IDs that are still actively owned by its current in-flight `response.result(...)` path.

Reconciliation skips those tasks so it does not race the live dispatcher-owned execution path.

This preserves the existing "live owner first, reconcile as backup" model.

### 4. Add a terminal-state fence on status updates

Once a task reaches durable `SUCCESS` or `FAILURE`, later status updates will not overwrite that terminal state.

This prevents a late coordinator replica from resurrecting a task that reconciliation already failed after a restart.

### 5. Add a defensive TTL to execution leases

Execution leases now get a TTL and each heartbeat refresh extends that TTL.

The lease is still explicitly deleted on task terminalization, but the TTL ensures an abandoned lease cannot become immortal if recovery logic misses it.

## Before / After

### Before

- Dispatcher restart during the pre-claim window could strand a dispatched task forever
- `STARTED` without a lease had no bounded recovery path after restart
- Execution leases had no self-expiry
- A late replica could potentially update status after recovery had already terminalized the task

### After

- Dispatched-but-unclaimed tasks are failed after a bounded claim deadline
- `STARTED` tasks without a lease are also failed after that same bounded deadline
- Active tasks whose dispatch state has expired are treated as orphaned and cleaned up
- Execution leases expire defensively if no heartbeat refresh keeps them alive
- Durable terminal task state cannot be resurrected by late status updates

## Effect

This keeps the existing fast-path behavior unchanged while making dispatcher restart recovery bounded and capacity-correct.

Tasks that previously could remain stuck forever now converge to a terminal failure state, and tenant concurrency is released so queued work can continue.
