### PR TITLE
fix: Make Ray enqueue cheap by dropping per-request dispatcher health RPC

### DIFF
--- a/docling_jobkit/orchestrators/ray/orchestrator.py
+++ b/docling_jobkit/orchestrators/ray/orchestrator.py
@@ -486,12 +486,6 @@ class RayOrchestrator(BaseOrchestrator):
         The health-check RPC is bounded by config.dispatcher_rpc_timeout so this
         method never hangs when the Ray head is gone.
 
-        This probe is side-effect-free with respect to ``self.dispatcher``: it
-        never nulls the handle. Handle repair (rebind/redeploy/session-restart)
-        is owned exclusively by ``_supervise_dispatcher``, which nulls the handle
-        in its own exception path. Keeping this method non-mutating lets the
-        readiness probe (check_connection) call it without racing the supervisor
-        by clearing the handle out from under it.
         """
         rpc_timeout = self.config.dispatcher_rpc_timeout
         try:

--- a/docling_jobkit/orchestrators/ray/orchestrator.py
+++ b/docling_jobkit/orchestrators/ray/orchestrator.py
@@ -485,6 +485,13 @@ class RayOrchestrator(BaseOrchestrator):
 
         The health-check RPC is bounded by config.dispatcher_rpc_timeout so this
         method never hangs when the Ray head is gone.
+
+        This probe is side-effect-free with respect to ``self.dispatcher``: it
+        never nulls the handle. Handle repair (rebind/redeploy/session-restart)
+        is owned exclusively by ``_supervise_dispatcher``, which nulls the handle
+        in its own exception path. Keeping this method non-mutating lets the
+        readiness probe (check_connection) call it without racing the supervisor
+        by clearing the handle out from under it.
         """
         rpc_timeout = self.config.dispatcher_rpc_timeout
         try:
@@ -495,14 +502,12 @@ class RayOrchestrator(BaseOrchestrator):
                 dispatcher.get_health.remote(), timeout=rpc_timeout
             )
         except asyncio.TimeoutError as exc:
-            self.dispatcher = None
             raise DispatcherUnavailableError(
                 f"Ray dispatcher health check timed out after {rpc_timeout}s"
             ) from exc
         except asyncio.CancelledError:
             raise
         except BaseException as exc:
-            self.dispatcher = None
             raise DispatcherUnavailableError(
                 f"Ray dispatcher is unavailable: {exc}"
             ) from exc
@@ -687,7 +692,21 @@ class RayOrchestrator(BaseOrchestrator):
                     f"Tenant {tenant_id} exceeding limits but enqueueing: {reason}"
                 )
 
-            await self.ensure_dispatcher_ready()
+            # Admission does NOT perform a live Ray RPC. Redis is the durable
+            # queue: the task is safely enqueued the moment enqueue_task()
+            # returns, and the supervisor (_supervise_dispatcher) owns dispatcher
+            # health, rebind, and dispatch-loop restart. A per-request
+            # get_health.remote() converged every replica's storm onto the single
+            # detached actor, and a slow probe both manufactured 503s and (by
+            # holding the Redis gate across the RPC) throttled enqueue throughput.
+            # We instead refuse new work only once the dispatcher has been
+            # continuously unavailable past the liveness deadline, using a cheap
+            # in-memory check (no RPC, no lock, no actor round-trip).
+            if not self.is_liveness_healthy():
+                raise DispatcherUnavailableError(
+                    "Ray dispatcher has been unavailable past the liveness "
+                    "deadline; refusing new work until it recovers."
+                )
             await self.redis_manager.set_task_metadata(
                 task_id=task_id,
                 tenant_id=tenant_id,


### PR DESCRIPTION
## Make Ray enqueue cheap: drop per-request dispatcher health RPC

### Problem
Under a request storm, `docling-serve` returned frequent `503 "Ray dispatcher is unavailable."` even though Redis (the durable queue) was healthy. Every `enqueue()` performed a synchronous Ray RPC — `dispatcher.get_health.remote()` — to a single detached singleton actor, *while holding the Redis caller gate*. This converged every replica's storm onto one actor's event loop, manufactured `DispatcherUnavailableError` whenever a probe exceeded `dispatcher_rpc_timeout` (5s) on a merely-backlogged actor, capped enqueue throughput at `gate_concurrency / rpc_latency`, and amplified failures: a single hot-path timeout nulled the dispatcher handle, making that replica reject *all* subsequent enqueues until the background supervisor rebound it.

### Change (docling-jobkit)
- **Removed the live health RPC from the enqueue hot path.** Admission now uses a cheap in-memory check (`is_liveness_healthy()`) before the Redis writes — no RPC, no lock contention, no holding the gate across a remote call. Redis remains the durable queue; the task is safely enqueued the moment `enqueue_task()` returns.
- **Made `ensure_dispatcher_ready()` side-effect-free** — it no longer nulls `self.dispatcher`. Handle repair (rebind/redeploy/session-restart) is owned solely by `_supervise_dispatcher`, which already nulls and rebinds on its own poll cycle.

### Recovery safety
Crash recovery is unchanged and more consistent. The supervisor already restarts the dispatch loop, rebinds the handle, and redeploys on its poll interval; on loop restart, tenants are resynced from Redis so no queued work is lost. The only delta: dispatch-loop restart after an actor crash happens on the next supervisor poll (≤5s) rather than possibly on the next enqueue — tasks are still durably accepted during that window. Whoever nulls the handle (the supervisor) is now also the only thing that rebinds it, eliminating the previous split-ownership rejection window.
