### PR TITLE
feat: Enforce source size limits early in service paths

### DIFF
--- a/docling_jobkit/connectors/google_drive_source_processor.py
+++ b/docling_jobkit/connectors/google_drive_source_processor.py
@@ -32,7 +32,10 @@ class GoogleDriveSourceProcessor(
     def _finalize(self):
         return
 
-    def _fetch_documents(self) -> Iterator[DocumentStream]:
+    def _fetch_documents(
+        self, *, max_file_size: int | None = None
+    ) -> Iterator[DocumentStream]:
+        del max_file_size
         from docling_jobkit.connectors.google_drive_helper import (
             download_file,
             get_source_files_infos,
@@ -64,7 +67,13 @@ class GoogleDriveSourceProcessor(
         for info in get_source_files_infos(self._service, self._coords):
             yield info
 
-    def _fetch_document_by_id(self, info: GoogleDriveFileIdentifier) -> DocumentStream:
+    def _fetch_document_by_id(
+        self,
+        info: GoogleDriveFileIdentifier,
+        *,
+        max_file_size: int | None = None,
+    ) -> DocumentStream:
+        del max_file_size
         from docling_jobkit.connectors.google_drive_helper import download_file
 
         buffer = BytesIO()

--- a/docling_jobkit/connectors/http_source_processor.py
+++ b/docling_jobkit/connectors/http_source_processor.py
@@ -1,3 +1,4 @@
+from io import BytesIO
 from typing import Iterator
 
 from pydantic import BaseModel, ConfigDict
@@ -10,6 +11,12 @@ from docling_jobkit.connectors.source_processor import (
     BaseSourceProcessor,
     ConverterSource,
     SourceDocumentRef,
+)
+from docling_jobkit.convert.materialization import (
+    SourceLimitExceededError,
+    _filename_for_http_source,
+    fetch_http_source_bytes,
+    normalize_max_file_size,
 )
 
 
@@ -36,21 +43,62 @@ class HttpSourceProcessor(
 
     def _list_document_ids(self) -> Iterator[HttpFileIdentifier]:
         """Yield a single identifier for the HTTP/File source."""
+        if isinstance(self._source, HttpSource):
+            size, etag = self._try_head_request(self._source)
+            yield HttpFileIdentifier(source=self._source, size=size, etag=etag)
+            return
         yield HttpFileIdentifier(source=self._source)
 
     def _try_head_request(self, source: HttpSource) -> tuple[int | None, str | None]:
-        # TODO: Populate size/etag when cache comparison and conditional fetch are designed.
-        del source
-        return None, None
+        try:
+            import httpx
 
-    def _fetch_document_by_id(self, identifier: HttpFileIdentifier) -> DocumentStream:
+            with httpx.Client(follow_redirects=True) as client:
+                response = client.head(
+                    str(source.url),
+                    headers=source.headers,
+                )
+                if not response.is_success:
+                    return None, None
+                content_length = response.headers.get("content-length")
+                size = int(content_length) if content_length is not None else None
+                return size, response.headers.get("etag")
+        except (ValueError, httpx.HTTPError):
+            return None, None
+
+    def _fetch_document_by_id(
+        self,
+        identifier: HttpFileIdentifier,
+        *,
+        max_file_size: int | None = None,
+    ) -> DocumentStream:
         """Fetch document from the identifier."""
         source = identifier.source
         if isinstance(source, FileSource):
             return source.to_document_stream()
         elif isinstance(source, HttpSource):
-            # TODO: fetch, e.g. using the helpers in docling-core
-            raise NotImplementedError("HttpSource fetching is not yet implemented")
+            limit = normalize_max_file_size(max_file_size)
+            if (
+                limit is not None
+                and identifier.size is not None
+                and identifier.size > limit
+            ):
+                raise SourceLimitExceededError(
+                    f"Source '{_filename_for_http_source(source)}' "
+                    f"exceeds max_file_size={limit} bytes"
+                )
+            # The HEAD probe already ran in _list_document_ids (identifier.size);
+            # skip the redundant HEAD here. The streamed cap below still guards
+            # against missing/incorrect Content-Length.
+            source_bytes = fetch_http_source_bytes(
+                source,
+                max_file_size=max_file_size,
+                probe_head=False,
+            )
+            return DocumentStream(
+                name=_filename_for_http_source(source),
+                stream=BytesIO(source_bytes),
+            )
         else:
             raise ValueError(f"Unsupported source type: {type(source)}")
 
@@ -74,12 +122,23 @@ class HttpSourceProcessor(
 
     @override
     def fetch_converter_source_by_ref(
-        self, ref: SourceDocumentRef[HttpFileIdentifier]
+        self,
+        ref: SourceDocumentRef[HttpFileIdentifier],
+        *,
+        max_file_size: int | None = None,
     ) -> ConverterSource:
         source = ref.id.source
-        if isinstance(source, HttpSource):
+        # No effective limit -> keep raw URL passthrough so the converter fetches
+        # it directly. Materializing here would be accidental and is not allowed.
+        if (
+            isinstance(source, HttpSource)
+            and normalize_max_file_size(max_file_size) is None
+        ):
             return str(source.url)
-        return self._fetch_document_by_id(ref.id)
+        return self._fetch_document_by_id(
+            ref.id,
+            max_file_size=max_file_size,
+        )
 
     @override
     def headers_for_ref(
@@ -90,9 +149,13 @@ class HttpSourceProcessor(
             return source.headers
         return None
 
-    def _fetch_documents(self) -> Iterator[DocumentStream]:
-        if isinstance(self._source, FileSource):
-            yield self._source.to_document_stream()
-        elif isinstance(self._source, HttpSource):
-            # TODO: fetch, e.g. using the helpers in docling-core
-            raise NotImplementedError()
+    def _fetch_documents(
+        self, *, max_file_size: int | None = None
+    ) -> Iterator[DocumentStream]:
+        # _list_document_ids performs the single HEAD probe (populating
+        # identifier.size); reuse it so the fetch path does not HEAD again.
+        for identifier in self._list_document_ids():
+            yield self._fetch_document_by_id(
+                identifier,
+                max_file_size=max_file_size,
+            )

--- a/docling_jobkit/connectors/http_source_processor.py
+++ b/docling_jobkit/connectors/http_source_processor.py
@@ -1,4 +1,3 @@
-from io import BytesIO
 from typing import Iterator
 
 from pydantic import BaseModel, ConfigDict
@@ -15,7 +14,6 @@ from docling_jobkit.connectors.source_processor import (
 from docling_jobkit.convert.materialization import (
     SourceLimitExceededError,
     _filename_for_http_source,
-    fetch_http_source_bytes,
     normalize_max_file_size,
 )
 
@@ -73,32 +71,16 @@ class HttpSourceProcessor(
         max_file_size: int | None = None,
     ) -> DocumentStream:
         """Fetch document from the identifier."""
+        del max_file_size
         source = identifier.source
         if isinstance(source, FileSource):
             return source.to_document_stream()
         elif isinstance(source, HttpSource):
-            limit = normalize_max_file_size(max_file_size)
-            if (
-                limit is not None
-                and identifier.size is not None
-                and identifier.size > limit
-            ):
-                raise SourceLimitExceededError(
-                    f"Source '{_filename_for_http_source(source)}' "
-                    f"exceeds max_file_size={limit} bytes"
-                )
-            # The HEAD probe already ran in _list_document_ids (identifier.size);
-            # skip the redundant HEAD here. The streamed cap below still guards
-            # against missing/incorrect Content-Length.
-            source_bytes = fetch_http_source_bytes(
-                source,
-                max_file_size=max_file_size,
-                probe_head=False,
-            )
-            return DocumentStream(
-                name=_filename_for_http_source(source),
-                stream=BytesIO(source_bytes),
-            )
+            # HttpSource is never materialized by this processor: service runtimes
+            # pass the raw URL through to the converter (see
+            # fetch_converter_source_by_ref / expand_task_sources). Direct byte
+            # retrieval here is intentionally unsupported.
+            raise NotImplementedError("HttpSource fetching is not supported")
         else:
             raise ValueError(f"Unsupported source type: {type(source)}")
 
@@ -128,12 +110,19 @@ class HttpSourceProcessor(
         max_file_size: int | None = None,
     ) -> ConverterSource:
         source = ref.id.source
-        # No effective limit -> keep raw URL passthrough so the converter fetches
-        # it directly. Materializing here would be accidental and is not allowed.
-        if (
-            isinstance(source, HttpSource)
-            and normalize_max_file_size(max_file_size) is None
-        ):
+        if isinstance(source, HttpSource):
+            # Enforce max_file_size from HEAD metadata only; never materialize in
+            # this path. Either reject on the advertised Content-Length (already
+            # probed into ref.id.size by _list_document_ids), or hand the raw URL
+            # to the converter so it performs the fetch -- identical to the
+            # no-limit behavior. Setting a limit must not introduce a fetch that
+            # would not otherwise happen.
+            limit = normalize_max_file_size(max_file_size)
+            if limit is not None and ref.id.size is not None and ref.id.size > limit:
+                raise SourceLimitExceededError(
+                    f"Source '{_filename_for_http_source(source)}' "
+                    f"exceeds max_file_size={limit} bytes"
+                )
             return str(source.url)
         return self._fetch_document_by_id(
             ref.id,
@@ -152,10 +141,9 @@ class HttpSourceProcessor(
     def _fetch_documents(
         self, *, max_file_size: int | None = None
     ) -> Iterator[DocumentStream]:
-        # _list_document_ids performs the single HEAD probe (populating
-        # identifier.size); reuse it so the fetch path does not HEAD again.
-        for identifier in self._list_document_ids():
-            yield self._fetch_document_by_id(
-                identifier,
-                max_file_size=max_file_size,
-            )
+        del max_file_size
+        if isinstance(self._source, FileSource):
+            yield self._source.to_document_stream()
+        elif isinstance(self._source, HttpSource):
+            # See _fetch_document_by_id: HttpSource is passthrough-only.
+            raise NotImplementedError("HttpSource fetching is not supported")

--- a/docling_jobkit/connectors/local_path_source_processor.py
+++ b/docling_jobkit/connectors/local_path_source_processor.py
@@ -116,9 +116,13 @@ class LocalPathSourceProcessor(
         return sum(1 for _ in self._list_document_ids())
 
     def _fetch_document_by_id(
-        self, identifier: LocalPathFileIdentifier
+        self,
+        identifier: LocalPathFileIdentifier,
+        *,
+        max_file_size: int | None = None,
     ) -> DocumentStream:
         """Fetch a document by opening the file from the local filesystem."""
+        del max_file_size
         file_path = identifier.path
 
         # Open file in binary mode and return as DocumentStream
@@ -143,7 +147,12 @@ class LocalPathSourceProcessor(
             filename=str(file_path),
         )
 
-    def _fetch_documents(self) -> Iterator[DocumentStream]:
+    def _fetch_documents(
+        self, *, max_file_size: int | None = None
+    ) -> Iterator[DocumentStream]:
         """Iterate through all documents."""
         for identifier in self._list_document_ids():
-            yield self._fetch_document_by_id(identifier)
+            yield self._fetch_document_by_id(
+                identifier,
+                max_file_size=max_file_size,
+            )

--- a/docling_jobkit/connectors/s3_source_processor.py
+++ b/docling_jobkit/connectors/s3_source_processor.py
@@ -15,6 +15,10 @@ from docling_jobkit.connectors.source_processor import (
     BaseSourceProcessor,
     SourceDocumentRef,
 )
+from docling_jobkit.convert.materialization import (
+    SourceLimitExceededError,
+    normalize_max_file_size,
+)
 
 _log = logging.getLogger(__name__)
 
@@ -91,7 +95,18 @@ class S3SourceProcessor(BaseSourceProcessor[S3Coordinates, S3FileIdentifier]):
 
     # ----------------- Document fetch -----------------
 
-    def _fetch_document_by_id(self, identifier: S3FileIdentifier) -> DocumentStream:
+    def _fetch_document_by_id(
+        self,
+        identifier: S3FileIdentifier,
+        *,
+        max_file_size: int | None = None,
+    ) -> DocumentStream:
+        limit = normalize_max_file_size(max_file_size)
+        if limit is not None and identifier.size > limit:
+            raise SourceLimitExceededError(
+                f"Source '{identifier.key}' exceeds max_file_size={limit} bytes"
+            )
+
         buffer = BytesIO()
         try:
             self._client.download_fileobj(
@@ -108,6 +123,11 @@ class S3SourceProcessor(BaseSourceProcessor[S3Coordinates, S3FileIdentifier]):
         buffer.seek(0)
         return DocumentStream(name=identifier.key, stream=buffer)
 
-    def _fetch_documents(self):
+    def _fetch_documents(
+        self, *, max_file_size: int | None = None
+    ) -> Iterator[DocumentStream]:
         for key in self._list_document_ids():
-            yield self._fetch_document_by_id(key)
+            yield self._fetch_document_by_id(
+                key,
+                max_file_size=max_file_size,
+            )

--- a/docling_jobkit/connectors/source_processor.py
+++ b/docling_jobkit/connectors/source_processor.py
@@ -93,13 +93,21 @@ class BaseSourceProcessor(
         """Clean up resources."""
 
     @abstractmethod
-    def _fetch_documents(self) -> Iterator[DocumentStream]:
+    def _fetch_documents(
+        self, *, max_file_size: int | None = None
+    ) -> Iterator[DocumentStream]:
         """Yield documents from the source."""
 
     def _list_document_ids(self) -> Iterator[FileIdentifierT] | None:
         return None
 
-    def _fetch_document_by_id(self, identifier: FileIdentifierT) -> DocumentStream:
+    def _fetch_document_by_id(
+        self,
+        identifier: FileIdentifierT,
+        *,
+        max_file_size: int | None = None,
+    ) -> DocumentStream:
+        del max_file_size
         raise NotImplementedError
 
     def _make_document_ref(
@@ -123,7 +131,10 @@ class BaseSourceProcessor(
         return None
 
     def fetch_converter_source_by_ref(
-        self, ref: SourceDocumentRef[FileIdentifierT]
+        self,
+        ref: SourceDocumentRef[FileIdentifierT],
+        *,
+        max_file_size: int | None = None,
     ) -> ConverterSource:
         """Resolve a ref into the converter input expected by the backend.
 
@@ -131,7 +142,7 @@ class BaseSourceProcessor(
         Connectors with remote-fetch semantics may override this to return a lighter
         representation such as a source URL.
         """
-        return self._fetch_document_by_id(ref.id)
+        return self._fetch_document_by_id(ref.id, max_file_size=max_file_size)
 
     def headers_for_ref(
         self, ref: SourceDocumentRef[FileIdentifierT]
@@ -140,12 +151,14 @@ class BaseSourceProcessor(
         del ref
         return None
 
-    def iterate_documents(self) -> Iterator[DocumentStream]:
+    def iterate_documents(
+        self, *, max_file_size: int | None = None
+    ) -> Iterator[DocumentStream]:
         if not self._initialized:
             raise RuntimeError(
                 "Processor not initialized. Use 'with' to open it first."
             )
-        yield from self._fetch_documents()
+        yield from self._fetch_documents(max_file_size=max_file_size)
 
     def iterate_document_chunks(
         self, chunk_size: int

--- a/docling_jobkit/convert/materialization.py
+++ b/docling_jobkit/convert/materialization.py
@@ -90,26 +90,24 @@ async def fetch_http_source_bytes_async(
     *,
     max_file_size: int | None,
     error_cls: type[MaterializationError] = SourceLimitExceededError,
-    probe_head: bool = True,
 ) -> bytes:
     filename = _filename_for_http_source(source)
     limit = normalize_max_file_size(max_file_size)
     async with httpx.AsyncClient(follow_redirects=True) as client:
-        if probe_head:
-            try:
-                head_response = await client.head(
-                    str(source.url),
-                    headers=source.headers,
+        try:
+            head_response = await client.head(
+                str(source.url),
+                headers=source.headers,
+            )
+            if head_response.is_success:
+                _check_content_length_limit(
+                    content_length=_parse_content_length(head_response.headers),
+                    max_file_size=max_file_size,
+                    source_name=filename,
+                    error_cls=error_cls,
                 )
-                if head_response.is_success:
-                    _check_content_length_limit(
-                        content_length=_parse_content_length(head_response.headers),
-                        max_file_size=max_file_size,
-                        source_name=filename,
-                        error_cls=error_cls,
-                    )
-            except httpx.HTTPError:
-                pass
+        except httpx.HTTPError:
+            pass
 
         async with client.stream(
             "GET",
@@ -126,57 +124,6 @@ async def fetch_http_source_bytes_async(
             buffer = BytesIO()
             bytes_seen = 0
             async for chunk in response.aiter_bytes():
-                if chunk:
-                    bytes_seen += len(chunk)
-                    if limit is not None and bytes_seen > limit:
-                        raise error_cls(
-                            f"Source '{filename}' exceeds max_file_size={limit} bytes"
-                        )
-                    buffer.write(chunk)
-    return buffer.getvalue()
-
-
-def fetch_http_source_bytes(
-    source: HttpSource,
-    *,
-    max_file_size: int | None,
-    error_cls: type[MaterializationError] = SourceLimitExceededError,
-    probe_head: bool = True,
-) -> bytes:
-    filename = _filename_for_http_source(source)
-    limit = normalize_max_file_size(max_file_size)
-    with httpx.Client(follow_redirects=True) as client:
-        if probe_head:
-            try:
-                head_response = client.head(
-                    str(source.url),
-                    headers=source.headers,
-                )
-                if head_response.is_success:
-                    _check_content_length_limit(
-                        content_length=_parse_content_length(head_response.headers),
-                        max_file_size=max_file_size,
-                        source_name=filename,
-                        error_cls=error_cls,
-                    )
-            except httpx.HTTPError:
-                pass
-
-        with client.stream(
-            "GET",
-            str(source.url),
-            headers=source.headers,
-        ) as response:
-            response.raise_for_status()
-            _check_content_length_limit(
-                content_length=_parse_content_length(response.headers),
-                max_file_size=max_file_size,
-                source_name=filename,
-                error_cls=error_cls,
-            )
-            buffer = BytesIO()
-            bytes_seen = 0
-            for chunk in response.iter_bytes():
                 if chunk:
                     bytes_seen += len(chunk)
                     if limit is not None and bytes_seen > limit:

--- a/docling_jobkit/convert/materialization.py
+++ b/docling_jobkit/convert/materialization.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import sys
+from collections.abc import Mapping
 from io import BytesIO
 from pathlib import PurePath
 from urllib.parse import urlparse
@@ -43,10 +45,146 @@ class MaterializationLimitExceededError(MaterializationError):
     """Raised when the source exceeds configured document admission limits."""
 
 
+class SourceLimitExceededError(MaterializationError):
+    """Raised when source retrieval exceeds a configured fetch-time size limit."""
+
+
+def normalize_max_file_size(max_file_size: int | None) -> int | None:
+    if max_file_size is None or max_file_size >= sys.maxsize:
+        return None
+    return max_file_size
+
+
+def _check_content_length_limit(
+    *,
+    content_length: int | None,
+    max_file_size: int | None,
+    source_name: str,
+    error_cls: type[MaterializationError],
+) -> None:
+    limit = normalize_max_file_size(max_file_size)
+    if content_length is None or limit is None:
+        return
+    if content_length > limit:
+        raise error_cls(f"Source '{source_name}' exceeds max_file_size={limit} bytes")
+
+
+def _parse_content_length(headers: Mapping[str, str]) -> int | None:
+    raw_content_length = headers.get("content-length")
+    if raw_content_length is None:
+        return None
+    try:
+        return int(raw_content_length)
+    except (TypeError, ValueError):
+        return None
+
+
 def _filename_for_http_source(source: HttpSource) -> str:
     parsed = urlparse(str(source.url))
     filename = PurePath(parsed.path).name
     return filename or "document.pdf"
+
+
+async def fetch_http_source_bytes_async(
+    source: HttpSource,
+    *,
+    max_file_size: int | None,
+    error_cls: type[MaterializationError] = SourceLimitExceededError,
+    probe_head: bool = True,
+) -> bytes:
+    filename = _filename_for_http_source(source)
+    limit = normalize_max_file_size(max_file_size)
+    async with httpx.AsyncClient(follow_redirects=True) as client:
+        if probe_head:
+            try:
+                head_response = await client.head(
+                    str(source.url),
+                    headers=source.headers,
+                )
+                if head_response.is_success:
+                    _check_content_length_limit(
+                        content_length=_parse_content_length(head_response.headers),
+                        max_file_size=max_file_size,
+                        source_name=filename,
+                        error_cls=error_cls,
+                    )
+            except httpx.HTTPError:
+                pass
+
+        async with client.stream(
+            "GET",
+            str(source.url),
+            headers=source.headers,
+        ) as response:
+            response.raise_for_status()
+            _check_content_length_limit(
+                content_length=_parse_content_length(response.headers),
+                max_file_size=max_file_size,
+                source_name=filename,
+                error_cls=error_cls,
+            )
+            buffer = BytesIO()
+            bytes_seen = 0
+            async for chunk in response.aiter_bytes():
+                if chunk:
+                    bytes_seen += len(chunk)
+                    if limit is not None and bytes_seen > limit:
+                        raise error_cls(
+                            f"Source '{filename}' exceeds max_file_size={limit} bytes"
+                        )
+                    buffer.write(chunk)
+    return buffer.getvalue()
+
+
+def fetch_http_source_bytes(
+    source: HttpSource,
+    *,
+    max_file_size: int | None,
+    error_cls: type[MaterializationError] = SourceLimitExceededError,
+    probe_head: bool = True,
+) -> bytes:
+    filename = _filename_for_http_source(source)
+    limit = normalize_max_file_size(max_file_size)
+    with httpx.Client(follow_redirects=True) as client:
+        if probe_head:
+            try:
+                head_response = client.head(
+                    str(source.url),
+                    headers=source.headers,
+                )
+                if head_response.is_success:
+                    _check_content_length_limit(
+                        content_length=_parse_content_length(head_response.headers),
+                        max_file_size=max_file_size,
+                        source_name=filename,
+                        error_cls=error_cls,
+                    )
+            except httpx.HTTPError:
+                pass
+
+        with client.stream(
+            "GET",
+            str(source.url),
+            headers=source.headers,
+        ) as response:
+            response.raise_for_status()
+            _check_content_length_limit(
+                content_length=_parse_content_length(response.headers),
+                max_file_size=max_file_size,
+                source_name=filename,
+                error_cls=error_cls,
+            )
+            buffer = BytesIO()
+            bytes_seen = 0
+            for chunk in response.iter_bytes():
+                if chunk:
+                    bytes_seen += len(chunk)
+                    if limit is not None and bytes_seen > limit:
+                        raise error_cls(
+                            f"Source '{filename}' exceeds max_file_size={limit} bytes"
+                        )
+                    buffer.write(chunk)
+    return buffer.getvalue()
 
 
 async def materialize_and_preflight(
@@ -67,14 +205,12 @@ async def materialize_and_preflight(
         source_bytes = source.to_document_stream().stream.getvalue()
         filename = source.filename
     else:
-        async with httpx.AsyncClient(follow_redirects=True) as client:
-            response = await client.get(
-                str(source.url),
-                headers=source.headers,
-            )
-            response.raise_for_status()
-            source_bytes = response.content
-            filename = _filename_for_http_source(source)
+        source_bytes = await fetch_http_source_bytes_async(
+            source,
+            max_file_size=limits.max_file_size,
+            error_cls=MaterializationLimitExceededError,
+        )
+        filename = _filename_for_http_source(source)
 
     input_doc = InputDocument(
         path_or_stream=BytesIO(source_bytes),

--- a/docling_jobkit/convert/source_expansion.py
+++ b/docling_jobkit/convert/source_expansion.py
@@ -9,6 +9,8 @@ from docling_jobkit.datamodel.task import Task
 
 def expand_task_sources(
     task: Task,
+    *,
+    max_file_size: int | None = None,
 ) -> tuple[list[Union[str, DocumentStream]], Optional[dict[str, Any]]]:
     """Expand task sources into converter inputs and optional HTTP headers."""
     convert_sources: list[Union[str, DocumentStream]] = []
@@ -29,7 +31,9 @@ def expand_task_sources(
             # change task/result semantics for DocumentStream/FileSource/HttpSource
             # inputs, so the runtime path expands sources directly here instead.
             with get_source_processor(source) as source_processor:
-                for document_stream in source_processor.iterate_documents():
+                for document_stream in source_processor.iterate_documents(
+                    max_file_size=max_file_size
+                ):
                     convert_sources.append(document_stream)
         else:
             raise RuntimeError(f"Unsupported runtime task source: {type(source)!r}")

--- a/docling_jobkit/orchestrators/local/worker.py
+++ b/docling_jobkit/orchestrators/local/worker.py
@@ -17,6 +17,7 @@ from docling_jobkit.datamodel.exportable_document import (
 from docling_jobkit.datamodel.result import DoclingTaskResult
 from docling_jobkit.datamodel.task_meta import TaskStatus
 from docling_jobkit.orchestrators.callback_invoker import CallbackInvoker
+from docling_jobkit.public_errors import build_public_task_error
 
 if TYPE_CHECKING:
     from docling_jobkit.orchestrators.local.orchestrator import LocalOrchestrator
@@ -68,7 +69,10 @@ class AsyncLocalWorker:
 
                 # Define a callback function to send progress updates to the client.
                 def run_task() -> DoclingTaskResult:
-                    convert_sources, headers = expand_task_sources(task)
+                    convert_sources, headers = expand_task_sources(
+                        task,
+                        max_file_size=cm.config.max_file_size,
+                    )
                     # Note: results are only an iterator->lazy evaluation
                     conv_results = cm.convert_documents(
                         sources=convert_sources,
@@ -129,6 +133,7 @@ class AsyncLocalWorker:
                     f"Worker {self.worker_id} failed to process job {task_id}: {e}"
                 )
                 task.set_status(TaskStatus.FAILURE)
+                task.error_message = build_public_task_error(e)
 
             finally:
                 if workdir.exists():

--- a/docling_jobkit/orchestrators/ray/serve_deployment.py
+++ b/docling_jobkit/orchestrators/ray/serve_deployment.py
@@ -586,7 +586,10 @@ class DoclingProcessorConverterDeployment:
             conv_results = await self._run_with_retry(
                 f"{request.task.task_id}:chunk:{request.chunk.chunk_index}",
                 lambda: self._convert_source_chunk_request(request),
+                task=request.task,
             )
+            if isinstance(conv_results, ConverterFailureResult):
+                return conv_results
             exportable = _to_exportable_documents_from_chunk(
                 request.chunk, conv_results
             )
@@ -731,7 +734,10 @@ class DoclingProcessorConverterDeployment:
 
     def _convert_passthrough_task(self, task: Task) -> list[ConversionResult]:
         _validate_no_s3_source_in_passthrough(task)
-        convert_sources, headers = expand_task_sources(task)
+        convert_sources, headers = expand_task_sources(
+            task,
+            max_file_size=self.converter_manager_config.max_file_size,
+        )
         convert_opts = task.convert_options or ConvertDocumentsOptions()
         return list(
             self.cm.convert_documents(
@@ -759,9 +765,13 @@ class DoclingProcessorConverterDeployment:
             convert_sources: list[str | DocumentStream] = []
             headers: Optional[dict[str, Any]] = None
             for ref in request.chunk.refs:
-                convert_sources.append(
-                    source_processor.fetch_converter_source_by_ref(ref)
+                convert_source = source_processor.fetch_converter_source_by_ref(
+                    ref,
+                    max_file_size=self.converter_manager_config.max_file_size,
                 )
+                convert_sources.append(convert_source)
+                if not isinstance(convert_source, str):
+                    continue
                 ref_headers = source_processor.headers_for_ref(ref)
                 if headers is None and ref_headers:
                     headers = ref_headers

--- a/docling_jobkit/orchestrators/rq/worker.py
+++ b/docling_jobkit/orchestrators/rq/worker.py
@@ -55,13 +55,18 @@ def _null_phase_cm(_: str) -> ContextManager[Any]:
 
 def _prepare_convert_sources(
     task: Task,
+    *,
+    max_file_size: int | None = None,
     on_source_prepared: Optional[_SourcePreparedHook] = None,
 ) -> tuple[
     list[Union[str, DocumentStream]],
     Optional[dict[str, Any]],
     list[dict[str, str]],
 ]:
-    convert_sources, headers = expand_task_sources(task)
+    convert_sources, headers = expand_task_sources(
+        task,
+        max_file_size=max_file_size,
+    )
     source_info: list[dict[str, str]] = []
 
     for idx, source in enumerate(task.sources):
@@ -123,9 +128,13 @@ def _run_docling_task(
                 ).model_dump_json(),
             )
 
+        if not conversion_manager:
+            raise RuntimeError("No converter")
+
         with phase_cm("prepare_sources"):
             convert_sources, headers, source_info = _prepare_convert_sources(
                 task,
+                max_file_size=conversion_manager.config.max_file_size,
                 on_source_prepared=on_source_prepared,
             )
             if on_sources_prepared:
@@ -135,8 +144,6 @@ def _run_docling_task(
                     headers is not None,
                 )
 
-        if not conversion_manager:
-            raise RuntimeError("No converter")
         if not task.convert_options:
             raise RuntimeError("No conversion options")
 

--- a/docling_jobkit/public_errors.py
+++ b/docling_jobkit/public_errors.py
@@ -14,7 +14,10 @@ from docling.datamodel.service.responses import (
     PublicFailureInfo,
 )
 
-from docling_jobkit.convert.materialization import MaterializationLimitExceededError
+from docling_jobkit.convert.materialization import (
+    MaterializationLimitExceededError,
+    SourceLimitExceededError,
+)
 
 
 class TargetWriteError(RuntimeError):
@@ -111,6 +114,11 @@ def classify_public_task_failure(
         phase = FailurePhase.ADMISSION
         retryable = False
         message = "Document exceeds service limits."
+    elif isinstance(root_exc, SourceLimitExceededError):
+        category = FailureCategory.POLICY
+        phase = FailurePhase.SOURCE_ENUMERATION
+        retryable = False
+        message = exception_text
     elif isinstance(root_exc, httpx.HTTPStatusError):
         # httpx fetched the source but the upstream HTTP status is not usable.
         merged_details = {**merged_details, **_safe_details(source_kind="http")}
@@ -161,8 +169,10 @@ def classify_public_task_failure(
 
 def build_public_task_error(exc: BaseException) -> str:
     root_exc = _unwrap_failure_exception(exc)
-    if isinstance(root_exc, httpx.HTTPStatusError) or isinstance(
-        root_exc, RequestsHTTPError
+    if (
+        isinstance(root_exc, httpx.HTTPStatusError)
+        or isinstance(root_exc, RequestsHTTPError)
+        or isinstance(root_exc, SourceLimitExceededError)
     ):
         return _exception_text(root_exc)
     return INTERNAL_TASK_ERROR_MESSAGE

--- a/tests/test_http_source_processor.py
+++ b/tests/test_http_source_processor.py
@@ -1,7 +1,10 @@
+import pytest
+
 from docling.datamodel.service.sources import HttpSource
 from docling_core.types.io import DocumentStream
 
 from docling_jobkit.connectors.http_source_processor import HttpSourceProcessor
+from docling_jobkit.convert.materialization import SourceLimitExceededError
 from docling_jobkit.datamodel.http_inputs import FileSource
 
 
@@ -58,7 +61,17 @@ def test_http_file_source_list_and_fetch():
         assert doc.stream.read() == content
 
 
-def test_http_source_ref_returns_converter_url_and_headers():
+def _stub_head(monkeypatch, *, size=None, etag=None):
+    """Avoid real network HEAD probes in _list_document_ids."""
+    monkeypatch.setattr(
+        HttpSourceProcessor,
+        "_try_head_request",
+        lambda self, source: (size, etag),
+    )
+
+
+def test_http_source_ref_returns_converter_url_and_headers(monkeypatch):
+    _stub_head(monkeypatch)
     http_source = HttpSource(
         url="https://example.com/document.pdf",
         headers={"Authorization": "Bearer token"},
@@ -73,6 +86,93 @@ def test_http_source_ref_returns_converter_url_and_headers():
         )
         assert processor.headers_for_ref(ref) == {"Authorization": "Bearer token"}
         assert ref.source_uri == "https://example.com/document.pdf"
+
+
+def test_http_source_ref_passthrough_with_unlimited_sentinel(monkeypatch):
+    """max_file_size=sys.maxsize (the config default) must NOT materialize."""
+    import sys
+
+    _stub_head(monkeypatch)
+
+    def _should_not_fetch(*args, **kwargs):
+        raise AssertionError("passthrough must not materialize when unlimited")
+
+    monkeypatch.setattr(
+        "docling_jobkit.connectors.http_source_processor.fetch_http_source_bytes",
+        _should_not_fetch,
+    )
+    http_source = HttpSource(url="https://example.com/document.pdf")
+
+    with HttpSourceProcessor(http_source) as processor:
+        chunk = next(processor.iterate_document_chunks(chunk_size=1))
+        ref = chunk.refs[0]
+        assert (
+            processor.fetch_converter_source_by_ref(ref, max_file_size=sys.maxsize)
+            == "https://example.com/document.pdf"
+        )
+
+
+def test_http_source_ref_fetches_document_stream_when_limit_is_provided(
+    monkeypatch,
+):
+    _stub_head(monkeypatch)
+    http_source = HttpSource(url="https://example.com/document.pdf")
+
+    monkeypatch.setattr(
+        "docling_jobkit.connectors.http_source_processor.fetch_http_source_bytes",
+        lambda source, *, max_file_size, probe_head=True: b"pdf-bytes",
+    )
+
+    with HttpSourceProcessor(http_source) as processor:
+        chunk = next(processor.iterate_document_chunks(chunk_size=1))
+        ref = chunk.refs[0]
+        source = processor.fetch_converter_source_by_ref(ref, max_file_size=8)
+
+    assert isinstance(source, DocumentStream)
+    assert source.name == "document.pdf"
+    assert source.stream.read() == b"pdf-bytes"
+
+
+def test_http_source_ref_rejects_from_head_size_before_fetch(monkeypatch):
+    """A HEAD-advertised size over the limit rejects without a GET."""
+    _stub_head(monkeypatch, size=9)
+
+    def _should_not_fetch(*args, **kwargs):
+        raise AssertionError("must reject before downloading the body")
+
+    monkeypatch.setattr(
+        "docling_jobkit.connectors.http_source_processor.fetch_http_source_bytes",
+        _should_not_fetch,
+    )
+    http_source = HttpSource(url="https://example.com/document.pdf")
+
+    with HttpSourceProcessor(http_source) as processor:
+        chunk = next(processor.iterate_document_chunks(chunk_size=1))
+        ref = chunk.refs[0]
+        with pytest.raises(SourceLimitExceededError, match="max_file_size=8"):
+            processor.fetch_converter_source_by_ref(ref, max_file_size=8)
+
+
+def test_http_source_ref_limit_failure_propagates(monkeypatch):
+    _stub_head(monkeypatch)
+    http_source = HttpSource(url="https://example.com/document.pdf")
+
+    def _raise_limit(source, *, max_file_size, probe_head=True):
+        del source, max_file_size, probe_head
+        raise SourceLimitExceededError(
+            "Source 'document.pdf' exceeds max_file_size=8 bytes"
+        )
+
+    monkeypatch.setattr(
+        "docling_jobkit.connectors.http_source_processor.fetch_http_source_bytes",
+        _raise_limit,
+    )
+
+    with HttpSourceProcessor(http_source) as processor:
+        chunk = next(processor.iterate_document_chunks(chunk_size=1))
+        ref = chunk.refs[0]
+        with pytest.raises(SourceLimitExceededError, match="max_file_size=8"):
+            processor.fetch_converter_source_by_ref(ref, max_file_size=8)
 
 
 def test_http_file_source_iterate_documents():

--- a/tests/test_http_source_processor.py
+++ b/tests/test_http_source_processor.py
@@ -88,62 +88,31 @@ def test_http_source_ref_returns_converter_url_and_headers(monkeypatch):
         assert ref.source_uri == "https://example.com/document.pdf"
 
 
-def test_http_source_ref_passthrough_with_unlimited_sentinel(monkeypatch):
-    """max_file_size=sys.maxsize (the config default) must NOT materialize."""
+@pytest.mark.parametrize("head_size", [None, 4])
+def test_http_source_ref_passthrough_when_within_limit(monkeypatch, head_size):
+    """A limit alone must NOT materialize: an unknown or in-limit size passes the
+    raw URL through to the converter. Also covers the sys.maxsize sentinel."""
     import sys
 
-    _stub_head(monkeypatch)
-
-    def _should_not_fetch(*args, **kwargs):
-        raise AssertionError("passthrough must not materialize when unlimited")
-
-    monkeypatch.setattr(
-        "docling_jobkit.connectors.http_source_processor.fetch_http_source_bytes",
-        _should_not_fetch,
-    )
+    _stub_head(monkeypatch, size=head_size)
     http_source = HttpSource(url="https://example.com/document.pdf")
 
     with HttpSourceProcessor(http_source) as processor:
         chunk = next(processor.iterate_document_chunks(chunk_size=1))
         ref = chunk.refs[0]
         assert (
+            processor.fetch_converter_source_by_ref(ref, max_file_size=8)
+            == "https://example.com/document.pdf"
+        )
+        assert (
             processor.fetch_converter_source_by_ref(ref, max_file_size=sys.maxsize)
             == "https://example.com/document.pdf"
         )
 
 
-def test_http_source_ref_fetches_document_stream_when_limit_is_provided(
-    monkeypatch,
-):
-    _stub_head(monkeypatch)
-    http_source = HttpSource(url="https://example.com/document.pdf")
-
-    monkeypatch.setattr(
-        "docling_jobkit.connectors.http_source_processor.fetch_http_source_bytes",
-        lambda source, *, max_file_size, probe_head=True: b"pdf-bytes",
-    )
-
-    with HttpSourceProcessor(http_source) as processor:
-        chunk = next(processor.iterate_document_chunks(chunk_size=1))
-        ref = chunk.refs[0]
-        source = processor.fetch_converter_source_by_ref(ref, max_file_size=8)
-
-    assert isinstance(source, DocumentStream)
-    assert source.name == "document.pdf"
-    assert source.stream.read() == b"pdf-bytes"
-
-
-def test_http_source_ref_rejects_from_head_size_before_fetch(monkeypatch):
-    """A HEAD-advertised size over the limit rejects without a GET."""
+def test_http_source_ref_rejects_from_head_size(monkeypatch):
+    """A HEAD-advertised Content-Length over the limit rejects without a fetch."""
     _stub_head(monkeypatch, size=9)
-
-    def _should_not_fetch(*args, **kwargs):
-        raise AssertionError("must reject before downloading the body")
-
-    monkeypatch.setattr(
-        "docling_jobkit.connectors.http_source_processor.fetch_http_source_bytes",
-        _should_not_fetch,
-    )
     http_source = HttpSource(url="https://example.com/document.pdf")
 
     with HttpSourceProcessor(http_source) as processor:
@@ -153,26 +122,14 @@ def test_http_source_ref_rejects_from_head_size_before_fetch(monkeypatch):
             processor.fetch_converter_source_by_ref(ref, max_file_size=8)
 
 
-def test_http_source_ref_limit_failure_propagates(monkeypatch):
+def test_http_source_iterate_documents_not_supported(monkeypatch):
+    """HttpSource is passthrough-only; direct byte retrieval is unsupported."""
     _stub_head(monkeypatch)
     http_source = HttpSource(url="https://example.com/document.pdf")
 
-    def _raise_limit(source, *, max_file_size, probe_head=True):
-        del source, max_file_size, probe_head
-        raise SourceLimitExceededError(
-            "Source 'document.pdf' exceeds max_file_size=8 bytes"
-        )
-
-    monkeypatch.setattr(
-        "docling_jobkit.connectors.http_source_processor.fetch_http_source_bytes",
-        _raise_limit,
-    )
-
     with HttpSourceProcessor(http_source) as processor:
-        chunk = next(processor.iterate_document_chunks(chunk_size=1))
-        ref = chunk.refs[0]
-        with pytest.raises(SourceLimitExceededError, match="max_file_size=8"):
-            processor.fetch_converter_source_by_ref(ref, max_file_size=8)
+        with pytest.raises(NotImplementedError):
+            list(processor.iterate_documents())
 
 
 def test_http_file_source_iterate_documents():

--- a/tests/test_rq_orchestrator.py
+++ b/tests/test_rq_orchestrator.py
@@ -42,7 +42,10 @@ from docling_jobkit.orchestrators.rq.orchestrator import (
     RQOrchestrator,
     RQOrchestratorConfig,
 )
-from docling_jobkit.orchestrators.rq.worker import CustomRQWorker
+from docling_jobkit.orchestrators.rq.worker import (
+    CustomRQWorker,
+    _prepare_convert_sources,
+)
 
 
 @pytest_asyncio.fixture
@@ -137,6 +140,39 @@ async def test_convert_file(orchestrator: RQOrchestrator):
     assert isinstance(task_result.result, ExportResult)
 
     assert task_result.result.status == ConversionStatus.SUCCESS
+
+
+def test_prepare_convert_sources_threads_max_file_size(monkeypatch: pytest.MonkeyPatch):
+    task = Task(
+        task_id="task-prepare",
+        sources=[
+            FileSource(
+                filename="doc.pdf", base64_string=base64.b64encode(b"pdf").decode()
+            )
+        ],
+        target=InBodyTarget(),
+    )
+    captured: list[int | None] = []
+
+    def _fake_expand(task_arg, *, max_file_size=None):
+        assert task_arg is task
+        captured.append(max_file_size)
+        return ([], None)
+
+    monkeypatch.setattr(
+        "docling_jobkit.orchestrators.rq.worker.expand_task_sources",
+        _fake_expand,
+    )
+
+    convert_sources, headers, source_info = _prepare_convert_sources(
+        task,
+        max_file_size=123,
+    )
+
+    assert convert_sources == []
+    assert headers is None
+    assert source_info == [{"type": "FileSource", "filename": "doc.pdf"}]
+    assert captured == [123]
 
 
 @pytest.mark.parametrize("include_converted_doc", [False, True])

--- a/tests/test_s3_source_orchestrators.py
+++ b/tests/test_s3_source_orchestrators.py
@@ -57,7 +57,8 @@ def test_expand_task_sources_materializes_s3(monkeypatch: pytest.MonkeyPatch):
         def __exit__(self, exc_type, exc, tb):
             return False
 
-        def iterate_documents(self):
+        def iterate_documents(self, *, max_file_size=None):
+            del max_file_size
             return iter(expected_docs)
 
     monkeypatch.setattr(
@@ -74,6 +75,42 @@ def test_expand_task_sources_materializes_s3(monkeypatch: pytest.MonkeyPatch):
 def test_get_source_processor_accepts_s3coordinates():
     processor = get_source_processor(_make_s3_source())
     assert isinstance(processor, S3SourceProcessor)
+
+
+def test_expand_task_sources_passes_max_file_size_to_source_processor(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    s3_source = _make_s3_source()
+    task = Task(
+        task_id="task-1",
+        task_type=TaskType.CONVERT,
+        sources=[s3_source],
+        target=InBodyTarget(),
+    )
+    expected_docs = [DocumentStream(name="a.pdf", stream=BytesIO(b"a"))]
+    seen_limits: list[int | None] = []
+
+    class FakeSourceProcessor:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def iterate_documents(self, *, max_file_size=None):
+            seen_limits.append(max_file_size)
+            return iter(expected_docs)
+
+    monkeypatch.setattr(
+        "docling_jobkit.convert.source_expansion.get_source_processor",
+        lambda source: FakeSourceProcessor(),
+    )
+
+    convert_sources, headers = expand_task_sources(task, max_file_size=123)
+
+    assert headers is None
+    assert convert_sources == expected_docs
+    assert seen_limits == [123]
 
 
 def test_task_roundtrip_accepts_request_subclasses_without_normalization():

--- a/tests/test_s3_source_processor.py
+++ b/tests/test_s3_source_processor.py
@@ -12,6 +12,7 @@ from docling_jobkit.connectors.s3_source_processor import (
     S3FileIdentifier,
     S3SourceProcessor,
 )
+from docling_jobkit.convert.materialization import SourceLimitExceededError
 from docling_jobkit.datamodel.s3_coords import S3Coordinates
 
 # -------------------------------------------------------------------
@@ -170,7 +171,7 @@ def test_s3_iterate_documents_respects_max_num_elements(minio_coords):
         }
     ]
     processor._fetch_document_by_id = MagicMock(
-        side_effect=lambda identifier: DocumentStream(
+        side_effect=lambda identifier, *, max_file_size=None: DocumentStream(
             name=identifier.key,
             stream=BytesIO(b"content"),
         )
@@ -180,6 +181,21 @@ def test_s3_iterate_documents_respects_max_num_elements(minio_coords):
 
     assert [doc.name for doc in docs] == ["incoming/a.pdf", "incoming/b.pdf"]
     assert processor._fetch_document_by_id.call_count == 2
+
+
+def test_s3_fetch_document_rejects_identifier_size_before_download(minio_coords):
+    processor = S3SourceProcessor(minio_coords)
+    processor._client = MagicMock()
+    identifier = S3FileIdentifier(
+        key="incoming/too-large.pdf",
+        size=9,
+        last_modified=None,
+    )
+
+    with pytest.raises(SourceLimitExceededError, match="max_file_size=8"):
+        processor._fetch_document_by_id(identifier, max_file_size=8)
+
+    processor._client.download_fileobj.assert_not_called()
 
 
 def test_s3_fetch_document_logs_and_reraises_client_error(minio_coords, caplog):

--- a/tests/test_source_processor.py
+++ b/tests/test_source_processor.py
@@ -34,13 +34,18 @@ class MockSourceProcessor(BaseSourceProcessor):
         return len(self._all_ids)
 
     # ---- Simulated fetch ----
-    def _fetch_document_by_id(self, identifier: str) -> DocumentStream:
+    def _fetch_document_by_id(
+        self, identifier: str, *, max_file_size: int | None = None
+    ) -> DocumentStream:
+        del max_file_size
         return DocumentStream(name=identifier, stream=BytesIO(b"content"))
 
     # ---- Only used for full streaming ----
-    def _fetch_documents(self) -> Iterator[DocumentStream]:
+    def _fetch_documents(
+        self, *, max_file_size: int | None = None
+    ) -> Iterator[DocumentStream]:
         for x in self._list_document_ids():
-            yield self._fetch_document_by_id(x)
+            yield self._fetch_document_by_id(x, max_file_size=max_file_size)
 
 
 # -------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR moves document admission checks earlier in the service runtime paths that already fetch or materialize sources inside `docling-jobkit`.

The main change is shared early `max_file_size` enforcement in source-processor-owned fetch paths used by the service orchestrators (`ray`, `local`, and `rq`). Raw `HttpSource` passthrough remains unchanged where the converter still owns the URL fetch, so we do not diverge from upstream docling behavior.

It also keeps Ray’s existing single-PDF materialization path as the early fail-fast point for `max_num_pages` before slice planning and child task dispatch.

## What changed

- Added shared fetch-time `max_file_size` enforcement for processor-owned source retrieval.
- Applied that shared behavior to service orchestrator paths in `ray`, `local`, and `rq`.
- Kept raw `HttpSource` passthrough unchanged where `cm.convert_documents` still fetches the URL itself.
- Added early HTTP rejection from `Content-Length` when available.
- Added early S3 rejection from known object size before download.
- Kept Ray-specific early PDF preflight for `max_num_pages` on the slice/materialization path.
- Preserved deterministic limit failures as non-retryable policy errors.

## Behavior

Before this change, `max_file_size` and `max_num_pages` were primarily enforced inside converter-level document admission, which is too late for some service runtime paths.

After this change:

- Processor-owned HTTP fetches fail before full download when the response is already known to exceed `max_file_size`.
- S3 fetches fail before download when the object size exceeds `max_file_size`.
- Ray slice-eligible single-PDF requests fail on `max_num_pages` before any slice plan is built or child slice tasks are dispatched.
- Raw HTTP passthrough continues to be evaluated later by the converter, unchanged.
