### PR TITLE
feat: Expose max_replicas_per_node for coordinator and converter deployments

### DIFF
--- a/docling_jobkit/orchestrators/ray/config.py
+++ b/docling_jobkit/orchestrators/ray/config.py
@@ -188,6 +188,15 @@ class RayOrchestratorConfig(BaseSettings):
             "Defaults to target_requests_per_replica when unset."
         ),
     )
+    converter_max_replicas_per_node: Optional[int] = Field(
+        default=None,
+        ge=1,
+        le=100,
+        description=(
+            "Hard cap on converter Serve replicas per Ray node (KubeRay worker "
+            "pod). None = no cap (let Ray pack replicas for density)."
+        ),
+    )
     upscale_delay_s: float = Field(
         default=30.0,
         description="Seconds to wait before scaling up (prevents flapping)",
@@ -291,6 +300,17 @@ class RayOrchestratorConfig(BaseSettings):
         default=None,
         ge=1,
         description="Coordinator hard cap on in-flight requests per replica",
+    )
+    coordinator_max_replicas_per_node: Optional[int] = Field(
+        default=None,
+        ge=1,
+        le=100,
+        description=(
+            "Hard cap on coordinator Serve replicas per Ray node (KubeRay worker "
+            "pod). None = no cap. Setting this to 1 spreads coordinators one per "
+            "node, which caps coordinator replicas at the node count until the "
+            "node autoscaler adds nodes."
+        ),
     )
     coordinator_actor_num_cpus: float = Field(
         default=0.25,

--- a/docling_jobkit/orchestrators/ray/serve_deployment.py
+++ b/docling_jobkit/orchestrators/ray/serve_deployment.py
@@ -1565,19 +1565,23 @@ def _build_deployment_options(
     downscale_delay_s: float,
     graceful_shutdown_wait_loop_s: Optional[float],
     graceful_shutdown_timeout_s: Optional[float],
+    max_replicas_per_node: Optional[int] = None,
 ) -> dict[str, Any]:
     deployment_options: dict[str, Any] = {
         "name": name,
         "autoscaling_config": {
             "min_replicas": min_replicas,
             "max_replicas": max_replicas,
-            "target_num_ongoing_requests_per_replica": target_requests_per_replica,
+            "target_ongoing_requests": target_requests_per_replica,
             "upscale_delay_s": upscale_delay_s,
             "downscale_delay_s": downscale_delay_s,
         },
         "ray_actor_options": {"num_cpus": num_cpus},
         "max_ongoing_requests": max_ongoing_requests,
     }
+
+    if max_replicas_per_node is not None:
+        deployment_options["max_replicas_per_node"] = max_replicas_per_node
 
     memory_bytes = parse_memory_bytes(memory_limit)
     if memory_bytes is not None:
@@ -1628,6 +1632,7 @@ def create_deployment(
         downscale_delay_s=config.downscale_delay_s,
         graceful_shutdown_wait_loop_s=config.graceful_shutdown_wait_loop_s,
         graceful_shutdown_timeout_s=config.graceful_shutdown_timeout_s,
+        max_replicas_per_node=config.converter_max_replicas_per_node,
     )
     coordinator_options = _build_deployment_options(
         name="coordinator",
@@ -1641,6 +1646,7 @@ def create_deployment(
         downscale_delay_s=config.downscale_delay_s,
         graceful_shutdown_wait_loop_s=config.graceful_shutdown_wait_loop_s,
         graceful_shutdown_timeout_s=config.graceful_shutdown_timeout_s,
+        max_replicas_per_node=config.coordinator_max_replicas_per_node,
     )
 
     _log.info(

--- a/tests/test_ray_orchestrator.py
+++ b/tests/test_ray_orchestrator.py
@@ -529,7 +529,7 @@ def test_create_deployment_sets_hard_replica_concurrency_limit():
     )
     assert (
         mock_coordinator_options_call.call_args.kwargs["autoscaling_config"][
-            "target_num_ongoing_requests_per_replica"
+            "target_ongoing_requests"
         ]
         == 4
     )
@@ -586,7 +586,45 @@ def test_create_deployment_defaults_replica_cap_to_autoscaling_target():
     )
     assert (
         mock_coordinator_options_call.call_args.kwargs["autoscaling_config"][
-            "target_num_ongoing_requests_per_replica"
+            "target_ongoing_requests"
         ]
         == 2
     )
+
+
+def test_create_deployment_threads_max_replicas_per_node():
+    """max_replicas_per_node should be emitted per deployment only when set."""
+    from unittest.mock import MagicMock, patch
+
+    from docling_jobkit.orchestrators.ray.serve_deployment import create_deployment
+
+    config = RayOrchestratorConfig(
+        redis_url="redis://localhost:6379/",
+        coordinator_max_replicas_per_node=1,
+        converter_max_replicas_per_node=None,
+    )
+
+    mock_converter_options = MagicMock()
+    mock_converter_options.bind.return_value = MagicMock()
+    mock_coordinator_options = MagicMock()
+    mock_coordinator_options.bind.return_value = MagicMock()
+
+    with (
+        patch(
+            "docling_jobkit.orchestrators.ray.serve_deployment.DoclingProcessorConverterDeployment.options",
+            return_value=mock_converter_options,
+        ) as mock_converter_options_call,
+        patch(
+            "docling_jobkit.orchestrators.ray.serve_deployment.DoclingProcessorCoordinatorDeployment.options",
+            return_value=mock_coordinator_options,
+        ) as mock_coordinator_options_call,
+    ):
+        create_deployment(
+            converter_manager_config=MagicMock(),
+            config=config,
+            redis_url=config.redis_url,
+        )
+
+    assert mock_coordinator_options_call.call_args.kwargs["max_replicas_per_node"] == 1
+    # Unset converter cap must not emit the option (let Ray pack for density).
+    assert "max_replicas_per_node" not in mock_converter_options_call.call_args.kwargs


### PR DESCRIPTION
## Summary

Exposes Ray's per-node replica cap (`max_replicas_per_node`) for the coordinator and converter Serve deployments, and fixes a deprecated autoscaling key that was silently disabling the configured target.

## Changes

- **`max_replicas_per_node` control.** New config fields `coordinator_max_replicas_per_node` and `converter_max_replicas_per_node` on `RayOrchestratorConfig` (`Optional[int]`, range `[1, 100]`, default `None`). `_build_deployment_options` accepts the value and emits it only when set; `create_deployment` passes each deployment its own value. With `None` there is no cap, so existing behavior is unchanged.
- **Deprecated key fix.** Renamed the autoscaling key `target_num_ongoing_requests_per_replica` → `target_ongoing_requests`. In Ray 2.52 the old name was silently ignored (the model is `extra=ignore`), so both deployments autoscaled on the default target of `2` rather than the configured coordinator/converter targets. The configured target is now honored.

## Operator notes

Setting `coordinator_max_replicas_per_node = 1` spreads coordinators one per Ray node (KubeRay worker pod), which caps coordinator replicas at the node count until the node autoscaler adds nodes. Converters are left uncapped by default. This is the per-deployment `max_replicas_per_node` piece from the queue-driven autoscaling plan's replica-spread addendum, established here in isolation.