### PR TITLE
fix(ray): task-lifecycle metrics via monotonic Redis counters

### DIFF
--- a/docling_jobkit/orchestrators/ray/models.py
+++ b/docling_jobkit/orchestrators/ray/models.py
@@ -68,6 +68,30 @@ class TenantStats(BaseModel):
     failed_documents: int = Field(default=0, description="Failed documents")
 
 
+class TenantTaskCounters(BaseModel):
+    """Per-tenant monotonic task-lifecycle counters.
+
+    These are cumulative, never-decremented counters incremented atomically at
+    each task state transition (queued -> dispatched -> started -> terminal).
+    Because they persist in Redis and only ever increase, Prometheus can read
+    them at any scrape interval without losing transitions that happen between
+    scrapes. Exposed by docling-serve as Prometheus counters; instantaneous
+    occupancy (currently running/dispatched) is derived in Grafana from the
+    differences between these counters.
+
+    These count tasks, not documents: the number of documents in a task is only
+    known once the coordinator actor expands the sources (e.g. iterating an S3
+    bucket), so it cannot be attributed at enqueue/dispatch/start time. Per-
+    document outcome counts live in TenantStats instead.
+    """
+
+    tasks_enqueued_total: int = Field(default=0, description="Tasks enqueued")
+    tasks_dispatched_total: int = Field(default=0, description="Tasks dispatched")
+    tasks_started_total: int = Field(default=0, description="Tasks started")
+    tasks_succeeded_total: int = Field(default=0, description="Tasks succeeded")
+    tasks_failed_total: int = Field(default=0, description="Tasks failed")
+
+
 class TaskUpdate(BaseModel):
     """Internal task status update message for pub/sub communication.
 

--- a/docling_jobkit/orchestrators/ray/redis_helper.py
+++ b/docling_jobkit/orchestrators/ray/redis_helper.py
@@ -32,6 +32,7 @@ from docling_jobkit.orchestrators.ray.models import (
     TaskUpdate,
     TenantLimits,
     TenantStats,
+    TenantTaskCounters,
 )
 from docling_jobkit.orchestrators.serialization import make_msgpack_safe
 
@@ -79,6 +80,23 @@ end
 redis.call('HINCRBY', KEYS[1], 'converter_units', -rel)
 redis.call('HINCRBY', KEYS[2], 'converter_units', -rel)
 return rel
+"""
+
+# Atomically mark a task STARTED and bump the per-tenant started counter, but
+# only on a genuine transition INTO started (i.e. not when the task is already
+# started or already terminal). This guarantees tasks_started_total increments
+# exactly once per task even if process_task is retried, and never counts a task
+# that reconciliation already terminalized.
+# KEYS[1] = task:{id}, KEYS[2] = tenant:{id}:task_counters
+# ARGV[1] = "started", ARGV[2] = ISO timestamp
+_MARK_TASK_STARTED_LUA = """
+local cur = redis.call('HGET', KEYS[1], 'status')
+redis.call('HSET', KEYS[1], 'status', ARGV[1], 'last_update_at', ARGV[2], 'started_at', ARGV[2])
+if cur ~= 'started' and cur ~= 'success' and cur ~= 'failure' then
+    redis.call('HINCRBY', KEYS[2], 'tasks_started_total', 1)
+    return 1
+end
+return 0
 """
 
 
@@ -230,9 +248,16 @@ class RedisStateManager:
             await self.connect()
 
         queue_key = f"tenant:{tenant_id}:tasks"
+        task_counters_key = f"tenant:{tenant_id}:task_counters"
         task_json = task.model_dump_json()
 
-        await self.redis.rpush(queue_key, task_json)  # type: ignore[misc, union-attr]
+        # Push the task and bump the monotonic enqueued counter atomically so the
+        # counter can never drift from the queue contents.
+        redis = self._ensure_redis()
+        async with redis.pipeline(transaction=True) as pipe:
+            pipe.rpush(queue_key, task_json)
+            pipe.hincrby(task_counters_key, "tasks_enqueued_total", 1)
+            await pipe.execute()
 
         # Update tenant limits
         await self.update_tenant_limits(tenant_id, delta_queued_tasks=1)
@@ -372,6 +397,38 @@ class RedisStateManager:
         await redis.hset(task_key, mapping=updates)  # type: ignore[misc]
 
         _log.debug(f"Updated task {task_id} status to {status}")
+
+    async def mark_task_started(self, task_id: str, tenant_id: str) -> bool:
+        """Atomically mark a task STARTED and bump the started counter once.
+
+        Replaces ``update_task_status(STARTED)`` at the processing entry point.
+        Uses a Lua script so the status write and the counter increment are atomic
+        and the increment only happens on a genuine transition into STARTED
+        (idempotent under Ray retries, and a no-op if the task was already
+        terminalized by reconciliation).
+
+        Returns:
+            True if the task transitioned into STARTED (counter bumped), False if
+            it was already started/terminal.
+        """
+        if not self.redis:
+            await self.connect()
+
+        task_key = f"task:{task_id}"
+        task_counters_key = f"tenant:{tenant_id}:task_counters"
+        timestamp = datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+        redis = self._ensure_redis()
+        result = await redis.eval(  # type: ignore[misc]
+            _MARK_TASK_STARTED_LUA,
+            2,
+            task_key,
+            task_counters_key,
+            TaskStatus.STARTED.value,
+            timestamp,
+        )
+        _log.debug(f"Marked task {task_id} STARTED (transitioned={bool(result)})")
+        return bool(result)
 
     async def get_task_metadata(self, task_id: str) -> dict:
         """Get task metadata.
@@ -714,6 +771,32 @@ class RedisStateManager:
 
         return TenantStats.model_validate(stats_dict)
 
+    async def get_tenant_task_counters(self, tenant_id: str) -> TenantTaskCounters:
+        """Get the monotonic lifecycle counters for a tenant.
+
+        Args:
+            tenant_id: Tenant identifier
+
+        Returns:
+            Tenant counters object (all-zero if the tenant has no counters yet)
+        """
+        if not self.redis:
+            await self.connect()
+
+        task_counters_key = f"tenant:{tenant_id}:task_counters"
+        redis = self._ensure_redis()
+        task_counters_data = await redis.hgetall(task_counters_key)  # type: ignore[misc]
+
+        if not task_counters_data:
+            return TenantTaskCounters()
+
+        # Decode bytes; pydantic coerces the string values to int and ignores any
+        # unexpected fields.
+        decoded = {
+            k.decode("utf-8"): v.decode("utf-8") for k, v in task_counters_data.items()
+        }
+        return TenantTaskCounters.model_validate(decoded)
+
     # Atomic Task Dispatch Operations
 
     async def dispatch_task_atomic(
@@ -734,6 +817,7 @@ class RedisStateManager:
         queue_key = f"tenant:{tenant_id}:tasks"
         active_key = f"tenant:{tenant_id}:active_tasks"
         limits_key = f"tenant:{tenant_id}:limits"
+        task_counters_key = f"tenant:{tenant_id}:task_counters"
         dispatch_key = f"task:{task_id}:dispatch"
 
         redis = self._ensure_redis()
@@ -785,6 +869,11 @@ class RedisStateManager:
                     },
                 )
                 pipe.expire(dispatch_key, self.processing_ttl)
+
+                # 5. Bump the monotonic dispatched counter (atomic with the
+                # pop/add). On a raced dispatch we return before reaching
+                # pipe.execute(), so this is never committed.
+                pipe.hincrby(task_counters_key, "tasks_dispatched_total", 1)
 
                 # Execute transaction
                 await pipe.execute()
@@ -862,6 +951,7 @@ class RedisStateManager:
         task_key = f"task:{task_id}"
         active_key = f"tenant:{tenant_id}:active_tasks"
         limits_key = f"tenant:{tenant_id}:limits"
+        task_counters_key = f"tenant:{tenant_id}:task_counters"
         dispatch_key = f"task:{task_id}:dispatch"
         execution_key = f"task:{task_id}:execution"
         redis = self._ensure_redis()
@@ -925,6 +1015,16 @@ class RedisStateManager:
                         ):
                             updates["failure"] = failure.model_dump_json()
                         pipe.hset(task_key, mapping=updates)
+
+                        # Bump the monotonic terminal counter exactly once: this
+                        # block only runs on the first transition into a terminal
+                        # state (the status_changed guard), so duplicate finalizes
+                        # from replica + dispatcher + reconciliation never
+                        # double-count.
+                        if terminal_status == TaskStatus.SUCCESS:
+                            pipe.hincrby(task_counters_key, "tasks_succeeded_total", 1)
+                        elif terminal_status == TaskStatus.FAILURE:
+                            pipe.hincrby(task_counters_key, "tasks_failed_total", 1)
 
                     if terminal_status == TaskStatus.SUCCESS:
                         pipe.hdel(task_key, "error_message", "failure")
@@ -1036,6 +1136,27 @@ class RedisStateManager:
         tenants_set.update(active_tenants)
 
         return list(tenants_set)
+
+    async def get_all_tenants_with_task_counters(self) -> list[str]:
+        """Get list of all tenants that have lifecycle counters.
+
+        Counters persist after a tenant's queue and active set drain, so this is
+        needed (in addition to get_all_tenants_with_any_tasks) to keep scraping a
+        tenant's cumulative counters even when it is currently idle. A counter
+        that disappears and later reappears would look like a reset to Prometheus
+        and corrupt rate()/increase().
+
+        Returns:
+            List of tenant IDs that have a counters hash
+        """
+        tenants = []
+        redis = self._ensure_redis()
+        async for key in redis.scan_iter(match="tenant:*:task_counters"):  # type: ignore[union-attr]
+            key_str = key.decode("utf-8")
+            parts = key_str.split(":")
+            if len(parts) == 3:
+                tenants.append(parts[1])
+        return tenants
 
     async def _get_task_size_for_resync(self, task_id: str) -> int:
         metadata = await self.get_task_metadata_model(task_id)

--- a/docling_jobkit/orchestrators/ray/serve_deployment.py
+++ b/docling_jobkit/orchestrators/ray/serve_deployment.py
@@ -956,8 +956,9 @@ class DoclingProcessorCoordinatorDeployment:
         workdir = self.scratch_dir / task.task_id
 
         try:
-            await self.redis_manager.update_task_status(
-                task.task_id, TaskStatus.STARTED
+            await self.redis_manager.mark_task_started(
+                task_id=task.task_id,
+                tenant_id=tenant_id,
             )
         except Exception as exc:  # pragma: no cover - best effort status update
             _log.warning(

--- a/tests/test_ray_lifecycle_counters.py
+++ b/tests/test_ray_lifecycle_counters.py
@@ -1,0 +1,355 @@
+"""Tests for the monotonic per-tenant task-lifecycle counters.
+
+The lifecycle (queued -> dispatched -> started -> terminal) is instrumented with
+cumulative counters in a ``tenant:{id}:task_counters`` Redis hash, incremented
+atomically at each transition. docling-serve exposes these as Prometheus
+counters so transitions that happen between two scrapes are never lost.
+
+The suite has no live Redis, so these tests run against a small in-memory fake
+that faithfully models the Redis commands the instrumented code paths use
+(hashes, lists, sets, transactional pipelines, and the mark-started Lua script).
+This mirrors the hermetic style of ``test_ray_converter_units.py``.
+"""
+
+import pytest
+
+pytest.importorskip("msgpack")
+pytest.importorskip("redis")
+
+from docling.datamodel.service.sources import HttpSource
+
+from docling_jobkit.datamodel.task import Task
+from docling_jobkit.datamodel.task_meta import TaskStatus
+from docling_jobkit.orchestrators.ray.redis_helper import (
+    _MARK_TASK_STARTED_LUA,
+    RedisStateManager,
+)
+
+
+class _FakeRedis:
+    """In-memory Redis modelling the commands used by the counter code paths."""
+
+    def __init__(self) -> None:
+        self.hashes: dict[str, dict[str, str]] = {}
+        self.lists: dict[str, list[str]] = {}
+        self.sets: dict[str, set[str]] = {}
+        self.strings: dict[str, object] = {}
+
+    # --- shared command implementation (used by direct calls and pipelines) ---
+    def _apply(self, method: str, args: tuple, kwargs: dict):
+        if method == "rpush":
+            key, *vals = args
+            self.lists.setdefault(key, []).extend(vals)
+            return len(self.lists[key])
+        if method == "lpop":
+            lst = self.lists.get(args[0], [])
+            return lst.pop(0) if lst else None
+        if method == "lindex":
+            key, idx = args
+            lst = self.lists.get(key, [])
+            return lst[idx] if -len(lst) <= idx < len(lst) else None
+        if method == "sadd":
+            key, *members = args
+            self.sets.setdefault(key, set()).update(members)
+            return len(members)
+        if method == "srem":
+            key, *members = args
+            self.sets.setdefault(key, set()).difference_update(members)
+            return len(members)
+        if method == "sismember":
+            key, member = args
+            return member in self.sets.get(key, set())
+        if method == "scard":
+            return len(self.sets.get(args[0], set()))
+        if method == "hset":
+            key = args[0]
+            h = self.hashes.setdefault(key, {})
+            mapping = kwargs.get("mapping")
+            if mapping is not None:
+                h.update({k: str(v) for k, v in mapping.items()})
+            else:
+                # hset(key, f1, v1, f2, v2, ...)
+                rest = args[1:]
+                for i in range(0, len(rest), 2):
+                    h[rest[i]] = str(rest[i + 1])
+            return 1
+        if method == "hget":
+            v = self.hashes.get(args[0], {}).get(args[1])
+            return v.encode("utf-8") if v is not None else None
+        if method == "hgetall":
+            return {
+                k.encode("utf-8"): v.encode("utf-8")
+                for k, v in self.hashes.get(args[0], {}).items()
+            }
+        if method == "hdel":
+            h = self.hashes.get(args[0], {})
+            for field in args[1:]:
+                h.pop(field, None)
+            return 1
+        if method == "hincrby":
+            key, field, amount = args
+            h = self.hashes.setdefault(key, {})
+            h[field] = str(int(h.get(field, "0")) + int(amount))
+            return int(h[field])
+        if method == "setex":
+            key, _ttl, value = args
+            self.strings[key] = value
+            return True
+        if method == "delete":
+            for key in args:
+                self.hashes.pop(key, None)
+                self.lists.pop(key, None)
+                self.sets.pop(key, None)
+                self.strings.pop(key, None)
+            return 1
+        if method == "expire":
+            return True
+        raise AssertionError(f"unexpected command: {method}")
+
+    # --- direct (awaited) commands ---
+    async def lindex(self, key, idx):
+        return self._apply("lindex", (key, idx), {})
+
+    async def hget(self, key, field):
+        return self._apply("hget", (key, field), {})
+
+    async def hgetall(self, key):
+        return self._apply("hgetall", (key,), {})
+
+    async def scard(self, key):
+        return self._apply("scard", (key,), {})
+
+    async def eval(self, script, numkeys, *args):
+        assert script == _MARK_TASK_STARTED_LUA
+        keys = args[:numkeys]
+        argv = args[numkeys:]
+        return self._eval_mark_started(keys, argv)
+
+    def _eval_mark_started(self, keys, argv) -> int:
+        task_key, task_counters_key = keys
+        status, timestamp = argv[0], argv[1]
+        task = self.hashes.setdefault(task_key, {})
+        cur = task.get("status")
+        task["status"] = status
+        task["last_update_at"] = timestamp
+        task["started_at"] = timestamp
+        if cur not in ("started", "success", "failure"):
+            counters = self.hashes.setdefault(task_counters_key, {})
+            counters["tasks_started_total"] = str(
+                int(counters.get("tasks_started_total", "0")) + 1
+            )
+            return 1
+        return 0
+
+    def pipeline(self, transaction: bool = True):
+        return _FakePipeline(self)
+
+
+class _FakePipeline:
+    """Transactional pipeline: buffers commands after multi(), applies on execute()."""
+
+    def __init__(self, store: _FakeRedis) -> None:
+        self._store = store
+        self._buffer: list[tuple] = []
+        self._multi = False
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        self._buffer = []
+        self._multi = False
+        return False
+
+    async def watch(self, *keys):
+        return True
+
+    async def unwatch(self):
+        self._multi = False
+        return True
+
+    def multi(self):
+        self._multi = True
+
+    async def execute(self):
+        results = [self._store._apply(m, a, kw) for (m, a, kw) in self._buffer]
+        self._buffer = []
+        self._multi = False
+        return results
+
+    def __getattr__(self, name):
+        def cmd(*args, **kwargs):
+            if self._multi:
+                self._buffer.append((name, args, kwargs))
+                return self
+            return self._store._apply(name, args, kwargs)
+
+        return cmd
+
+
+def _manager() -> tuple[RedisStateManager, _FakeRedis]:
+    manager = RedisStateManager(redis_url="redis://localhost:6379/")
+    fake = _FakeRedis()
+    manager.redis = fake  # type: ignore[assignment]
+    return manager, fake
+
+
+def _task(task_id: str, n_sources: int = 1) -> Task:
+    return Task(
+        task_id=task_id,
+        sources=[
+            HttpSource(url=f"https://example.com/doc-{i}.pdf") for i in range(n_sources)
+        ],
+    )
+
+
+# --- get_tenant_task_counters --------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_tenant_task_counters_defaults_when_absent() -> None:
+    manager, _ = _manager()
+    counters = await manager.get_tenant_task_counters("tenant-a")
+    assert counters.tasks_enqueued_total == 0
+    assert counters.tasks_succeeded_total == 0
+
+
+@pytest.mark.asyncio
+async def test_get_tenant_task_counters_parses_and_ignores_unknown_fields() -> None:
+    manager, fake = _manager()
+    fake.hashes["tenant:tenant-a:task_counters"] = {
+        "tasks_enqueued_total": "4",
+        "tasks_succeeded_total": "9",
+        "some_future_field": "123",
+    }
+    counters = await manager.get_tenant_task_counters("tenant-a")
+    assert counters.tasks_enqueued_total == 4
+    assert counters.tasks_succeeded_total == 9
+
+
+# --- enqueue --------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_enqueue_increments_enqueued_counters(monkeypatch) -> None:
+    manager, fake = _manager()
+
+    async def _noop_limits(*a, **k):
+        return None
+
+    monkeypatch.setattr(manager, "update_tenant_limits", _noop_limits)
+
+    await manager.enqueue_task("tenant-a", _task("t1", n_sources=3))
+
+    assert fake.lists["tenant:tenant-a:tasks"]  # task was pushed
+    counters = await manager.get_tenant_task_counters("tenant-a")
+    # One task enqueued regardless of how many source specs it carries: the real
+    # document count is not known until the coordinator expands the sources.
+    assert counters.tasks_enqueued_total == 1
+
+
+# --- dispatch -------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dispatch_increments_dispatched_counters() -> None:
+    manager, fake = _manager()
+    task = _task("t1")
+    fake.lists["tenant:tenant-a:tasks"] = [task.model_dump_json()]
+
+    ok = await manager.dispatch_task_atomic("tenant-a", "t1", task_size=4)
+
+    assert ok is True
+    counters = await manager.get_tenant_task_counters("tenant-a")
+    assert counters.tasks_dispatched_total == 1
+    assert "t1" in fake.sets["tenant:tenant-a:active_tasks"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_race_does_not_increment() -> None:
+    manager, fake = _manager()
+    # Front of queue is a different task: simulate a lost race.
+    fake.lists["tenant:tenant-a:tasks"] = [_task("other").model_dump_json()]
+
+    ok = await manager.dispatch_task_atomic("tenant-a", "t1", task_size=4)
+
+    assert ok is False
+    counters = await manager.get_tenant_task_counters("tenant-a")
+    assert counters.tasks_dispatched_total == 0
+
+
+# --- started --------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mark_task_started_is_idempotent() -> None:
+    manager, _ = _manager()
+
+    first = await manager.mark_task_started("t1", "tenant-a")
+    second = await manager.mark_task_started("t1", "tenant-a")
+
+    assert first is True
+    assert second is False
+    counters = await manager.get_tenant_task_counters("tenant-a")
+    assert counters.tasks_started_total == 1
+
+
+@pytest.mark.asyncio
+async def test_mark_task_started_noop_when_already_terminal() -> None:
+    manager, fake = _manager()
+    fake.hashes["task:t1"] = {"status": "success"}
+
+    transitioned = await manager.mark_task_started("t1", "tenant-a")
+
+    assert transitioned is False
+    counters = await manager.get_tenant_task_counters("tenant-a")
+    assert counters.tasks_started_total == 0
+
+
+# --- terminal -------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_finalize_success_increments_once() -> None:
+    manager, fake = _manager()
+    fake.hashes["task:t1"] = {"status": "started"}
+    fake.sets["tenant:tenant-a:active_tasks"] = {"t1"}
+
+    result = await manager._finalize_task_terminal_state_atomic(
+        tenant_id="tenant-a",
+        task_id="t1",
+        task_size=4,
+        terminal_status=TaskStatus.SUCCESS,
+    )
+
+    assert result.status_changed is True
+    counters = await manager.get_tenant_task_counters("tenant-a")
+    assert counters.tasks_succeeded_total == 1
+    assert counters.tasks_failed_total == 0
+
+
+@pytest.mark.asyncio
+async def test_finalize_is_exactly_once_first_terminal_wins() -> None:
+    manager, fake = _manager()
+    fake.hashes["task:t1"] = {"status": "started"}
+    fake.sets["tenant:tenant-a:active_tasks"] = {"t1"}
+
+    await manager._finalize_task_terminal_state_atomic(
+        tenant_id="tenant-a",
+        task_id="t1",
+        task_size=4,
+        terminal_status=TaskStatus.SUCCESS,
+    )
+    # A duplicate finalize (e.g. reconciliation) must not double-count.
+    second = await manager._finalize_task_terminal_state_atomic(
+        tenant_id="tenant-a",
+        task_id="t1",
+        task_size=4,
+        terminal_status=TaskStatus.FAILURE,
+        error_message="late",
+    )
+
+    assert second.status_changed is False
+    counters = await manager.get_tenant_task_counters("tenant-a")
+    assert counters.tasks_succeeded_total == 1
+    assert counters.tasks_failed_total == 0


### PR DESCRIPTION
## Description

Reworks the Ray orchestrator's task-lifecycle observability from point-in-time gauges (scanned from Redis at scrape time) to **monotonic per-tenant counters** that are incremented atomically at each state transition.

### Why

The previous metrics scanned Redis at scrape time and exposed only gauges. That model loses data: any transition that happens entirely between two Prometheus scrapes is never observed. Concretely, submitting a handful of short tasks could show **nothing** in `ray_tenant_tasks_dispatched`, because:

- A task only counted as "dispatched" while its status was still `PENDING` in the active set, but `dispatch_task_atomic` never changes status and `process_task` flips it to `STARTED` immediately — so "dispatched" was a sub-second transient, almost always 0.
- Short tasks could pass `queued → running → done` between two scrapes and be completely invisible.
- A dead fallback branch checked a `processing_started_at` field that the dispatch hash never contains.

### What changed

- **New `tenant:{id}:task_counters` Redis hash** (`TenantTaskCounters` model) with cumulative, never-decremented counters: `tasks_enqueued_total`, `tasks_dispatched_total`, `tasks_started_total`, `tasks_succeeded_total`, `tasks_failed_total`. Because they persist in Redis and only increase, Prometheus reads them at any interval without losing transitions.
- Increments are placed **inside the existing atomic boundaries** so they can never drift from the state machine:
  - `enqueue_task` — wraps the `rpush` + counter bump in a transaction.
  - `dispatch_task_atomic` — bumps inside the existing `MULTI/EXEC` (a raced dispatch returns before `execute()`, so nothing is miscounted).
  - `mark_task_started` (new) — a Lua script that sets `STARTED` + bumps the counter only on a genuine transition into `STARTED`, so it's exactly-once under Ray retries and a no-op after reconciliation has terminalized the task. Replaces the plain `update_task_status(STARTED)` call in `serve_deployment.py`.
  - `_finalize_task_terminal_state_atomic` — bumps succeeded/failed inside the existing `status_changed` exactly-once guard, so duplicate finalizes from replica + dispatcher + reconciliation don't double-count.
- **Counts tasks, not documents.** The true document count is only known once the coordinator expands the sources (e.g. iterating an S3 bucket), so it can't be attributed at enqueue/dispatch/start time. Per-document outcome counts continue to live in the separate `tenant:{id}:stats` hash (`TenantStats`), which is kept distinct because it has different write semantics (best-effort post-finalize follow-up) and different units (documents).
- New getters: `get_tenant_task_counters`, `get_all_tenants_with_task_counters` (the latter so idle-but-historically-active tenants keep being scraped — a counter that vanishes then reappears would look like a reset and corrupt `rate()`).

In Grafana, instantaneous occupancy is derived from counter differences, e.g. currently-running = `tasks_started_total - tasks_succeeded_total - tasks_failed_total`, which is exact and loss-proof.

### Tests

`tests/test_ray_lifecycle_counters.py` covers: enqueue/dispatch/finalize increments within their transactions, idempotent `mark_task_started`, the dispatch race path leaving counters untouched, and `get_tenant_task_counters` parsing (defaults + ignoring unknown fields).

### Reviewer note

This has a **companion change in `docling-serve`** (`RayCollector` in `ray_metrics_collector.py`) that consumes these counters and exposes them as Prometheus `CounterMetricFamily` metrics (`ray_tenant_tasks_*_total`), replacing the old dispatched/running gauges. The serve-side PR depends on the new getter names introduced here.