### PR TITLE
fix(rq): preserve Task.metadata in _get_task_from_rq_direct

### DIFF
--- a/docling_jobkit/orchestrators/rq/orchestrator.py
+++ b/docling_jobkit/orchestrators/rq/orchestrator.py
@@ -404,6 +404,15 @@ class RQOrchestrator(BaseOrchestrator):
             if original_task is not None and original_task.is_completed():
                 return original_task
 
+            job_task_data: dict[str, Any] = {}
+            try:
+                job = await asyncio.to_thread(
+                    Job.fetch, task_id, connection=self._redis_conn
+                )
+                job_task_data = job.kwargs.get("task_data") or {}
+            except NoSuchJobError:
+                pass
+
             temp_task = Task(
                 task_id=task_id,
                 task_type=TaskType.CONVERT,
@@ -415,6 +424,7 @@ class RQOrchestrator(BaseOrchestrator):
                     "num_partially_succeeded": 0,
                     "num_failed": 0,
                 },
+                metadata=job_task_data.get("metadata") or {},
             )
 
             self.tasks[task_id] = temp_task

--- a/tests/test_rq_orchestrator.py
+++ b/tests/test_rq_orchestrator.py
@@ -433,3 +433,32 @@ async def test_convert_with_callbacks(orchestrator: RQOrchestrator, callback_ser
     assert len(final_callback["docs"]) == 1
     assert final_callback["docs"][0]["source"] == doc_filename.name
     assert final_callback["docs"][0]["status"] == ConversionStatus.SUCCESS
+
+
+async def test_get_task_from_rq_direct_preserves_metadata(
+    orchestrator: RQOrchestrator,
+):
+    from rq.job import Job, JobStatus
+
+    options = ConvertDocumentsOptions()
+    sources: list[TaskSource] = [HttpSource(url="https://example.com/test.pdf")]
+
+    task = await orchestrator.enqueue(
+        sources=sources,
+        convert_options=options,
+        target=InBodyTarget(),
+        metadata={"tenant_id": "test-tenant"},
+    )
+    assert task.metadata == {"tenant_id": "test-tenant"}
+
+    orchestrator.tasks.pop(task.task_id, None)
+
+    job = Job.fetch(task.task_id, connection=orchestrator._redis_conn)
+    job.set_status(JobStatus.FINISHED)
+
+    refreshed = await orchestrator.task_status(task_id=task.task_id)
+    assert refreshed.metadata == {"tenant_id": "test-tenant"}
+
+    cached = await orchestrator._get_task_from_redis(task.task_id)
+    assert cached is not None
+    assert cached.metadata == {"tenant_id": "test-tenant"}


### PR DESCRIPTION
The fall-through reconstruction in `_get_task_from_rq_direct` built a
fresh `Task` with an empty `metadata` dict. The caller in `task_status`
then persisted this via `_store_task_in_redis`, overwriting any prior
metadata-bearing cached copy.

This recovers the metadata from the durable RQ job kwargs, which are
written once at enqueue and never mutated.

Fixes #178.

### Tested
Added `test_get_task_from_rq_direct_preserves_metadata` against the
existing RQ orchestrator fixture. Verified the test fails without the
fix and passes with it.