### PR TITLE
feat: unify CLI/Ray connector processing and add a pluggy connector plugin system

### DIFF
--- a/docling_jobkit/cli/local.py
+++ b/docling_jobkit/cli/local.py
@@ -21,6 +21,7 @@ from docling_jobkit.convert.manager import (
     DoclingConverterManagerConfig,
 )
 from docling_jobkit.convert.results_processor import ResultsProcessor
+from docling_jobkit.datamodel.dynamic_unions import build_job_config_model
 from docling_jobkit.datamodel.task_sources import (
     TaskGoogleDriveSource,
     TaskLocalPathSource,
@@ -87,11 +88,14 @@ def convert(
         ),
     ] = False,
 ):
-    # Open and validate config file
+    # Open and validate config file. The config model is built from the connector
+    # factories so that, when external plugins are allowed, third-party source/
+    # target ``kind`` values validate from YAML exactly like the built-ins.
     try:
         with config_file.open("r") as f:
             raw_data = yaml.safe_load(f)
-        config = JobConfig(**raw_data)
+        config_model = build_job_config_model(allow_external_plugins)
+        config = config_model(**raw_data)
     except ValidationError as e:
         typer.echo("❌ Validation failed:")
         typer.echo(e.json(indent=2))
@@ -106,7 +110,9 @@ def convert(
     manager = DoclingConverterManager(config=cm_config)
 
     results = []
-    with get_target_processor(config.target) as target_processor:
+    with get_target_processor(
+        config.target, allow_external_plugins=allow_external_plugins
+    ) as target_processor:
         result_processor = ResultsProcessor(
             target_processor=target_processor,
             to_formats=[v.value for v in config.options.to_formats],
@@ -114,7 +120,9 @@ def convert(
             generate_picture_images=config.options.include_images,
         )
         for source in config.sources:
-            with get_source_processor(source) as source_processor:
+            with get_source_processor(
+                source, allow_external_plugins=allow_external_plugins
+            ) as source_processor:
                 for item in result_processor.process_documents(
                     manager.convert_documents(
                         sources=source_processor.iterate_documents(),

--- a/docling_jobkit/cli/multiproc.py
+++ b/docling_jobkit/cli/multiproc.py
@@ -169,7 +169,7 @@ def _process_source(
                             pool.apply_async(
                                 process_batch,
                                 (
-                                    chunk.for_transport(),
+                                    chunk,
                                     config.target,
                                     config.options,
                                     artifacts_path,
@@ -287,9 +287,9 @@ def process_batch(
     - Writing results to target
     - Tracking successes and failures
 
-    The chunk arrives fetcher-stripped (see ``DocumentChunk.for_transport``); the
-    documents are fetched one at a time via ``open_chunk_sources`` so peak memory
-    stays bounded to a single in-flight document regardless of batch size.
+    The chunk carries only source + refs; the documents are fetched one at a time
+    via ``open_chunk_sources`` so peak memory stays bounded to a single in-flight
+    document regardless of batch size.
 
     Args:
         chunk: Transport (fetcher-stripped) chunk carrying source + refs

--- a/docling_jobkit/cli/multiproc.py
+++ b/docling_jobkit/cli/multiproc.py
@@ -25,13 +25,16 @@ from docling.datamodel.service.requests import (
 )
 from docling.datamodel.service.targets import S3Target, ZipTarget
 
+from docling_jobkit.connectors.source_processor import DocumentChunk
 from docling_jobkit.connectors.source_processor_factory import get_source_processor
 from docling_jobkit.connectors.target_processor_factory import get_target_processor
+from docling_jobkit.convert.chunk_execution import open_chunk_sources
 from docling_jobkit.convert.manager import (
     DoclingConverterManager,
     DoclingConverterManagerConfig,
 )
 from docling_jobkit.convert.results_processor import ResultsProcessor
+from docling_jobkit.datamodel.dynamic_unions import build_job_config_model
 from docling_jobkit.datamodel.task_sources import (
     TaskGoogleDriveSource,
     TaskLocalPathSource,
@@ -85,12 +88,18 @@ class BatchResult(BaseModel):
     error_message: Optional[str] = None
 
 
-def _load_config(config_file: Path) -> JobConfig:
-    """Load and validate configuration file."""
+def _load_config(config_file: Path, allow_external_plugins: bool = False) -> JobConfig:
+    """Load and validate configuration file.
+
+    The config model is built from the connector factories so that, when external
+    plugins are allowed, third-party source/target ``kind`` values validate from
+    YAML exactly like the built-ins.
+    """
     try:
         with config_file.open("r") as f:
             raw_data = yaml.safe_load(f)
-        return JobConfig(**raw_data)
+        config_model = build_job_config_model(allow_external_plugins)
+        return config_model(**raw_data)
     except FileNotFoundError:
         err_console.print(f"[red]❌ File not found: {config_file}[/red]")
         raise typer.Exit(1)
@@ -122,7 +131,9 @@ def _process_source(
 
     batch_results: list[BatchResult] = []
 
-    with get_source_processor(source) as source_processor:
+    with get_source_processor(
+        source, allow_external_plugins=allow_external_plugins
+    ) as source_processor:
         # Check if source supports chunking
         try:
             chunks_iter = source_processor.iterate_document_chunks(batch_size)
@@ -133,41 +144,10 @@ def _process_source(
             )
             raise typer.Exit(1)
 
-        # Collect all chunks first to know total count
-        chunks = list(chunks_iter)
-        num_chunks = len(chunks)
-
-        if num_chunks == 0:
-            if not quiet:
-                console.print("[yellow]No documents found in source[/yellow]")
-            return batch_results
-
-        # Calculate total number of documents across all chunks
-        total_documents = sum(len(list(chunk.ids)) for chunk in chunks)
-
-        if not quiet:
-            console.print(
-                f"Found {total_documents} documents in {num_chunks} batches to process"
-            )
-
-        # Prepare arguments for each batch
-        batch_args = [
-            (
-                chunk.index,
-                list(chunk.ids),
-                source,
-                config.target,
-                config.options,
-                artifacts_path,
-                enable_remote_services,
-                allow_external_plugins,
-                log_level,
-                progress_queue,
-            )
-            for chunk in chunks
-        ]
-
-        # Process batches in parallel with progress tracking
+        # Process batches in parallel with progress tracking. Chunks are streamed
+        # from the source and submitted to the pool as they are produced — only the
+        # lightweight refs (no document bytes) ever live in this process, and each
+        # subprocess fetches its documents lazily from chunk.source.
         with Progress(
             SpinnerColumn(),
             TextColumn("[progress.description]{task.description}"),
@@ -176,21 +156,51 @@ def _process_source(
             console=console,
             disable=quiet,
         ) as progress:
-            task = progress.add_task("Processing documents...", total=total_documents)
+            task = progress.add_task("Processing documents...", total=0)
 
             with mp.Pool(processes=num_processes) as pool:
-                # Start async processing
-                async_results = [
-                    pool.apply_async(process_batch, args) for args in batch_args
-                ]
+                async_results = []
+                total_documents = 0
+                try:
+                    for chunk in chunks_iter:
+                        total_documents += len(chunk.refs)
+                        progress.update(task, total=total_documents)
+                        async_results.append(
+                            pool.apply_async(
+                                process_batch,
+                                (
+                                    chunk.for_transport(),
+                                    config.target,
+                                    config.options,
+                                    artifacts_path,
+                                    enable_remote_services,
+                                    allow_external_plugins,
+                                    log_level,
+                                    progress_queue,
+                                ),
+                            )
+                        )
 
-                # Track which results have been collected
-                collected_indices = set()
-                completed_batches = 0
+                    num_chunks = len(async_results)
+                    if num_chunks == 0:
+                        if not quiet:
+                            console.print(
+                                "[yellow]No documents found in source[/yellow]"
+                            )
+                        return batch_results
 
-                # Monitor progress queue while batches are processing
-                while completed_batches < len(batch_args):
-                    try:
+                    if not quiet:
+                        console.print(
+                            f"Found {total_documents} documents in "
+                            f"{num_chunks} batches to process"
+                        )
+
+                    # Track which results have been collected
+                    collected_indices: set[int] = set()
+                    completed_batches = 0
+
+                    # Monitor progress queue while batches are processing
+                    while completed_batches < num_chunks:
                         # Check for progress updates (non-blocking with timeout)
                         if progress_queue:
                             try:
@@ -203,13 +213,12 @@ def _process_source(
                         # Check if any batch has completed
                         for idx, async_result in enumerate(async_results):
                             if idx not in collected_indices and async_result.ready():
-                                batch_result = async_result.get()
-                                batch_results.append(batch_result)
+                                batch_results.append(async_result.get())
                                 collected_indices.add(idx)
                                 completed_batches += 1
-                    except KeyboardInterrupt:
-                        pool.terminate()
-                        raise
+                except KeyboardInterrupt:
+                    pool.terminate()
+                    raise
 
     return batch_results
 
@@ -259,9 +268,7 @@ def _display_summary(
 
 
 def process_batch(
-    chunk_index: int,
-    document_ids: list[Any],
-    source: JobTaskSource,
+    chunk: DocumentChunk,
     target: JobTaskTarget,
     options: ConvertDocumentsOptions,
     artifacts_path: Optional[Path],
@@ -275,14 +282,17 @@ def process_batch(
 
     This function is executed in a separate process and handles:
     - Initializing source and target processors from config
+    - Fetching the batch's documents lazily from the chunk's refs
     - Converting documents in the batch
     - Writing results to target
     - Tracking successes and failures
 
+    The chunk arrives fetcher-stripped (see ``DocumentChunk.for_transport``); the
+    documents are fetched one at a time via ``open_chunk_sources`` so peak memory
+    stays bounded to a single in-flight document regardless of batch size.
+
     Args:
-        chunk_index: Index of this batch/chunk
-        document_ids: List of document identifiers for this batch
-        source: Source configuration
+        chunk: Transport (fetcher-stripped) chunk carrying source + refs
         target: Target configuration
         options: Conversion options
         artifacts_path: Optional path to model artifacts
@@ -300,6 +310,8 @@ def process_batch(
     num_succeeded = 0
     num_failed = 0
     failed_documents: list[str] = []
+    chunk_index = chunk.chunk_index
+    num_documents = len(chunk.refs)
 
     try:
         # Initialize converter manager
@@ -312,37 +324,27 @@ def process_batch(
         manager = DoclingConverterManager(config=cm_config)
 
         # Process documents in this batch using factories
-        with get_source_processor(source) as source_processor:
-            with get_target_processor(target) as target_processor:
-                result_processor = ResultsProcessor(
-                    target_processor=target_processor,
-                    to_formats=[v.value for v in options.to_formats],
-                    generate_page_images=options.include_page_images,
-                    generate_picture_images=options.include_images,
-                )
+        with get_target_processor(
+            target, allow_external_plugins=allow_external_plugins
+        ) as target_processor:
+            result_processor = ResultsProcessor(
+                target_processor=target_processor,
+                to_formats=[v.value for v in options.to_formats],
+                generate_page_images=options.include_page_images,
+                generate_picture_images=options.include_images,
+            )
 
-                # Get a new chunk with the same document IDs
-                # This recreates the chunk in the subprocess context
-                chunk = None
-                for c in source_processor.iterate_document_chunks(len(document_ids)):
-                    # Find the chunk with matching IDs
-                    if list(c.ids) == document_ids:
-                        chunk = c
-                        break
-
-                if chunk is None:
-                    raise RuntimeError(
-                        f"Could not find documents for batch {chunk_index} with IDs: {document_ids}"
-                    )
-
-                # Use the chunk's iter_documents method to get documents
-                documents = list(chunk.iter_documents())
-
-                # Convert and process documents
+            # Fetch documents lazily from the chunk refs (one in flight at a time)
+            with open_chunk_sources(
+                chunk,
+                max_file_size=manager.config.max_file_size,
+                allow_external_plugins=allow_external_plugins,
+            ) as (sources, headers):
                 for item in result_processor.process_documents(
                     manager.convert_documents(
-                        sources=documents,
+                        sources=sources,
                         options=options,
+                        headers=headers,
                     )
                 ):
                     if "SUCCESS" in item:
@@ -359,7 +361,7 @@ def process_batch(
 
         return BatchResult(
             chunk_index=chunk_index,
-            num_documents=len(document_ids),
+            num_documents=num_documents,
             num_succeeded=num_succeeded,
             num_failed=num_failed,
             failed_documents=failed_documents,
@@ -371,9 +373,9 @@ def process_batch(
         _log.error(f"Batch {chunk_index} failed with error: {e}")
         return BatchResult(
             chunk_index=chunk_index,
-            num_documents=len(document_ids),
+            num_documents=num_documents,
             num_succeeded=num_succeeded,
-            num_failed=len(document_ids) - num_succeeded,
+            num_failed=num_documents - num_succeeded,
             failed_documents=failed_documents or [f"Batch error: {e!s}"],
             processing_time=processing_time,
             error_message=str(e),
@@ -469,7 +471,7 @@ def convert(
         console.print()
 
     # Load and validate config file
-    config = _load_config(config_file)
+    config = _load_config(config_file, allow_external_plugins=allow_external_plugins)
 
     # Create a queue for progress updates from worker processes
     manager = mp.Manager()

--- a/docling_jobkit/connectors/connector_factory.py
+++ b/docling_jobkit/connectors/connector_factory.py
@@ -1,0 +1,196 @@
+"""Pluggy-based factory for source/target connectors.
+
+Mirrors docling's ``docling.models.factories.base_factory`` so connectors can be
+discovered through setuptools entry points (group ``docling_jobkit``) and
+contributed by third-party packages, while built-in connectors keep working with
+no configuration. The registry is keyed by the connector's *config* model type
+(the pydantic model carrying a ``Literal`` ``kind``), and instances are created
+from a config object via :meth:`BaseConnectorFactory.create_instance`.
+"""
+
+import logging
+from abc import ABCMeta
+from functools import lru_cache
+from typing import Annotated, Generic, Optional, TypeVar, Union
+
+from pluggy import PluginManager
+from pydantic import BaseModel, Field
+
+from docling_jobkit.connectors.source_processor import BaseSourceProcessor
+from docling_jobkit.connectors.target_processor import BaseTargetProcessor
+
+logger = logging.getLogger(__name__)
+
+PLUGIN_GROUP = "docling_jobkit"
+_INTERNAL_MODULE_PREFIX = "docling_jobkit."
+
+P = TypeVar("P", BaseSourceProcessor, BaseTargetProcessor)
+
+
+class ConnectorFactoryMeta(BaseModel):
+    kind: str
+    plugin_name: str
+    module: str
+
+
+def _kind_of(config_type: type[BaseModel]) -> str:
+    """Return the ``kind`` discriminator value declared on a config model."""
+    field = config_type.model_fields.get("kind")
+    if field is None or field.default is None:
+        raise ValueError(
+            f"Connector config {config_type!r} must declare a `kind` field with a "
+            "literal default to be registered."
+        )
+    return str(field.default)
+
+
+class BaseConnectorFactory(Generic[P], metaclass=ABCMeta):
+    default_plugin_name = PLUGIN_GROUP
+
+    def __init__(self, plugin_attr_name: str, plugin_name: str = default_plugin_name):
+        self.plugin_name = plugin_name
+        self.plugin_attr_name = (
+            plugin_attr_name  # "source_connectors"/"target_connectors"
+        )
+        self._classes: dict[type[BaseModel], type[P]] = {}
+        self._meta: dict[type[BaseModel], ConnectorFactoryMeta] = {}
+
+    @property
+    def registered_config_types(self) -> tuple[type[BaseModel], ...]:
+        return tuple(self._classes.keys())
+
+    @property
+    def registered_kinds(self) -> list[str]:
+        return [meta.kind for meta in self._meta.values()]
+
+    @property
+    def registered_meta(self) -> dict[type[BaseModel], ConnectorFactoryMeta]:
+        return self._meta
+
+    def register(self, cls: type[P], plugin_name: str, plugin_module_name: str) -> None:
+        for config_type in cls.get_config_types():
+            kind = _kind_of(config_type)
+            if config_type in self._classes:
+                raise ValueError(
+                    f"{kind!r} ({config_type!r}) already registered to class "
+                    f"{self._classes[config_type]!r}"
+                )
+            self._classes[config_type] = cls
+            self._meta[config_type] = ConnectorFactoryMeta(
+                kind=kind,
+                plugin_name=plugin_name,
+                module=plugin_module_name,
+            )
+
+    def _resolve_class(self, config: BaseModel) -> Optional[type[P]]:
+        # 1. Exact config-type match (the discriminated-union / YAML path).
+        cls = self._classes.get(type(config))
+        if cls is not None:
+            return cls
+        # 2. config is an instance of a registered (super)type.
+        for config_type, candidate in self._classes.items():
+            if isinstance(config, config_type):
+                return candidate
+        # 3. A bare base object (e.g. S3Coordinates) was passed but the registry
+        #    holds the kind-bearing subclass (e.g. S3SourceRequest). Match when the
+        #    registered type derives from the runtime type.
+        for config_type, candidate in self._classes.items():
+            if issubclass(config_type, type(config)):
+                return candidate
+        return None
+
+    def create_instance(self, config: BaseModel, **kwargs) -> P:
+        cls = self._resolve_class(config)
+        if cls is None:
+            raise RuntimeError(self._err_msg_on_class_not_found(config))
+        return cls(config, **kwargs)  # type: ignore[call-arg]
+
+    def build_discriminated_union(self):
+        """Build a pydantic discriminated union of the registered config types.
+
+        Returns the bare type when only one connector is registered (pydantic
+        rejects a single-member discriminated union).
+        """
+        types = self.registered_config_types
+        if not types:
+            raise RuntimeError(
+                f"No connectors registered for {self.plugin_attr_name!r}."
+            )
+        if len(types) == 1:
+            return types[0]
+        return Annotated[Union[types], Field(discriminator="kind")]  # type: ignore[valid-type]
+
+    def load_from_plugins(
+        self,
+        plugin_name: Optional[str] = None,
+        allow_external_plugins: bool = False,
+    ) -> None:
+        plugin_name = plugin_name or self.plugin_name
+
+        plugin_manager = PluginManager(plugin_name)
+        plugin_manager.load_setuptools_entrypoints(plugin_name)
+
+        for entry_name, plugin_module in plugin_manager.list_name_plugin():
+            plugin_module_name = str(plugin_module.__name__)  # type: ignore[attr-defined]
+
+            if not allow_external_plugins and not plugin_module_name.startswith(
+                _INTERNAL_MODULE_PREFIX
+            ):
+                logger.warning(
+                    "The plugin %r will not be loaded because docling-jobkit is "
+                    "being executed with allow_external_plugins=false.",
+                    entry_name,
+                )
+                continue
+
+            attr = getattr(plugin_module, self.plugin_attr_name, None)
+            if callable(attr):
+                logger.info("Loading connector plugin %r", entry_name)
+                config = attr()
+                self.process_plugin(config, entry_name, plugin_module_name)
+
+    def process_plugin(self, config, plugin_name: str, plugin_module_name: str) -> None:
+        for item in config[self.plugin_attr_name]:
+            try:
+                self.register(item, plugin_name, plugin_module_name)
+            except ValueError:
+                logger.warning("%r already registered", item)
+
+    def _err_msg_on_class_not_found(self, config: BaseModel) -> str:
+        known = "\n".join(
+            f"\t{meta.kind!r} => {cls!r}"
+            for cls, meta in zip(self._classes.values(), self._meta.values())
+        )
+        kind = getattr(config, "kind", type(config).__name__)
+        return (
+            f"No connector found for {kind!r} ({type(config)!r}), known "
+            f"connectors are:\n{known}"
+        )
+
+
+class SourceConnectorFactory(BaseConnectorFactory[BaseSourceProcessor]):
+    def __init__(self, plugin_name: str = PLUGIN_GROUP):
+        super().__init__("source_connectors", plugin_name)
+
+
+class TargetConnectorFactory(BaseConnectorFactory[BaseTargetProcessor]):
+    def __init__(self, plugin_name: str = PLUGIN_GROUP):
+        super().__init__("target_connectors", plugin_name)
+
+
+@lru_cache(maxsize=None)
+def get_source_connector_factory(
+    allow_external_plugins: bool = False,
+) -> SourceConnectorFactory:
+    factory = SourceConnectorFactory()
+    factory.load_from_plugins(allow_external_plugins=allow_external_plugins)
+    return factory
+
+
+@lru_cache(maxsize=None)
+def get_target_connector_factory(
+    allow_external_plugins: bool = False,
+) -> TargetConnectorFactory:
+    factory = TargetConnectorFactory()
+    factory.load_from_plugins(allow_external_plugins=allow_external_plugins)
+    return factory

--- a/docling_jobkit/connectors/google_drive_source_processor.py
+++ b/docling_jobkit/connectors/google_drive_source_processor.py
@@ -10,19 +10,26 @@ from docling.datamodel.base_models import DocumentStream
 if TYPE_CHECKING:
     from docling_jobkit.connectors.google_drive_helper import GoogleDriveFileIdentifier
 
+from pydantic import BaseModel
+
 from docling_jobkit.connectors.source_processor import (
     BaseSourceProcessor,
     SourceDocumentRef,
 )
 from docling_jobkit.datamodel.google_drive_coords import GoogleDriveCoordinates
+from docling_jobkit.datamodel.task_sources import TaskGoogleDriveSource
 
 
 class GoogleDriveSourceProcessor(
-    BaseSourceProcessor[GoogleDriveCoordinates, GoogleDriveFileIdentifier]
+    BaseSourceProcessor[GoogleDriveCoordinates, "GoogleDriveFileIdentifier"]
 ):
     def __init__(self, coords: GoogleDriveCoordinates):
         super().__init__(coords)
         self._coords = coords
+
+    @classmethod
+    def get_config_types(cls) -> tuple[type[BaseModel], ...]:
+        return (TaskGoogleDriveSource,)
 
     def _initialize(self):
         from docling_jobkit.connectors.google_drive_helper import get_service

--- a/docling_jobkit/connectors/google_drive_target_processor.py
+++ b/docling_jobkit/connectors/google_drive_target_processor.py
@@ -2,14 +2,21 @@ from io import BytesIO
 from pathlib import Path
 from typing import BinaryIO
 
+from pydantic import BaseModel
+
 from docling_jobkit.connectors.target_processor import BaseTargetProcessor
 from docling_jobkit.datamodel.google_drive_coords import GoogleDriveCoordinates
+from docling_jobkit.datamodel.task_targets import GoogleDriveTarget
 
 
 class GoogleDriveTargetProcessor(BaseTargetProcessor):
     def __init__(self, coords: GoogleDriveCoordinates):
         super().__init__()
         self._coords = coords
+
+    @classmethod
+    def get_config_types(cls) -> tuple[type[BaseModel], ...]:
+        return (GoogleDriveTarget,)
 
     def _initialize(self):
         from docling_jobkit.connectors.google_drive_helper import get_service

--- a/docling_jobkit/connectors/http_put_target_processor.py
+++ b/docling_jobkit/connectors/http_put_target_processor.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from typing import BinaryIO, Optional
 
 import httpx
+from pydantic import BaseModel
 
 from docling.datamodel.service.targets import PutTarget
 
@@ -14,6 +15,10 @@ _log = logging.getLogger(__name__)
 
 class HttpPutTargetProcessor(BaseTargetProcessor):
     """Target processor that PUTs file/object bytes to a remote HTTP URL."""
+
+    @classmethod
+    def get_config_types(cls) -> tuple[type[BaseModel], ...]:
+        return (PutTarget,)
 
     def __init__(
         self, target: PutTarget, *, max_retries: int = 3, retry_delay: float = 1.0

--- a/docling_jobkit/connectors/http_source_processor.py
+++ b/docling_jobkit/connectors/http_source_processor.py
@@ -3,6 +3,10 @@ from typing import Iterator
 from pydantic import BaseModel, ConfigDict
 from typing_extensions import override
 
+from docling.datamodel.service.requests import (
+    FileSourceRequest,
+    HttpSourceRequest,
+)
 from docling.datamodel.service.sources import FileSource, HttpSource
 from docling_core.types.io import DocumentStream
 
@@ -32,6 +36,10 @@ class HttpSourceProcessor(
     def __init__(self, source: HttpSource | FileSource):
         super().__init__(source)
         self._source = source
+
+    @classmethod
+    def get_config_types(cls) -> tuple[type[BaseModel], ...]:
+        return (FileSourceRequest, HttpSourceRequest)
 
     def _initialize(self):
         pass

--- a/docling_jobkit/connectors/local_path_source_processor.py
+++ b/docling_jobkit/connectors/local_path_source_processor.py
@@ -63,6 +63,10 @@ class LocalPathSourceProcessor(
         super().__init__(source)
         self._source = source
 
+    @classmethod
+    def get_config_types(cls) -> tuple[type[BaseModel], ...]:
+        return (TaskLocalPathSource,)
+
     def _initialize(self):
         """Validate that the path exists."""
         if not self._source.path.exists():

--- a/docling_jobkit/connectors/local_path_target_processor.py
+++ b/docling_jobkit/connectors/local_path_target_processor.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 from typing import BinaryIO
 
+from pydantic import BaseModel
+
 from docling_jobkit.connectors.target_processor import BaseTargetProcessor
 from docling_jobkit.datamodel.task_targets import LocalPathTarget
 
@@ -9,6 +11,10 @@ class LocalPathTargetProcessor(BaseTargetProcessor):
     def __init__(self, target: LocalPathTarget):
         super().__init__()
         self._target = target
+
+    @classmethod
+    def get_config_types(cls) -> tuple[type[BaseModel], ...]:
+        return (LocalPathTarget,)
 
     def _initialize(self) -> None:
         """

--- a/docling_jobkit/connectors/plugins/defaults.py
+++ b/docling_jobkit/connectors/plugins/defaults.py
@@ -1,0 +1,54 @@
+"""Built-in connector plugin for docling-jobkit.
+
+Registered under the ``docling_jobkit`` setuptools entry-point group (see
+``pyproject.toml``). The connector factory calls :func:`source_connectors` /
+:func:`target_connectors` to discover the connectors shipped with the package.
+
+Imports are deferred into the functions so that merely loading this module (which
+happens for every entry-point scan) stays cheap and never pulls optional, heavy
+SDKs at import time. The Google Drive connectors only import their google
+dependencies inside their methods, so listing the classes here is import-safe
+even when the ``gdrive`` extra is not installed.
+"""
+
+
+def source_connectors():
+    from docling_jobkit.connectors.google_drive_source_processor import (
+        GoogleDriveSourceProcessor,
+    )
+    from docling_jobkit.connectors.http_source_processor import HttpSourceProcessor
+    from docling_jobkit.connectors.local_path_source_processor import (
+        LocalPathSourceProcessor,
+    )
+    from docling_jobkit.connectors.s3_source_processor import S3SourceProcessor
+
+    return {
+        "source_connectors": [
+            HttpSourceProcessor,
+            S3SourceProcessor,
+            LocalPathSourceProcessor,
+            GoogleDriveSourceProcessor,
+        ]
+    }
+
+
+def target_connectors():
+    from docling_jobkit.connectors.google_drive_target_processor import (
+        GoogleDriveTargetProcessor,
+    )
+    from docling_jobkit.connectors.http_put_target_processor import (
+        HttpPutTargetProcessor,
+    )
+    from docling_jobkit.connectors.local_path_target_processor import (
+        LocalPathTargetProcessor,
+    )
+    from docling_jobkit.connectors.s3_target_processor import S3TargetProcessor
+
+    return {
+        "target_connectors": [
+            S3TargetProcessor,
+            LocalPathTargetProcessor,
+            HttpPutTargetProcessor,
+            GoogleDriveTargetProcessor,
+        ]
+    }

--- a/docling_jobkit/connectors/s3_source_processor.py
+++ b/docling_jobkit/connectors/s3_source_processor.py
@@ -7,6 +7,7 @@ from botocore.exceptions import ClientError
 from pydantic import BaseModel
 from typing_extensions import override
 
+from docling.datamodel.service.requests import S3SourceRequest
 from docling.datamodel.service.sources import S3Coordinates
 from docling_core.types.io import DocumentStream
 
@@ -33,6 +34,10 @@ class S3SourceProcessor(BaseSourceProcessor[S3Coordinates, S3FileIdentifier]):
     def __init__(self, coords: S3Coordinates):
         super().__init__(coords)
         self._coords = coords
+
+    @classmethod
+    def get_config_types(cls) -> tuple[type[BaseModel], ...]:
+        return (S3SourceRequest,)
 
     def _initialize(self):
         self._client, self._resource = get_s3_connection(self._coords)

--- a/docling_jobkit/connectors/s3_target_processor.py
+++ b/docling_jobkit/connectors/s3_target_processor.py
@@ -1,7 +1,10 @@
 from pathlib import Path
 from typing import BinaryIO
 
+from pydantic import BaseModel
+
 from docling.datamodel.service.sources import S3Coordinates
+from docling.datamodel.service.targets import S3Target
 
 from docling_jobkit.connectors.s3_helper import get_s3_connection
 from docling_jobkit.connectors.s3_upload_support import (
@@ -15,6 +18,10 @@ class S3TargetProcessor(BaseTargetProcessor):
     def __init__(self, coords: S3Coordinates):
         super().__init__()
         self._coords = coords
+
+    @classmethod
+    def get_config_types(cls) -> tuple[type[BaseModel], ...]:
+        return (S3Target,)
 
     def _initialize(self):
         self._client, self._resource = get_s3_connection(self._coords)

--- a/docling_jobkit/connectors/source_processor.py
+++ b/docling_jobkit/connectors/source_processor.py
@@ -62,6 +62,22 @@ class DocumentChunk(BaseModel, Generic[SourceT, FileIdentifierT]):
         for ref in self.refs:
             yield self._fetcher(ref.id)
 
+    def for_transport(self) -> "DocumentChunk[SourceT, FileIdentifierT]":
+        """Return a fetcher-stripped copy safe to send across a process boundary.
+
+        The ``_fetcher`` is a bound method of an initialized connector that may
+        capture unpicklable state (e.g. a boto3 client with thread locks). Any
+        chunk crossing a process boundary — CLI ``mp.Pool`` (pickle) or Ray
+        (cloudpickle) — must carry only ``source`` + ``refs``; the worker
+        reconstructs its own processor via ``get_source_processor(chunk.source)``
+        and fetches lazily with ``fetch_converter_source_by_ref``.
+        """
+        return DocumentChunk(
+            source=self.source,
+            refs=self.refs,
+            chunk_index=self.chunk_index,
+        )
+
 
 class BaseSourceProcessor(
     Generic[SourceT, FileIdentifierT], AbstractContextManager, ABC
@@ -74,6 +90,19 @@ class BaseSourceProcessor(
     def __init__(self, source: SourceT):
         self._processor_source = source
         self._initialized = False  # Track whether the processor is ready
+
+    @classmethod
+    def get_config_types(cls) -> tuple[type[BaseModel], ...]:
+        """Config (pydantic) models this processor accepts.
+
+        Each returned model must carry a ``Literal`` ``kind`` field. The connector
+        factory keys its registry on these types, so a processor that handles
+        several config shapes (e.g. file + http) returns a multi-element tuple.
+        """
+        raise NotImplementedError(
+            f"{cls.__name__} must implement get_config_types() to be registered "
+            "as a connector plugin."
+        )
 
     def __enter__(self):
         self._initialize()

--- a/docling_jobkit/connectors/source_processor.py
+++ b/docling_jobkit/connectors/source_processor.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from contextlib import AbstractContextManager
 from itertools import islice
-from typing import Callable, Generic, Iterator, Sequence, TypeVar
+from typing import Generic, Iterator, Sequence, TypeVar
 
 from pydantic import BaseModel, ConfigDict
 
@@ -22,12 +22,13 @@ class SourceDocumentRef(BaseModel, Generic[FileIdentifierT]):
 
 
 class DocumentChunk(BaseModel, Generic[SourceT, FileIdentifierT]):
-    """A serializable source chunk plus an optional local fetcher convenience.
+    """A serializable batch of connector-native document references.
 
-    Local/CLI callers may attach a fetcher so ``iter_documents()`` can materialize
-    streams lazily from the refs. Cross-process callers such as Ray must strip that
-    fetcher because it may capture initialized connector state that is not safe to
-    serialize.
+    A chunk carries only the root ``source`` plus the ``refs`` needed to fetch its
+    documents, so it is always safe to send across a process boundary (CLI
+    ``mp.Pool`` pickling or Ray cloudpickle). Workers reconstruct their own
+    processor via ``get_source_processor(chunk.source)`` and fetch each ref with
+    ``fetch_converter_source_by_ref``.
     """
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
@@ -35,17 +36,6 @@ class DocumentChunk(BaseModel, Generic[SourceT, FileIdentifierT]):
     source: SourceT
     refs: Sequence[SourceDocumentRef[FileIdentifierT]]
     chunk_index: int
-    _fetcher: Callable[[FileIdentifierT], DocumentStream] | None = None
-
-    def __init__(
-        self,
-        source: SourceT,
-        refs: Sequence[SourceDocumentRef[FileIdentifierT]],
-        chunk_index: int,
-        fetcher: Callable[[FileIdentifierT], DocumentStream] | None = None,
-    ):
-        super().__init__(source=source, refs=refs, chunk_index=chunk_index)
-        self._fetcher = fetcher
 
     @property
     def ids(self) -> list[FileIdentifierT]:
@@ -54,29 +44,6 @@ class DocumentChunk(BaseModel, Generic[SourceT, FileIdentifierT]):
     @property
     def index(self) -> int:
         return self.chunk_index
-
-    def iter_documents(self) -> Iterator[DocumentStream]:
-        """Materialize documents for local callers when a fetcher is attached."""
-        if self._fetcher is None:
-            raise RuntimeError("DocumentChunk does not have an attached fetcher.")
-        for ref in self.refs:
-            yield self._fetcher(ref.id)
-
-    def for_transport(self) -> "DocumentChunk[SourceT, FileIdentifierT]":
-        """Return a fetcher-stripped copy safe to send across a process boundary.
-
-        The ``_fetcher`` is a bound method of an initialized connector that may
-        capture unpicklable state (e.g. a boto3 client with thread locks). Any
-        chunk crossing a process boundary — CLI ``mp.Pool`` (pickle) or Ray
-        (cloudpickle) — must carry only ``source`` + ``refs``; the worker
-        reconstructs its own processor via ``get_source_processor(chunk.source)``
-        and fetches lazily with ``fetch_converter_source_by_ref``.
-        """
-        return DocumentChunk(
-            source=self.source,
-            refs=self.refs,
-            chunk_index=self.chunk_index,
-        )
 
 
 class BaseSourceProcessor(
@@ -212,7 +179,6 @@ class BaseSourceProcessor(
                 source=self.source,
                 refs=refs,
                 chunk_index=chunk_index,
-                fetcher=self._fetch_document_by_id,
             )
 
             chunk_index += 1

--- a/docling_jobkit/connectors/source_processor_factory.py
+++ b/docling_jobkit/connectors/source_processor_factory.py
@@ -1,10 +1,6 @@
 from docling.datamodel.service.sources import FileSource, HttpSource, S3Coordinates
 
-from docling_jobkit.connectors.http_source_processor import HttpSourceProcessor
-from docling_jobkit.connectors.local_path_source_processor import (
-    LocalPathSourceProcessor,
-)
-from docling_jobkit.connectors.s3_source_processor import S3SourceProcessor
+from docling_jobkit.connectors.connector_factory import get_source_connector_factory
 from docling_jobkit.connectors.source_processor import BaseSourceProcessor
 from docling_jobkit.datamodel.task_sources import (
     TaskGoogleDriveSource,
@@ -20,18 +16,15 @@ def get_source_processor(
         | TaskGoogleDriveSource
         | TaskLocalPathSource
     ),
+    *,
+    allow_external_plugins: bool = False,
 ) -> BaseSourceProcessor:
-    if isinstance(source, (FileSource, HttpSource)):
-        return HttpSourceProcessor(source)
-    elif isinstance(source, S3Coordinates):
-        return S3SourceProcessor(source)
-    elif isinstance(source, TaskGoogleDriveSource):
-        from docling_jobkit.connectors.google_drive_source_processor import (
-            GoogleDriveSourceProcessor,
-        )
+    """Instantiate the source processor for ``source`` via the connector factory.
 
-        return GoogleDriveSourceProcessor(source)
-    elif isinstance(source, TaskLocalPathSource):
-        return LocalPathSourceProcessor(source)
-
-    raise RuntimeError(f"No source processor for this source. {type(source)=}")
+    Thin backward-compatible wrapper: dispatch is now driven by the pluggy-based
+    :class:`SourceConnectorFactory` (keyed on the config model's ``kind``), so new
+    source connectors are added by registering a plugin rather than editing this
+    function.
+    """
+    factory = get_source_connector_factory(allow_external_plugins)
+    return factory.create_instance(source)

--- a/docling_jobkit/connectors/target_processor.py
+++ b/docling_jobkit/connectors/target_processor.py
@@ -3,6 +3,8 @@ from contextlib import AbstractContextManager
 from pathlib import Path
 from typing import BinaryIO
 
+from pydantic import BaseModel
+
 
 class BaseTargetProcessor(AbstractContextManager, ABC):
     """
@@ -12,6 +14,18 @@ class BaseTargetProcessor(AbstractContextManager, ABC):
 
     def __init__(self):
         self._initialized = False
+
+    @classmethod
+    def get_config_types(cls) -> tuple[type[BaseModel], ...]:
+        """Config (pydantic) models this processor accepts.
+
+        Each returned model must carry a ``Literal`` ``kind`` field. The connector
+        factory keys its registry on these types.
+        """
+        raise NotImplementedError(
+            f"{cls.__name__} must implement get_config_types() to be registered "
+            "as a connector plugin."
+        )
 
     def __enter__(self):
         self._initialize()

--- a/docling_jobkit/connectors/target_processor_factory.py
+++ b/docling_jobkit/connectors/target_processor_factory.py
@@ -1,30 +1,20 @@
-from docling.datamodel.service.targets import PutTarget, S3Target
-
-from docling_jobkit.connectors.http_put_target_processor import HttpPutTargetProcessor
-from docling_jobkit.connectors.local_path_target_processor import (
-    LocalPathTargetProcessor,
-)
-from docling_jobkit.connectors.s3_target_processor import S3TargetProcessor
+from docling_jobkit.connectors.connector_factory import get_target_connector_factory
 from docling_jobkit.connectors.target_processor import BaseTargetProcessor
-from docling_jobkit.datamodel.task_targets import (
-    GoogleDriveTarget,
-    LocalPathTarget,
-    TaskTarget,
-)
+from docling_jobkit.datamodel.task_targets import TaskTarget
 
 
-def get_target_processor(target: TaskTarget) -> BaseTargetProcessor:
-    if isinstance(target, PutTarget):
-        return HttpPutTargetProcessor(target)
-    if isinstance(target, S3Target):
-        return S3TargetProcessor(target)
-    if isinstance(target, GoogleDriveTarget):
-        from docling_jobkit.connectors.google_drive_target_processor import (
-            GoogleDriveTargetProcessor,
-        )
+def get_target_processor(
+    target: TaskTarget,
+    *,
+    allow_external_plugins: bool = False,
+) -> BaseTargetProcessor:
+    """Instantiate the target processor for ``target`` via the connector factory.
 
-        return GoogleDriveTargetProcessor(target)
-    if isinstance(target, LocalPathTarget):
-        return LocalPathTargetProcessor(target)
-
-    raise RuntimeError(f"No target processor for this target. {type(target)=}")
+    Thin backward-compatible wrapper: dispatch is now driven by the pluggy-based
+    :class:`TargetConnectorFactory` (keyed on the config model's ``kind``), so new
+    target connectors are added by registering a plugin rather than editing this
+    function. Service-only targets (in-body / zip / presigned) are handled by the
+    result-export path and are intentionally not registered here.
+    """
+    factory = get_target_connector_factory(allow_external_plugins)
+    return factory.create_instance(target)

--- a/docling_jobkit/convert/chunk_execution.py
+++ b/docling_jobkit/convert/chunk_execution.py
@@ -1,11 +1,10 @@
 """Shared, low-memory consumption of a transport ``DocumentChunk``.
 
 Both the CLI multiprocessing workers and the Ray converter replica receive a
-fetcher-stripped :class:`DocumentChunk` (see ``DocumentChunk.for_transport``) and
-need to turn its ``refs`` into converter inputs. This module centralizes that step
-so the same logic runs everywhere and keeps peak memory bounded to a single
-in-flight document: sources are fetched lazily, one at a time, as the converter
-pulls them.
+:class:`DocumentChunk` (source + refs) and need to turn its ``refs`` into converter
+inputs. This module centralizes that step so the same logic runs everywhere and
+keeps peak memory bounded to a single in-flight document: sources are fetched
+lazily, one at a time, as the converter pulls them.
 """
 
 from contextlib import contextmanager
@@ -28,6 +27,12 @@ def _resolve_headers(
     ``headers_for_ref`` only inspects the ref metadata, so this pre-pass is cheap.
     Headers are assumed uniform across a chunk (the converter accepts a single
     ``headers`` argument); the first non-empty value wins.
+
+    NOTE: this per-chunk-uniform assumption is a workaround for
+    ``DoclingConverterManager.convert_documents`` taking a single ``headers``
+    argument. The proper fix is to let the converter accept per-document
+    ``HttpSourceRequest`` inputs (which already carry their own headers); that is
+    an upstream change in docling and out of scope here.
     """
     for ref in refs:
         ref_headers = source_processor.headers_for_ref(ref)

--- a/docling_jobkit/convert/chunk_execution.py
+++ b/docling_jobkit/convert/chunk_execution.py
@@ -1,0 +1,66 @@
+"""Shared, low-memory consumption of a transport ``DocumentChunk``.
+
+Both the CLI multiprocessing workers and the Ray converter replica receive a
+fetcher-stripped :class:`DocumentChunk` (see ``DocumentChunk.for_transport``) and
+need to turn its ``refs`` into converter inputs. This module centralizes that step
+so the same logic runs everywhere and keeps peak memory bounded to a single
+in-flight document: sources are fetched lazily, one at a time, as the converter
+pulls them.
+"""
+
+from contextlib import contextmanager
+from typing import Any, Iterator, Optional
+
+from docling_jobkit.connectors.source_processor import (
+    ConverterSource,
+    DocumentChunk,
+    SourceDocumentRef,
+)
+from docling_jobkit.connectors.source_processor_factory import get_source_processor
+
+
+def _resolve_headers(
+    source_processor: Any,
+    refs: list[SourceDocumentRef] | Any,
+) -> Optional[dict[str, Any]]:
+    """Resolve per-request headers without fetching any document bytes.
+
+    ``headers_for_ref`` only inspects the ref metadata, so this pre-pass is cheap.
+    Headers are assumed uniform across a chunk (the converter accepts a single
+    ``headers`` argument); the first non-empty value wins.
+    """
+    for ref in refs:
+        ref_headers = source_processor.headers_for_ref(ref)
+        if ref_headers:
+            return ref_headers
+    return None
+
+
+@contextmanager
+def open_chunk_sources(
+    chunk: DocumentChunk,
+    *,
+    max_file_size: int | None = None,
+    allow_external_plugins: bool = False,
+) -> Iterator[tuple[Iterator[ConverterSource], Optional[dict[str, Any]]]]:
+    """Open a transport chunk and yield ``(sources_iter, headers)``.
+
+    ``sources_iter`` is a generator that materializes ONE converter source
+    (``DocumentStream`` or remote URL string) per ``next()`` call, so feeding it
+    to ``DoclingConverterManager.convert_documents`` keeps at most one document
+    in memory at a time. The source processor stays open for the lifetime of the
+    ``with`` block, which must therefore enclose the full conversion loop.
+    """
+    with get_source_processor(
+        chunk.source, allow_external_plugins=allow_external_plugins
+    ) as source_processor:
+        headers = _resolve_headers(source_processor, chunk.refs)
+
+        def _iter() -> Iterator[ConverterSource]:
+            for ref in chunk.refs:
+                yield source_processor.fetch_converter_source_by_ref(
+                    ref,
+                    max_file_size=max_file_size,
+                )
+
+        yield _iter(), headers

--- a/docling_jobkit/convert/export.py
+++ b/docling_jobkit/convert/export.py
@@ -1,0 +1,304 @@
+"""Shared document-export primitives used by every execution path.
+
+Both the CLI and the orchestrators must turn converted documents into artifact
+files and push them through a :class:`BaseTargetProcessor`. Centralizing that
+materialize→upload step here means the *same code* runs whether a connector is
+exercised locally (CLI) or on distributed compute (Ray/RQ/local orchestrator),
+and keeps memory bounded: callers stream documents one at a time and release each
+document's heavy ``DoclingDocument`` reference right after its artifacts are sent.
+"""
+
+import logging
+import shutil
+import zipfile
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+from docling.datamodel.document import ConversionStatus
+from docling_core.types.doc import ImageRefMode
+
+from docling_jobkit.connectors.artifact_paths import ArtifactType
+from docling_jobkit.connectors.target_processor import BaseTargetProcessor
+from docling_jobkit.datamodel.exportable_document import ExportableDocument
+
+_log = logging.getLogger(__name__)
+
+
+@dataclass
+class ExportedArtifactFile:
+    artifact_type: ArtifactType
+    path: Path
+    target_filename: str
+    mime_type: str
+
+
+# Backwards-compatible private alias (historically defined in results.py).
+_ExportedArtifactFile = ExportedArtifactFile
+
+
+def is_exportable_status(status: ConversionStatus) -> bool:
+    return status in (ConversionStatus.SUCCESS, ConversionStatus.PARTIAL_SUCCESS)
+
+
+# Backwards-compatible private alias.
+_is_exportable_status = is_exportable_status
+
+
+def materialize_document_exports(
+    exportable_document: ExportableDocument,
+    output_dir: Path,
+    *,
+    export_json: bool,
+    export_html: bool,
+    export_md: bool,
+    export_txt: bool,
+    export_doctags: bool,
+    image_export_mode: ImageRefMode,
+    md_page_break_placeholder: str,
+    bundle_resources: bool,
+) -> list[ExportedArtifactFile]:
+    """Write the requested export formats to ``output_dir`` and return their files.
+
+    When ``bundle_resources`` is set and referenced artifacts (images) were
+    written, a self-contained ``<doc>_bundle.zip`` is also produced.
+    """
+    if not (
+        is_exportable_status(exportable_document.status)
+        and exportable_document.document is not None
+    ):
+        return []
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    artifacts_dir = Path("artifacts")
+    generated: list[ExportedArtifactFile] = []
+    doc_filename = exportable_document.file.stem
+
+    if export_json:
+        fname = output_dir / f"{doc_filename}.json"
+        _log.info(f"writing JSON output to {fname}")
+        exportable_document.document.save_as_json(
+            filename=fname,
+            image_mode=image_export_mode,
+            artifacts_dir=artifacts_dir,
+        )
+        generated.append(
+            ExportedArtifactFile(
+                artifact_type="json",
+                path=fname,
+                target_filename=fname.name,
+                mime_type="application/json",
+            )
+        )
+
+    if export_html:
+        fname = output_dir / f"{doc_filename}.html"
+        _log.info(f"writing HTML output to {fname}")
+        exportable_document.document.save_as_html(
+            filename=fname,
+            image_mode=image_export_mode,
+            artifacts_dir=artifacts_dir,
+        )
+        generated.append(
+            ExportedArtifactFile(
+                artifact_type="html",
+                path=fname,
+                target_filename=fname.name,
+                mime_type="text/html",
+            )
+        )
+
+    if export_txt:
+        fname = output_dir / f"{doc_filename}.txt"
+        _log.info(f"writing TXT output to {fname}")
+        exportable_document.document.save_as_markdown(
+            filename=fname,
+            strict_text=True,
+            image_mode=ImageRefMode.PLACEHOLDER,
+        )
+        generated.append(
+            ExportedArtifactFile(
+                artifact_type="text",
+                path=fname,
+                target_filename=fname.name,
+                mime_type="text/plain",
+            )
+        )
+
+    if export_md:
+        fname = output_dir / f"{doc_filename}.md"
+        _log.info(f"writing Markdown output to {fname}")
+        exportable_document.document.save_as_markdown(
+            filename=fname,
+            artifacts_dir=artifacts_dir,
+            image_mode=image_export_mode,
+            page_break_placeholder=md_page_break_placeholder or None,
+        )
+        generated.append(
+            ExportedArtifactFile(
+                artifact_type="markdown",
+                path=fname,
+                target_filename=fname.name,
+                mime_type="text/markdown",
+            )
+        )
+
+    if export_doctags:
+        fname = output_dir / f"{doc_filename}.doctags"
+        _log.info(f"writing Doc Tags output to {fname}")
+        exportable_document.document.save_as_doctags(filename=fname)
+        generated.append(
+            ExportedArtifactFile(
+                artifact_type="doctags",
+                path=fname,
+                target_filename=fname.name,
+                mime_type="text/plain",
+            )
+        )
+
+    artifacts_path = output_dir / artifacts_dir
+    if bundle_resources and artifacts_path.exists() and any(artifacts_path.iterdir()):
+        bundle_path = output_dir / f"{doc_filename}_bundle.zip"
+        with zipfile.ZipFile(bundle_path, "w", zipfile.ZIP_DEFLATED) as bundle_zip:
+            # Place the exported documents alongside the artifacts directory,
+            # using the same relative layout (`<artifacts_dir>/<file>`) that
+            # the documents themselves reference, so the bundle is
+            # self-contained and resolvable without any path rewriting.
+            for artifact in generated:
+                bundle_zip.write(artifact.path, arcname=artifact.target_filename)
+            for artifact_file in sorted(artifacts_path.rglob("*")):
+                if artifact_file.is_file():
+                    bundle_zip.write(
+                        artifact_file,
+                        arcname=str(
+                            artifacts_dir / artifact_file.relative_to(artifacts_path)
+                        ),
+                    )
+        generated.append(
+            ExportedArtifactFile(
+                artifact_type="resource_bundle",
+                path=bundle_path,
+                target_filename=bundle_path.name,
+                mime_type="application/zip",
+            )
+        )
+
+    return generated
+
+
+def upload_exportable_document(
+    *,
+    target_processor: BaseTargetProcessor,
+    exportable_document: ExportableDocument,
+    document_dir: Path,
+    export_json: bool,
+    export_html: bool,
+    export_md: bool,
+    export_txt: bool,
+    export_doctags: bool,
+    image_export_mode: ImageRefMode,
+    md_page_break_placeholder: str,
+    target_filename_fn: Callable[[str], str],
+    bundle_resources: bool = True,
+) -> list[ExportedArtifactFile]:
+    """Materialize one document's exports and upload them via ``target_processor``.
+
+    ``target_filename_fn(artifact_filename) -> target_key`` is the single seam
+    that controls the final layout, letting each caller keep its own convention
+    (e.g. ``<source_key>/<artifact>`` for orchestrators or ``json/<name>.json``
+    for the CLI) while the materialize+upload code itself stays shared.
+    """
+    artifacts = materialize_document_exports(
+        exportable_document,
+        document_dir,
+        export_json=export_json,
+        export_html=export_html,
+        export_md=export_md,
+        export_txt=export_txt,
+        export_doctags=export_doctags,
+        image_export_mode=image_export_mode,
+        md_page_break_placeholder=md_page_break_placeholder,
+        bundle_resources=bundle_resources,
+    )
+    for artifact in artifacts:
+        target_processor.upload_file(
+            filename=artifact.path,
+            target_filename=target_filename_fn(artifact.target_filename),
+            content_type=artifact.mime_type,
+        )
+    return artifacts
+
+
+def release_exportable_document_references(
+    *exportable_documents: ExportableDocument,
+) -> None:
+    for exportable_document in exportable_documents:
+        exportable_document.document = None
+
+
+def cleanup_document_output_dir(document_dir: Path) -> None:
+    shutil.rmtree(document_dir, ignore_errors=True)
+
+
+def export_documents_to_target(
+    *,
+    exportable_documents: Iterable[ExportableDocument],
+    target_processor: BaseTargetProcessor,
+    output_dir: Path,
+    export_json: bool,
+    export_html: bool,
+    export_md: bool,
+    export_txt: bool,
+    export_doctags: bool,
+    image_export_mode: ImageRefMode,
+    md_page_break_placeholder: str,
+    target_filename_fn: Callable[[ExportableDocument, str], str],
+    bundle_resources: bool = True,
+    on_document_uploaded: Callable[[ExportableDocument], None] | None = None,
+) -> int:
+    """Stream documents to ``target_processor``, releasing each after upload.
+
+    Consumes ``exportable_documents`` lazily so peak memory stays bounded to a
+    single document: each one is materialized into its own subdirectory of
+    ``output_dir``, uploaded, then its ``DoclingDocument`` reference and scratch
+    files are released before the next is pulled. Returns the number of
+    exportable documents uploaded.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    uploaded = 0
+    for index, exportable_document in enumerate(exportable_documents):
+        document_index = (
+            exportable_document.source_index
+            if exportable_document.source_index is not None
+            else index
+        )
+        document_dir = output_dir / f"{document_index:06d}"
+
+        def _document_target_filename(
+            artifact_filename: str, _doc: ExportableDocument = exportable_document
+        ) -> str:
+            return target_filename_fn(_doc, artifact_filename)
+
+        try:
+            artifacts = upload_exportable_document(
+                target_processor=target_processor,
+                exportable_document=exportable_document,
+                document_dir=document_dir,
+                export_json=export_json,
+                export_html=export_html,
+                export_md=export_md,
+                export_txt=export_txt,
+                export_doctags=export_doctags,
+                image_export_mode=image_export_mode,
+                md_page_break_placeholder=md_page_break_placeholder,
+                target_filename_fn=_document_target_filename,
+                bundle_resources=bundle_resources,
+            )
+            if artifacts:
+                uploaded += 1
+            if on_document_uploaded is not None:
+                on_document_uploaded(exportable_document)
+        finally:
+            release_exportable_document_references(exportable_document)
+            cleanup_document_output_dir(document_dir)
+    return uploaded

--- a/docling_jobkit/convert/export.py
+++ b/docling_jobkit/convert/export.py
@@ -6,6 +6,9 @@ materialize→upload step here means the *same code* runs whether a connector is
 exercised locally (CLI) or on distributed compute (Ray/RQ/local orchestrator),
 and keeps memory bounded: callers stream documents one at a time and release each
 document's heavy ``DoclingDocument`` reference right after its artifacts are sent.
+
+Only :func:`export_documents_to_target` is public; the other helpers are internal
+building blocks (underscore-prefixed) that ``convert.results`` reuses directly.
 """
 
 import logging
@@ -26,26 +29,18 @@ _log = logging.getLogger(__name__)
 
 
 @dataclass
-class ExportedArtifactFile:
+class _ExportedArtifactFile:
     artifact_type: ArtifactType
     path: Path
     target_filename: str
     mime_type: str
 
 
-# Backwards-compatible private alias (historically defined in results.py).
-_ExportedArtifactFile = ExportedArtifactFile
-
-
-def is_exportable_status(status: ConversionStatus) -> bool:
+def _is_exportable_status(status: ConversionStatus) -> bool:
     return status in (ConversionStatus.SUCCESS, ConversionStatus.PARTIAL_SUCCESS)
 
 
-# Backwards-compatible private alias.
-_is_exportable_status = is_exportable_status
-
-
-def materialize_document_exports(
+def _materialize_document_exports(
     exportable_document: ExportableDocument,
     output_dir: Path,
     *,
@@ -57,21 +52,21 @@ def materialize_document_exports(
     image_export_mode: ImageRefMode,
     md_page_break_placeholder: str,
     bundle_resources: bool,
-) -> list[ExportedArtifactFile]:
+) -> list[_ExportedArtifactFile]:
     """Write the requested export formats to ``output_dir`` and return their files.
 
     When ``bundle_resources`` is set and referenced artifacts (images) were
     written, a self-contained ``<doc>_bundle.zip`` is also produced.
     """
     if not (
-        is_exportable_status(exportable_document.status)
+        _is_exportable_status(exportable_document.status)
         and exportable_document.document is not None
     ):
         return []
 
     output_dir.mkdir(parents=True, exist_ok=True)
     artifacts_dir = Path("artifacts")
-    generated: list[ExportedArtifactFile] = []
+    generated: list[_ExportedArtifactFile] = []
     doc_filename = exportable_document.file.stem
 
     if export_json:
@@ -83,7 +78,7 @@ def materialize_document_exports(
             artifacts_dir=artifacts_dir,
         )
         generated.append(
-            ExportedArtifactFile(
+            _ExportedArtifactFile(
                 artifact_type="json",
                 path=fname,
                 target_filename=fname.name,
@@ -100,7 +95,7 @@ def materialize_document_exports(
             artifacts_dir=artifacts_dir,
         )
         generated.append(
-            ExportedArtifactFile(
+            _ExportedArtifactFile(
                 artifact_type="html",
                 path=fname,
                 target_filename=fname.name,
@@ -117,7 +112,7 @@ def materialize_document_exports(
             image_mode=ImageRefMode.PLACEHOLDER,
         )
         generated.append(
-            ExportedArtifactFile(
+            _ExportedArtifactFile(
                 artifact_type="text",
                 path=fname,
                 target_filename=fname.name,
@@ -135,7 +130,7 @@ def materialize_document_exports(
             page_break_placeholder=md_page_break_placeholder or None,
         )
         generated.append(
-            ExportedArtifactFile(
+            _ExportedArtifactFile(
                 artifact_type="markdown",
                 path=fname,
                 target_filename=fname.name,
@@ -148,7 +143,7 @@ def materialize_document_exports(
         _log.info(f"writing Doc Tags output to {fname}")
         exportable_document.document.save_as_doctags(filename=fname)
         generated.append(
-            ExportedArtifactFile(
+            _ExportedArtifactFile(
                 artifact_type="doctags",
                 path=fname,
                 target_filename=fname.name,
@@ -175,7 +170,7 @@ def materialize_document_exports(
                         ),
                     )
         generated.append(
-            ExportedArtifactFile(
+            _ExportedArtifactFile(
                 artifact_type="resource_bundle",
                 path=bundle_path,
                 target_filename=bundle_path.name,
@@ -186,7 +181,7 @@ def materialize_document_exports(
     return generated
 
 
-def upload_exportable_document(
+def _upload_exportable_document(
     *,
     target_processor: BaseTargetProcessor,
     exportable_document: ExportableDocument,
@@ -200,7 +195,7 @@ def upload_exportable_document(
     md_page_break_placeholder: str,
     target_filename_fn: Callable[[str], str],
     bundle_resources: bool = True,
-) -> list[ExportedArtifactFile]:
+) -> list[_ExportedArtifactFile]:
     """Materialize one document's exports and upload them via ``target_processor``.
 
     ``target_filename_fn(artifact_filename) -> target_key`` is the single seam
@@ -208,7 +203,7 @@ def upload_exportable_document(
     (e.g. ``<source_key>/<artifact>`` for orchestrators or ``json/<name>.json``
     for the CLI) while the materialize+upload code itself stays shared.
     """
-    artifacts = materialize_document_exports(
+    artifacts = _materialize_document_exports(
         exportable_document,
         document_dir,
         export_json=export_json,
@@ -229,14 +224,14 @@ def upload_exportable_document(
     return artifacts
 
 
-def release_exportable_document_references(
+def _release_exportable_document_references(
     *exportable_documents: ExportableDocument,
 ) -> None:
     for exportable_document in exportable_documents:
         exportable_document.document = None
 
 
-def cleanup_document_output_dir(document_dir: Path) -> None:
+def _cleanup_document_output_dir(document_dir: Path) -> None:
     shutil.rmtree(document_dir, ignore_errors=True)
 
 
@@ -280,7 +275,7 @@ def export_documents_to_target(
             return target_filename_fn(_doc, artifact_filename)
 
         try:
-            artifacts = upload_exportable_document(
+            artifacts = _upload_exportable_document(
                 target_processor=target_processor,
                 exportable_document=exportable_document,
                 document_dir=document_dir,
@@ -299,6 +294,6 @@ def export_documents_to_target(
             if on_document_uploaded is not None:
                 on_document_uploaded(exportable_document)
         finally:
-            release_exportable_document_references(exportable_document)
-            cleanup_document_output_dir(document_dir)
+            _release_exportable_document_references(exportable_document)
+            _cleanup_document_output_dir(document_dir)
     return uploaded

--- a/docling_jobkit/convert/results.py
+++ b/docling_jobkit/convert/results.py
@@ -1,7 +1,6 @@
 import logging
 import shutil
 import time
-import zipfile
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from enum import Enum
@@ -29,14 +28,20 @@ from docling_core.types.doc import ImageRefMode
 
 from docling_jobkit.config.target_config import S3PresignedConfig
 from docling_jobkit.connectors.artifact_paths import (
-    ArtifactType,
     hash_path_component,
 )
 from docling_jobkit.connectors.s3_presigned_target_processor import (
     S3PresignedTargetProcessor,
 )
-from docling_jobkit.connectors.s3_target_processor import S3TargetProcessor
 from docling_jobkit.connectors.target_processor import BaseTargetProcessor
+from docling_jobkit.connectors.target_processor_factory import get_target_processor
+from docling_jobkit.convert.export import (
+    _is_exportable_status,
+    cleanup_document_output_dir as _cleanup_document_output_dir,
+    materialize_document_exports as _materialize_document_exports,
+    release_exportable_document_references as _release_exportable_document_references,
+    upload_exportable_document,
+)
 from docling_jobkit.datamodel.exportable_document import (
     ExportableDocument,
     source_to_public_uri,
@@ -53,6 +58,10 @@ from docling_jobkit.datamodel.result import (
 )
 from docling_jobkit.datamodel.source_identity import SourceIdentity
 from docling_jobkit.datamodel.task import Task
+from docling_jobkit.datamodel.task_targets import (
+    GoogleDriveTarget,
+    LocalPathTarget,
+)
 from docling_jobkit.public_errors import (
     TargetWriteError,
     build_public_error_item,
@@ -66,14 +75,6 @@ _log = logging.getLogger(__name__)
 
 
 @dataclass
-class _ExportedArtifactFile:
-    artifact_type: ArtifactType
-    path: Path
-    target_filename: str
-    mime_type: str
-
-
-@dataclass
 class _ProcessedExportResults:
     task_result: DoclingTaskResult
     processed_docs: list[ProcessedDocsItem]
@@ -84,10 +85,6 @@ class CallbackMode(str, Enum):
 
     FULL = "full"
     CHILD_ONLY = "child_only"
-
-
-def _is_exportable_status(status: ConversionStatus) -> bool:
-    return status in (ConversionStatus.SUCCESS, ConversionStatus.PARTIAL_SUCCESS)
 
 
 def _count_document_statuses(
@@ -404,142 +401,6 @@ def _resolve_source_identity(
     )
 
 
-def _materialize_document_exports(
-    exportable_document: ExportableDocument,
-    output_dir: Path,
-    *,
-    export_json: bool,
-    export_html: bool,
-    export_md: bool,
-    export_txt: bool,
-    export_doctags: bool,
-    image_export_mode: ImageRefMode,
-    md_page_break_placeholder: str,
-    bundle_resources: bool,
-) -> list[_ExportedArtifactFile]:
-    if not (
-        _is_exportable_status(exportable_document.status)
-        and exportable_document.document is not None
-    ):
-        return []
-
-    output_dir.mkdir(parents=True, exist_ok=True)
-    artifacts_dir = Path("artifacts")
-    generated: list[_ExportedArtifactFile] = []
-    doc_filename = exportable_document.file.stem
-
-    if export_json:
-        fname = output_dir / f"{doc_filename}.json"
-        _log.info(f"writing JSON output to {fname}")
-        exportable_document.document.save_as_json(
-            filename=fname,
-            image_mode=image_export_mode,
-            artifacts_dir=artifacts_dir,
-        )
-        generated.append(
-            _ExportedArtifactFile(
-                artifact_type="json",
-                path=fname,
-                target_filename=fname.name,
-                mime_type="application/json",
-            )
-        )
-
-    if export_html:
-        fname = output_dir / f"{doc_filename}.html"
-        _log.info(f"writing HTML output to {fname}")
-        exportable_document.document.save_as_html(
-            filename=fname,
-            image_mode=image_export_mode,
-            artifacts_dir=artifacts_dir,
-        )
-        generated.append(
-            _ExportedArtifactFile(
-                artifact_type="html",
-                path=fname,
-                target_filename=fname.name,
-                mime_type="text/html",
-            )
-        )
-
-    if export_txt:
-        fname = output_dir / f"{doc_filename}.txt"
-        _log.info(f"writing TXT output to {fname}")
-        exportable_document.document.save_as_markdown(
-            filename=fname,
-            strict_text=True,
-            image_mode=ImageRefMode.PLACEHOLDER,
-        )
-        generated.append(
-            _ExportedArtifactFile(
-                artifact_type="text",
-                path=fname,
-                target_filename=fname.name,
-                mime_type="text/plain",
-            )
-        )
-
-    if export_md:
-        fname = output_dir / f"{doc_filename}.md"
-        _log.info(f"writing Markdown output to {fname}")
-        exportable_document.document.save_as_markdown(
-            filename=fname,
-            artifacts_dir=artifacts_dir,
-            image_mode=image_export_mode,
-            page_break_placeholder=md_page_break_placeholder or None,
-        )
-        generated.append(
-            _ExportedArtifactFile(
-                artifact_type="markdown",
-                path=fname,
-                target_filename=fname.name,
-                mime_type="text/markdown",
-            )
-        )
-
-    if export_doctags:
-        fname = output_dir / f"{doc_filename}.doctags"
-        _log.info(f"writing Doc Tags output to {fname}")
-        exportable_document.document.save_as_doctags(filename=fname)
-        generated.append(
-            _ExportedArtifactFile(
-                artifact_type="doctags",
-                path=fname,
-                target_filename=fname.name,
-                mime_type="text/plain",
-            )
-        )
-
-    artifacts_path = output_dir / artifacts_dir
-    if bundle_resources and artifacts_path.exists() and any(artifacts_path.iterdir()):
-        bundle_path = output_dir / f"{doc_filename}_bundle.zip"
-        with zipfile.ZipFile(bundle_path, "w", zipfile.ZIP_DEFLATED) as bundle_zip:
-            # Place the exported documents alongside the artifacts directory,
-            # using the same relative layout (`<artifacts_dir>/<file>`) that
-            # the documents themselves reference, so the bundle is
-            # self-contained and resolvable without any path rewriting.
-            for artifact in generated:
-                bundle_zip.write(artifact.path, arcname=artifact.target_filename)
-            for artifact_file in sorted(artifacts_path.rglob("*")):
-                if artifact_file.is_file():
-                    bundle_zip.write(
-                        artifact_file,
-                        arcname=str(
-                            artifacts_dir / artifact_file.relative_to(artifacts_path)
-                        ),
-                    )
-        generated.append(
-            _ExportedArtifactFile(
-                artifact_type="resource_bundle",
-                path=bundle_path,
-                target_filename=bundle_path.name,
-                mime_type="application/zip",
-            )
-        )
-
-    return generated
-
-
 def _upload_document_as_presigned_artifact(
     *,
     task: Task,
@@ -612,9 +473,10 @@ def _upload_document_via_processor(
     """
     source = _resolve_source_identity(task, exportable_document, response_index)
     document_dir = output_dir / f"{source.source_index:06d}"
-    for artifact in _materialize_document_exports(
-        exportable_document,
-        document_dir,
+    upload_exportable_document(
+        target_processor=target_processor,
+        exportable_document=exportable_document,
+        document_dir=document_dir,
         export_json=export_json,
         export_html=export_html,
         export_md=export_md,
@@ -622,27 +484,21 @@ def _upload_document_via_processor(
         export_doctags=export_doctags,
         image_export_mode=image_export_mode,
         md_page_break_placeholder=md_page_break_placeholder,
-        bundle_resources=True,
-    ):
-        target_filename = (
-            target_filename_fn(source, artifact.target_filename)
+        target_filename_fn=(
+            (lambda fn: target_filename_fn(source, fn))
             if target_filename_fn is not None
-            else artifact.target_filename
-        )
-        target_processor.upload_file(
-            filename=artifact.path,
-            target_filename=target_filename,
-            content_type=artifact.mime_type,
-        )
+            else (lambda fn: fn)
+        ),
+    )
 
 
-def _upload_document_to_s3_target(
+def _upload_document_to_storage_target(
     *,
     task: Task,
     exportable_document: ExportableDocument,
     response_index: int,
     output_dir: Path,
-    target_processor: S3TargetProcessor,
+    target_processor: BaseTargetProcessor,
     export_json: bool,
     export_html: bool,
     export_md: bool,
@@ -651,6 +507,12 @@ def _upload_document_to_s3_target(
     image_export_mode: ImageRefMode,
     md_page_break_placeholder: str,
 ) -> None:
+    """Upload one document to any storage target via ``get_target_processor``.
+
+    Used for every user-owned storage target (S3, local path, Google Drive, …):
+    the per-source artifact layout (``<source_key>/<artifact>``) is identical, and
+    each target processor applies its own prefix/root when writing.
+    """
     _upload_document_via_processor(
         task=task,
         exportable_document=exportable_document,
@@ -667,17 +529,6 @@ def _upload_document_to_s3_target(
         target_filename_fn=lambda source,
         artifact_filename: f"{source.source_key}/{artifact_filename}",
     )
-
-
-def _cleanup_document_output_dir(document_dir: Path) -> None:
-    shutil.rmtree(document_dir, ignore_errors=True)
-
-
-def _release_exportable_document_references(
-    *exportable_documents: ExportableDocument,
-) -> None:
-    for exportable_document in exportable_documents:
-        exportable_document.document = None
 
 
 def _process_remote_document(
@@ -811,11 +662,13 @@ def _process_remote_exportable_results(
             raise RuntimeError("No documents were generated by Docling.")
 
         task_result: ResultType = PresignedArtifactResult(documents=presigned_documents)
-    elif isinstance(task.target, S3Target):
-        # User-owned S3 targets preserve the caller's bucket layout. The shorter
-        # per-source artifact path is computed here, and S3TargetProcessor prepends
-        # the user-provided target.key_prefix when uploading.
-        with S3TargetProcessor(task.target) as target_processor:
+    elif isinstance(task.target, (S3Target, LocalPathTarget, GoogleDriveTarget)):
+        # Every user-owned storage target is handled identically through the
+        # connector factory: the per-source artifact path is computed here and
+        # the target processor applies its own prefix/root (S3 key_prefix, local
+        # directory, Drive folder, …) when writing. Adding a new storage
+        # connector therefore needs no change in this module.
+        with get_target_processor(task.target) as target_processor:
             for idx, exportable_document in enumerate(exportable_documents):
                 final_document, processed_doc, _ = _process_remote_document(
                     task=task,
@@ -826,7 +679,7 @@ def _process_remote_exportable_results(
                     callback_invoker=callback_invoker,
                     debug_error_details=debug_error_details,
                     callback_mode=callback_mode,
-                    upload_document=lambda _source: _upload_document_to_s3_target(
+                    upload_document=lambda _source: _upload_document_to_storage_target(
                         task=task,
                         exportable_document=exportable_document,
                         response_index=idx,
@@ -913,7 +766,10 @@ def _process_exportable_results_internal(
     export_txt = OutputFormat.TEXT in conversion_options.to_formats
     export_doctags = OutputFormat.DOCTAGS in conversion_options.to_formats
 
-    if isinstance(task.target, (PresignedUrlTarget, S3Target)):
+    if isinstance(
+        task.target,
+        (PresignedUrlTarget, S3Target, LocalPathTarget, GoogleDriveTarget),
+    ):
         return _process_remote_exportable_results(
             task=task,
             exportable_documents=exportable_documents,

--- a/docling_jobkit/convert/results.py
+++ b/docling_jobkit/convert/results.py
@@ -36,11 +36,11 @@ from docling_jobkit.connectors.s3_presigned_target_processor import (
 from docling_jobkit.connectors.target_processor import BaseTargetProcessor
 from docling_jobkit.connectors.target_processor_factory import get_target_processor
 from docling_jobkit.convert.export import (
+    _cleanup_document_output_dir,
     _is_exportable_status,
-    cleanup_document_output_dir as _cleanup_document_output_dir,
-    materialize_document_exports as _materialize_document_exports,
-    release_exportable_document_references as _release_exportable_document_references,
-    upload_exportable_document,
+    _materialize_document_exports,
+    _release_exportable_document_references,
+    _upload_exportable_document,
 )
 from docling_jobkit.datamodel.exportable_document import (
     ExportableDocument,
@@ -473,7 +473,7 @@ def _upload_document_via_processor(
     """
     source = _resolve_source_identity(task, exportable_document, response_index)
     document_dir = output_dir / f"{source.source_index:06d}"
-    upload_exportable_document(
+    _upload_exportable_document(
         target_processor=target_processor,
         exportable_document=exportable_document,
         document_dir=document_dir,

--- a/docling_jobkit/datamodel/dynamic_unions.py
+++ b/docling_jobkit/datamodel/dynamic_unions.py
@@ -1,0 +1,116 @@
+"""Build pydantic discriminated unions from the registered connector plugins.
+
+The static unions in :mod:`docling_jobkit.datamodel.task_sources` /
+:mod:`docling_jobkit.datamodel.task_targets` cover the built-in connectors. When
+third-party connectors are enabled (``allow_external_plugins=True``), their config
+models must also be accepted when validating job configs (CLI) and when a worker
+re-validates a ``Task`` (RQ). These helpers build those unions from the connector
+factories so external ``kind`` values parse.
+
+``install_dynamic_unions`` must run once at process entry, before any ``Task`` is
+validated, with the same ``allow_external_plugins`` value as the submitter.
+"""
+
+import logging
+
+from docling_jobkit.connectors.connector_factory import (
+    get_source_connector_factory,
+    get_target_connector_factory,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def build_source_union(allow_external_plugins: bool = False):
+    """Discriminated union of all registered source-connector config models."""
+    return get_source_connector_factory(
+        allow_external_plugins
+    ).build_discriminated_union()
+
+
+def build_target_union(allow_external_plugins: bool = False):
+    """Discriminated union of all registered target-connector config models."""
+    return get_target_connector_factory(
+        allow_external_plugins
+    ).build_discriminated_union()
+
+
+def install_dynamic_unions(allow_external_plugins: bool = False) -> None:
+    """Rebind ``Task.target`` to include externally-registered target connectors.
+
+    With ``allow_external_plugins=False`` the rebuilt union contains exactly the
+    built-in connectors, so this is a no-op equivalent to the static annotation.
+    Service-only targets (in-body / zip / presigned) are preserved because they
+    remain part of the original ``TaskTarget`` annotation that this union extends.
+    """
+    if not allow_external_plugins:
+        return
+
+    # Import here to avoid an import cycle (task -> task_targets) and to keep the
+    # entry-point scan out of module import time.
+    from typing import Annotated, Union
+
+    from pydantic import Field
+
+    from docling.datamodel.service.targets import (
+        InBodyTarget,
+        PresignedUrlTarget,
+        PutTarget,
+        S3Target,
+        ZipTarget,
+    )
+
+    from docling_jobkit.datamodel.task import Task
+    from docling_jobkit.datamodel.task_targets import (
+        GoogleDriveTarget,
+        LocalPathTarget,
+    )
+
+    factory = get_target_connector_factory(allow_external_plugins)
+    # Service-only targets are never registered as connectors but must stay valid.
+    service_only = (InBodyTarget, ZipTarget, PresignedUrlTarget)
+    builtin = (S3Target, PutTarget, LocalPathTarget, GoogleDriveTarget)
+    external = tuple(
+        t
+        for t in factory.registered_config_types
+        if t not in builtin and t not in service_only
+    )
+    if not external:
+        return
+
+    members = (*service_only, *builtin, *external)
+    new_union = Annotated[Union[members], Field(discriminator="kind")]  # type: ignore[valid-type]
+
+    Task.model_fields["target"].annotation = new_union  # type: ignore[assignment]
+    Task.model_rebuild(force=True)
+    logger.info(
+        "Installed dynamic target union with external kinds: %s",
+        [factory.registered_meta[t].kind for t in external],
+    )
+
+
+def build_job_config_model(allow_external_plugins: bool = False):
+    """Build a CLI ``JobConfig``-shaped model whose source/target accept plugins."""
+    from pydantic import ConfigDict, create_model
+
+    from docling.datamodel.service.options import ConvertDocumentsOptions
+
+    source_union = build_source_union(allow_external_plugins)
+    target_union = build_target_union(allow_external_plugins)
+
+    return create_model(
+        "DynamicJobConfig",
+        __config__=ConfigDict(arbitrary_types_allowed=True),
+        options=(ConvertDocumentsOptions, ConvertDocumentsOptions()),
+        sources=(list[source_union], ...),  # type: ignore[valid-type]
+        target=(target_union, ...),  # type: ignore[valid-type]
+    )
+
+
+# Re-exported for callers that only need the optional set helper.
+__all__ = [
+    "build_job_config_model",
+    "build_source_union",
+    "build_target_union",
+    "install_dynamic_unions",
+]

--- a/docling_jobkit/orchestrators/base_orchestrator.py
+++ b/docling_jobkit/orchestrators/base_orchestrator.py
@@ -35,13 +35,35 @@ class ProgressInvalid(OrchestratorError):
     pass
 
 
+class TargetNotAllowedError(OrchestratorError):
+    """Raised at enqueue when a target kind is not permitted by the orchestrator."""
+
+
 class BaseOrchestrator(ABC):
     def __init__(self):
         self.tasks: dict[str, Task] = {}
         self.notifier: Optional["BaseNotifier"] = None
+        # Optional allowlist of target ``kind`` values this orchestrator accepts.
+        # ``None`` means "allow all". Concrete orchestrators set this from config.
+        self.allowed_target_kinds: Optional[set[str]] = None
 
     def bind_notifier(self, notifier: "BaseNotifier"):
         self.notifier = notifier
+
+    def _validate_target(self, target: TaskTarget) -> None:
+        """Reject targets whose ``kind`` is not permitted by this orchestrator.
+
+        Called at the top of each concrete ``enqueue`` so a disallowed target
+        fails fast with a clear, non-retryable error before the task is queued.
+        """
+        if self.allowed_target_kinds is None:
+            return
+        kind = getattr(target, "kind", None)
+        if kind not in self.allowed_target_kinds:
+            raise TargetNotAllowedError(
+                f"Target kind {kind!r} is not permitted by this orchestrator. "
+                f"Allowed kinds: {sorted(self.allowed_target_kinds)}"
+            )
 
     @abstractmethod
     async def enqueue(

--- a/docling_jobkit/orchestrators/local/orchestrator.py
+++ b/docling_jobkit/orchestrators/local/orchestrator.py
@@ -35,6 +35,7 @@ class LocalOrchestratorConfig(BaseModel):
     scratch_dir: Optional[Path] = None
     result_removal_delay: int = 300  # seconds until result is deleted after fetch
     s3_presigned_config: S3PresignedConfig | None = None
+    allowed_target_kinds: Optional[set[str]] = None
 
 
 class LocalOrchestrator(BaseOrchestrator):
@@ -45,6 +46,7 @@ class LocalOrchestrator(BaseOrchestrator):
     ):
         super().__init__()
         self.config = config
+        self.allowed_target_kinds = config.allowed_target_kinds
         self.task_queue: asyncio.Queue[str] = asyncio.Queue()
         self.queue_list: list[str] = []
         self.cm = converter_manager
@@ -76,6 +78,7 @@ class LocalOrchestrator(BaseOrchestrator):
                 DeprecationWarning,
                 stacklevel=2,
             )
+        self._validate_target(target)
         task_id = str(uuid.uuid4())
         chunking_export_options = chunking_export_options or ChunkingExportOptions()
         task = Task(

--- a/docling_jobkit/orchestrators/ray/config.py
+++ b/docling_jobkit/orchestrators/ray/config.py
@@ -51,6 +51,14 @@ class RayOrchestratorConfig(BaseSettings):
         extra="ignore",
     )
 
+    allowed_target_kinds: Optional[set[str]] = Field(
+        default=None,
+        description=(
+            "If set, only these target kinds may be submitted to this orchestrator. "
+            "None allows all registered targets."
+        ),
+    )
+
     # Redis Configuration
     # Supports standard Redis, Redis Sentinel, and Redis Cluster via URL:
     # - Standard: "redis://localhost:6379/"

--- a/docling_jobkit/orchestrators/ray/orchestrator.py
+++ b/docling_jobkit/orchestrators/ray/orchestrator.py
@@ -105,6 +105,7 @@ class RayOrchestrator(BaseOrchestrator):
         """
         super().__init__()
         self.config = config
+        self.allowed_target_kinds = config.allowed_target_kinds
         self.cm = converter_manager
         assert self.config.redis_gate_concurrency is not None
         self._redis_gate = RedisCallerGate(self.config.redis_gate_concurrency)
@@ -625,7 +626,9 @@ class RayOrchestrator(BaseOrchestrator):
 
         Raises:
             QueueLimitExceededError: If queue limit exceeded and rejection enabled
+            TargetNotAllowedError: If the target kind is not permitted
         """
+        self._validate_target(target)
         async with self._redis_gate.acquire(self.config.redis_gate_wait_timeout):
             # Ensure Redis is connected
             await self.redis_manager.connect()

--- a/docling_jobkit/orchestrators/ray/serve_deployment.py
+++ b/docling_jobkit/orchestrators/ray/serve_deployment.py
@@ -40,6 +40,7 @@ from docling_jobkit.connectors.source_processor import (
     SourceDocumentRef,
 )
 from docling_jobkit.connectors.source_processor_factory import get_source_processor
+from docling_jobkit.convert.chunk_execution import open_chunk_sources
 from docling_jobkit.convert.chunking import (
     DocumentChunkerManager,
     process_chunkable_results,
@@ -811,28 +812,18 @@ class DoclingProcessorConverterDeployment:
     def _convert_source_chunk_request(
         self, request: SourceChunkConvertRequest
     ) -> list[ConversionResult]:
-        with get_source_processor(request.chunk.source) as source_processor:
-            convert_sources: list[str | DocumentStream] = []
-            headers: Optional[dict[str, Any]] = None
-            for ref in request.chunk.refs:
-                convert_source = source_processor.fetch_converter_source_by_ref(
-                    ref,
-                    max_file_size=self.converter_manager_config.max_file_size,
+        with open_chunk_sources(
+            request.chunk,
+            max_file_size=self.converter_manager_config.max_file_size,
+            allow_external_plugins=self.converter_manager_config.allow_external_plugins,
+        ) as (convert_sources, headers):
+            return list(
+                self.cm.convert_documents(
+                    sources=convert_sources,
+                    options=request.task.convert_options or ConvertDocumentsOptions(),
+                    headers=headers,
                 )
-                convert_sources.append(convert_source)
-                if not isinstance(convert_source, str):
-                    continue
-                ref_headers = source_processor.headers_for_ref(ref)
-                if headers is None and ref_headers:
-                    headers = ref_headers
-
-        return list(
-            self.cm.convert_documents(
-                sources=convert_sources,
-                options=request.task.convert_options or ConvertDocumentsOptions(),
-                headers=headers,
             )
-        )
 
     def _process_slice_convert(
         self, request: SliceConvertRequest
@@ -1602,9 +1593,7 @@ class DoclingProcessorCoordinatorDeployment:
         # when Ray cloudpickle serializes the chunk — causing a TypeError on thread
         # locks. The converter never calls iter_documents(); it reconstructs its own
         # source processor from chunk.source and uses fetch_converter_source_by_ref().
-        serializable_chunk = DocumentChunk(
-            source=chunk.source, refs=chunk.refs, chunk_index=chunk.chunk_index
-        )
+        serializable_chunk = chunk.for_transport()
         return await self.converter_handle.process_converter_request.remote(
             SourceChunkConvertRequest(
                 task=child_task,

--- a/docling_jobkit/orchestrators/ray/serve_deployment.py
+++ b/docling_jobkit/orchestrators/ray/serve_deployment.py
@@ -1586,18 +1586,13 @@ class DoclingProcessorCoordinatorDeployment:
         expected_doc_count: int,
     ) -> ConverterTaskResult:
         child_task = task.model_copy(update={"sources": [chunk.source]})
-        # Strip the fetcher before cross-process dispatch. The fetcher is a bound
-        # method of the coordinator's initialized S3SourceProcessor, which holds a
-        # boto3 client containing thread locks. Pydantic v2 serializes
-        # __pydantic_private__ via __getstate__, so the fetcher would be included
-        # when Ray cloudpickle serializes the chunk — causing a TypeError on thread
-        # locks. The converter never calls iter_documents(); it reconstructs its own
-        # source processor from chunk.source and uses fetch_converter_source_by_ref().
-        serializable_chunk = chunk.for_transport()
+        # The chunk carries only source + refs, so it is safe to cloudpickle as-is.
+        # The converter reconstructs its own source processor from chunk.source and
+        # fetches each ref via fetch_converter_source_by_ref().
         return await self.converter_handle.process_converter_request.remote(
             SourceChunkConvertRequest(
                 task=child_task,
-                chunk=serializable_chunk,
+                chunk=chunk,
                 expected_doc_count=expected_doc_count,
             )
         )

--- a/docling_jobkit/orchestrators/rq/orchestrator.py
+++ b/docling_jobkit/orchestrators/rq/orchestrator.py
@@ -59,6 +59,7 @@ class RQOrchestratorConfig(BaseModel):
     result_removal_delay: int = 300  # seconds until result key expires after fetch
     debug_error_details: bool = False
     s3_presigned_config: S3PresignedConfig | None = None
+    allowed_target_kinds: Optional[set[str]] = None
 
     @model_validator(mode="after")
     def resolve_redis_gate_concurrency(self) -> "RQOrchestratorConfig":
@@ -121,6 +122,7 @@ class RQOrchestrator(BaseOrchestrator):
     ):
         super().__init__()
         self.config = config
+        self.allowed_target_kinds = config.allowed_target_kinds
         assert self.config.redis_gate_concurrency is not None
         self._redis_gate = RedisCallerGate(self.config.redis_gate_concurrency)
         self._redis_conn, self._rq_queue = self.make_rq_queue(self.config)
@@ -158,6 +160,7 @@ class RQOrchestrator(BaseOrchestrator):
         callbacks: list[CallbackSpec] | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> Task:
+        self._validate_target(target)
         async with self._redis_gate.acquire(self.config.redis_gate_wait_timeout):
             if options is not None and convert_options is None:
                 convert_options = options

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -1,0 +1,134 @@
+# Writing a connector
+
+A **connector** lets docling-jobkit read documents from (source) or write results
+to (target) a storage system. Connectors are discovered as plugins, so a new one
+works identically when you test it locally with the CLI and when it runs on
+distributed compute (Ray / RQ), with no changes to the core dispatch or export
+code.
+
+This guide uses a hypothetical **OneDrive** target connector as the example.
+
+## How dispatch works
+
+- Every connector has a **config model** — a small `pydantic` model with a
+  `Literal` `kind` field that identifies it in YAML/JSON.
+- Every connector has a **processor** — a subclass of `BaseSourceProcessor` or
+  `BaseTargetProcessor` that does the actual I/O.
+- A processor declares which config models it handles via `get_config_types()`.
+- The pluggy-based factory (`docling_jobkit.connectors.connector_factory`) keys a
+  registry on the config type and instantiates the right processor from a config
+  object — `get_source_processor()` / `get_target_processor()` are thin wrappers
+  over it.
+- Connectors are found through the `docling_jobkit` setuptools entry-point group.
+
+## Checklist
+
+### 1. Config model with a `kind`
+
+```python
+from typing import Literal
+from pydantic import BaseModel
+
+class OneDriveTarget(BaseModel):
+    kind: Literal["onedrive"] = "onedrive"
+    drive_id: str
+    folder: str = ""
+```
+
+The `kind` must be unique within its registry (source kinds and target kinds are
+separate registries, so a source and a target may share a `kind`).
+
+### 2. Processor subclass
+
+Implement the base abstract methods and `get_config_types()`. **Import heavy or
+optional SDKs inside methods, not at module top**, so listing the class in a
+plugin module stays import-safe even when the SDK isn't installed. This also
+matters because chunks are shipped between processes fetcher-stripped: each worker
+reconstructs its own processor from the config and fetches lazily.
+
+```python
+from pydantic import BaseModel
+from docling_jobkit.connectors.target_processor import BaseTargetProcessor
+
+class OneDriveTargetProcessor(BaseTargetProcessor):
+    def __init__(self, target: OneDriveTarget):
+        super().__init__()
+        self._target = target
+
+    @classmethod
+    def get_config_types(cls) -> tuple[type[BaseModel], ...]:
+        return (OneDriveTarget,)
+
+    def _initialize(self) -> None:
+        from onedrive_sdk import Client          # lazy import
+        self._client = Client(self._target.drive_id)
+
+    def _finalize(self) -> None:
+        ...
+
+    def upload_file(self, filename, target_filename, content_type) -> None:
+        self._client.upload(self._target.folder, target_filename, open(filename, "rb"))
+
+    def upload_object(self, obj, target_filename, content_type) -> None:
+        self._client.upload(self._target.folder, target_filename, obj)
+```
+
+Source connectors instead subclass `BaseSourceProcessor` and implement
+`_fetch_documents` (and, for batch/chunked processing, `_list_document_ids` +
+`_fetch_document_by_id`). See `s3_source_processor.py` for a full example.
+
+### 3. Plugin module
+
+Expose `source_connectors()` and/or `target_connectors()` callables returning the
+classes. Keep the imports inside the functions.
+
+```python
+# my_pkg/plugin.py
+def target_connectors():
+    from my_pkg.onedrive import OneDriveTargetProcessor
+    return {"target_connectors": [OneDriveTargetProcessor]}
+```
+
+### 4. Entry point
+
+Register the plugin module under the `docling_jobkit` group in your package's
+`pyproject.toml`:
+
+```toml
+[project.entry-points.docling_jobkit]
+my_onedrive = "my_pkg.plugin"
+```
+
+After installing your package, the connector is discoverable.
+
+### 5. Enable external plugins
+
+External (non–docling-jobkit) plugins load only when external plugins are allowed:
+
+- **CLI:** `docling-jobkit-local convert config.yaml --allow-external-plugins`
+  (and the multiproc CLI likewise). The config then validates `kind: onedrive`
+  from YAML.
+- **Orchestrators:** set `allow_external_plugins=True` on the converter manager
+  config. For the RQ worker, the dynamic union must be installed *before* the
+  worker reconstructs `Task` objects — call
+  `docling_jobkit.datamodel.dynamic_unions.install_dynamic_unions(allow_external_plugins=True)`
+  at worker bootstrap (with the same flag as the submitter).
+
+## Restricting targets per orchestrator
+
+An orchestrator can declare which target kinds it accepts via
+`allowed_target_kinds` on its config (e.g. `RayOrchestratorConfig`,
+`RQOrchestratorConfig`, `LocalOrchestratorConfig`). A submission with a
+disallowed target kind fails fast at `enqueue` with `TargetNotAllowedError`.
+`None` (the default) allows every registered target. This is how a distributed
+deployment can, for example, forbid `local_path` targets that only make sense on
+a single machine.
+
+## Memory note
+
+Documents are fetched one at a time as the converter pulls them (see
+`open_chunk_sources`), and each result is released immediately after its artifacts
+are uploaded (see `export_documents_to_target`). Keep your source connector's
+`fetch_converter_source_by_ref` streaming a single document per call rather than
+materializing whole batches, so per-worker memory stays flat regardless of batch
+size.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,9 @@ docling-ray-job = "docling_jobkit.ray_job.main:main"
 docling-jobkit-local = "docling_jobkit.cli.local:app"
 docling-jobkit-multiproc = "docling_jobkit.cli.multiproc:app"
 
+[project.entry-points.docling_jobkit]
+docling_jobkit_defaults = "docling_jobkit.connectors.plugins.defaults"
+
 [project.urls]
 Homepage = "https://github.com/docling-project/docling-jobkit"
 Documentation = "https://docling-project.github.io/docling/usage/jobkit/"

--- a/tests/test_connector_factory.py
+++ b/tests/test_connector_factory.py
@@ -183,22 +183,20 @@ class _FakeSourceProcessor(BaseSourceProcessor):
         yield from ()
 
 
-def test_document_chunk_for_transport_strips_fetcher():
+def test_document_chunk_is_plain_serializable():
+    """A chunk carries only source + refs (no fetcher), so it is transport-safe."""
     refs = [
         SourceDocumentRef(id="a", source_index=0, source_uri="a", filename="a"),
     ]
-    chunk = DocumentChunk(
-        source=_FakeSource(),
-        refs=refs,
-        chunk_index=3,
-        fetcher=lambda _id: DocumentStream(name="a", stream=None),  # type: ignore[arg-type]
-    )
-    transport = chunk.for_transport()
-    assert transport._fetcher is None
-    assert transport.chunk_index == 3
-    assert list(transport.refs) == refs
-    # Original keeps its fetcher (local callers may still use it).
-    assert chunk._fetcher is not None
+    chunk = DocumentChunk(source=_FakeSource(), refs=refs, chunk_index=3)
+    assert chunk.chunk_index == 3
+    assert list(chunk.refs) == refs
+    # Round-trips through pickle (the CLI mp.Pool path) without special handling.
+    import pickle
+
+    restored = pickle.loads(pickle.dumps(chunk))
+    assert restored.chunk_index == 3
+    assert restored.ids == ["a"]
 
 
 # --- Orchestrator allowlist ----------------------------------------------------

--- a/tests/test_connector_factory.py
+++ b/tests/test_connector_factory.py
@@ -1,0 +1,299 @@
+"""Tests for the pluggy connector factory, dynamic unions, transport chunk,
+and the orchestrator target allowlist."""
+
+from typing import Iterator, Literal
+
+import pytest
+from pydantic import BaseModel
+
+from docling.datamodel.base_models import DocumentStream
+from docling.datamodel.service.requests import S3SourceRequest
+from docling.datamodel.service.sources import FileSource, HttpSource, S3Coordinates
+from docling.datamodel.service.targets import InBodyTarget, S3Target
+
+from docling_jobkit.connectors.connector_factory import (
+    SourceConnectorFactory,
+    TargetConnectorFactory,
+    get_source_connector_factory,
+    get_target_connector_factory,
+)
+from docling_jobkit.connectors.source_processor import (
+    BaseSourceProcessor,
+    DocumentChunk,
+    SourceDocumentRef,
+)
+from docling_jobkit.connectors.target_processor import BaseTargetProcessor
+from docling_jobkit.datamodel.task_targets import GoogleDriveTarget, LocalPathTarget
+
+
+def test_builtin_source_connectors_registered():
+    factory = get_source_connector_factory()
+    assert set(factory.registered_kinds) == {
+        "file",
+        "http",
+        "s3",
+        "local_path",
+        "google_drive",
+    }
+
+
+def test_builtin_target_connectors_registered():
+    factory = get_target_connector_factory()
+    assert set(factory.registered_kinds) == {
+        "s3",
+        "local_path",
+        "put",
+        "google_drive",
+    }
+
+
+def test_create_instance_exact_and_subtype_match():
+    factory = get_source_connector_factory()
+    # Discriminated subtype (YAML path)
+    proc = factory.create_instance(
+        S3SourceRequest(
+            endpoint="e", bucket="b", access_key="k", secret_key="s", key_prefix="p/"
+        )
+    )
+    assert type(proc).__name__ == "S3SourceProcessor"
+
+
+def test_create_instance_bare_base_fallback():
+    """A bare S3Coordinates (no kind) must resolve to the S3 processor that is
+    registered under the S3SourceRequest subclass."""
+    factory = get_source_connector_factory()
+    proc = factory.create_instance(
+        S3Coordinates(
+            endpoint="e", bucket="b", access_key="k", secret_key="s", key_prefix="p/"
+        )
+    )
+    assert type(proc).__name__ == "S3SourceProcessor"
+
+    http = factory.create_instance(HttpSource(url="https://example.com/a.pdf"))
+    assert type(http).__name__ == "HttpSourceProcessor"
+    file = factory.create_instance(FileSource(base64_string="", filename="a.pdf"))
+    assert type(file).__name__ == "HttpSourceProcessor"
+
+
+def test_target_factory_dispatch():
+    factory = get_target_connector_factory()
+    assert (
+        type(factory.create_instance(LocalPathTarget(path="./out"))).__name__
+        == "LocalPathTargetProcessor"
+    )
+    assert (
+        type(
+            factory.create_instance(
+                S3Target(
+                    endpoint="e",
+                    bucket="b",
+                    access_key="k",
+                    secret_key="s",
+                    key_prefix="p/",
+                )
+            )
+        ).__name__
+        == "S3TargetProcessor"
+    )
+
+
+def test_unknown_config_raises():
+    factory = TargetConnectorFactory()
+    factory.load_from_plugins()
+    with pytest.raises(RuntimeError):
+        factory.create_instance(InBodyTarget())  # service-only, never registered
+
+
+# --- External plugin registration + dynamic unions ----------------------------
+
+
+class _OneDriveTarget(BaseModel):
+    kind: Literal["onedrive"] = "onedrive"
+    drive_id: str
+
+
+class _OneDriveTargetProcessor(BaseTargetProcessor):
+    def __init__(self, target: _OneDriveTarget):
+        super().__init__()
+        self._target = target
+
+    @classmethod
+    def get_config_types(cls):
+        return (_OneDriveTarget,)
+
+    def _initialize(self):  # pragma: no cover - trivial
+        ...
+
+    def _finalize(self):  # pragma: no cover - trivial
+        ...
+
+    def upload_file(self, filename, target_filename, content_type):  # pragma: no cover
+        ...
+
+    def upload_object(self, obj, target_filename, content_type):  # pragma: no cover
+        ...
+
+
+def test_external_connector_registration_and_union():
+    factory = TargetConnectorFactory()
+    factory.load_from_plugins()  # built-ins
+    factory.register(_OneDriveTargetProcessor, "test_plugin", "tests.fake")
+    assert "onedrive" in factory.registered_kinds
+
+    union_adapter = factory.build_discriminated_union()
+    from pydantic import TypeAdapter
+
+    parsed = TypeAdapter(union_adapter).validate_python(
+        {"kind": "onedrive", "drive_id": "d1"}
+    )
+    assert isinstance(parsed, _OneDriveTarget)
+    assert parsed.drive_id == "d1"
+
+    proc = factory.create_instance(_OneDriveTarget(drive_id="d2"))
+    assert isinstance(proc, _OneDriveTargetProcessor)
+
+
+def test_single_member_union_returns_bare_type():
+    factory = TargetConnectorFactory()
+    factory.register(_OneDriveTargetProcessor, "test_plugin", "tests.fake")
+    # Only one registered type -> bare type, not an Annotated discriminated union.
+    assert factory.build_discriminated_union() is _OneDriveTarget
+
+
+# --- Transport chunk -----------------------------------------------------------
+
+
+class _FakeSource(BaseModel):
+    kind: Literal["fake"] = "fake"
+
+
+class _FakeSourceProcessor(BaseSourceProcessor):
+    def __init__(self, source: _FakeSource):
+        super().__init__(source)
+
+    @classmethod
+    def get_config_types(cls):
+        return (_FakeSource,)
+
+    def _initialize(self): ...
+
+    def _finalize(self): ...
+
+    def _fetch_documents(self, *, max_file_size=None) -> Iterator[DocumentStream]:
+        yield from ()
+
+
+def test_document_chunk_for_transport_strips_fetcher():
+    refs = [
+        SourceDocumentRef(id="a", source_index=0, source_uri="a", filename="a"),
+    ]
+    chunk = DocumentChunk(
+        source=_FakeSource(),
+        refs=refs,
+        chunk_index=3,
+        fetcher=lambda _id: DocumentStream(name="a", stream=None),  # type: ignore[arg-type]
+    )
+    transport = chunk.for_transport()
+    assert transport._fetcher is None
+    assert transport.chunk_index == 3
+    assert list(transport.refs) == refs
+    # Original keeps its fetcher (local callers may still use it).
+    assert chunk._fetcher is not None
+
+
+# --- Orchestrator allowlist ----------------------------------------------------
+
+
+def test_validate_target_allowlist():
+    from docling_jobkit.orchestrators.base_orchestrator import (
+        BaseOrchestrator,
+        TargetNotAllowedError,
+    )
+
+    class _Orch(BaseOrchestrator):
+        async def enqueue(self, *a, **k): ...  # pragma: no cover
+        async def queue_size(self): ...  # pragma: no cover
+        async def get_queue_position(self, task_id): ...  # pragma: no cover
+        async def process_queue(self): ...  # pragma: no cover
+        async def warm_up_caches(self): ...  # pragma: no cover
+        async def clear_converters(self): ...  # pragma: no cover
+        async def check_connection(self): ...  # pragma: no cover
+        async def task_result(self, task_id): ...  # pragma: no cover
+
+    orch = _Orch()
+    orch.allowed_target_kinds = {"s3"}
+
+    # Allowed kind passes
+    orch._validate_target(
+        S3Target(
+            endpoint="e", bucket="b", access_key="k", secret_key="s", key_prefix="p/"
+        )
+    )
+    # Disallowed kind raises
+    with pytest.raises(TargetNotAllowedError):
+        orch._validate_target(LocalPathTarget(path="./out"))
+
+    # None allowlist allows everything
+    orch.allowed_target_kinds = None
+    orch._validate_target(GoogleDriveTarget(token="t", path_id="x"))
+
+
+def test_factory_caches_are_isolated_by_flag():
+    a = get_source_connector_factory(False)
+    b = get_source_connector_factory(False)
+    assert a is b
+    assert isinstance(a, SourceConnectorFactory)
+
+
+# --- Lazy / low-memory chunk consumption --------------------------------------
+
+
+def test_open_chunk_sources_fetches_one_at_a_time(monkeypatch):
+    """open_chunk_sources must fetch documents lazily, one per next(), so peak
+    memory stays bounded to a single in-flight document regardless of batch size."""
+    from io import BytesIO
+
+    from docling_jobkit.convert import chunk_execution
+
+    fetched: list[int] = []
+
+    class _LazyProc(_FakeSourceProcessor):
+        def fetch_converter_source_by_ref(self, ref, *, max_file_size=None):
+            fetched.append(ref.id)
+            return DocumentStream(name=str(ref.id), stream=BytesIO(b"x"))
+
+    monkeypatch.setattr(
+        chunk_execution,
+        "get_source_processor",
+        lambda source, **kwargs: _LazyProc(source),
+    )
+
+    refs = [
+        SourceDocumentRef(id=i, source_index=i, source_uri=str(i), filename=str(i))
+        for i in range(5)
+    ]
+    chunk = DocumentChunk(source=_FakeSource(), refs=refs, chunk_index=0)
+
+    with chunk_execution.open_chunk_sources(chunk) as (sources, _headers):
+        assert fetched == []  # nothing fetched until the converter pulls
+        first = next(sources)
+        assert first.name == "0"
+        assert fetched == [0]  # exactly one in flight
+        list(sources)
+        assert fetched == [0, 1, 2, 3, 4]
+
+
+def test_dynamic_job_config_parses_builtins_and_rejects_presigned():
+    from docling_jobkit.datamodel.dynamic_unions import build_job_config_model
+
+    model = build_job_config_model(allow_external_plugins=False)
+    cfg = model(
+        sources=[{"kind": "local_path", "path": "."}],
+        target={"kind": "local_path", "path": "./out"},
+    )
+    assert cfg.target.kind == "local_path"
+    assert cfg.sources[0].kind == "local_path"
+
+    with pytest.raises(Exception):
+        # presigned_url is a service-only target, never a storage connector
+        model(sources=[], target={"kind": "presigned_url"})

--- a/tests/test_error_message_propagation.py
+++ b/tests/test_error_message_propagation.py
@@ -46,6 +46,7 @@ def _make_orchestrator_with_task():
     with patch.object(RQOrchestrator, "__init__", lambda self, **kw: None):
         orch = object.__new__(RQOrchestrator)
     orch.config = config
+    orch.allowed_target_kinds = config.allowed_target_kinds
     orch.tasks = {}
     orch.notifier = None
     orch._task_result_keys = {}

--- a/tests/test_http_source_processor.py
+++ b/tests/test_http_source_processor.py
@@ -26,8 +26,8 @@ def test_http_file_source_chunking():
         assert chunks[0].index == 0, "First chunk should have index 0"
         assert len(chunks[0].ids) == 1, "Chunk should contain one identifier"
 
-        # Verify document can be fetched from chunk
-        docs = list(chunks[0].iter_documents())
+        # Verify document can be fetched from the chunk refs via the processor
+        docs = [processor.fetch_converter_source_by_ref(ref) for ref in chunks[0].refs]
         assert len(docs) == 1
         assert isinstance(docs[0], DocumentStream)
         assert docs[0].name == "test.pdf"

--- a/tests/test_notifier_resilience.py
+++ b/tests/test_notifier_resilience.py
@@ -35,6 +35,7 @@ def _make_orchestrator_with_task():
     with patch.object(RQOrchestrator, "__init__", lambda self, **kw: None):
         orch = object.__new__(RQOrchestrator)
     orch.config = config
+    orch.allowed_target_kinds = config.allowed_target_kinds
     orch.tasks = {}
     orch.notifier = None
     orch._task_result_keys = {}

--- a/tests/test_ray_redis_gate.py
+++ b/tests/test_ray_redis_gate.py
@@ -22,6 +22,7 @@ def _make_orchestrator(
     with patch.object(RayOrchestrator, "__init__", lambda self, **kw: None):
         orch = object.__new__(RayOrchestrator)
     orch.config = config
+    orch.allowed_target_kinds = config.allowed_target_kinds
     orch.tasks = {}
     orch.notifier = None
     orch.redis_manager = AsyncMock()

--- a/tests/test_rq_redis_durability_and_gate.py
+++ b/tests/test_rq_redis_durability_and_gate.py
@@ -55,6 +55,7 @@ def _make_orchestrator(
     with patch.object(RQOrchestrator, "__init__", lambda self, **kw: None):
         orch = object.__new__(RQOrchestrator)
     orch.config = config
+    orch.allowed_target_kinds = config.allowed_target_kinds
     orch.tasks = {}
     orch.notifier = None
     orch._task_result_keys = {}

--- a/tests/test_source_processor.py
+++ b/tests/test_source_processor.py
@@ -79,7 +79,8 @@ def test_chunks_can_fetch_documents_lazily():
         chunks = list(p.iterate_document_chunks(chunk_size=2))
         first_chunk = chunks[0]
 
-        docs = list(first_chunk.iter_documents())
+        # Documents are fetched from the chunk refs via the source processor.
+        docs = [p.fetch_converter_source_by_ref(ref) for ref in first_chunk.refs]
 
         assert docs[0].name == "a"
         assert docs[1].name == "b"


### PR DESCRIPTION
## Why

We want developers to author a new connector (e.g. OneDrive) once, test it locally with the CLI, and have it run unchanged on distributed compute (Ray/RQ) — without editing core dispatch or export code, and without per-job memory growing with the number of documents.

Three gaps blocked this:
1. The chunk create→serialize→ship→fetch path differed between the CLI and Ray (the CLI re-enumerated the whole source in **every** subprocess — O(N²) — and materialized whole batches in memory).
2. Target export was two divergent implementations; orchestrators didn't use the target factory and silently produced a zip for `LocalPathTarget`/`GoogleDriveTarget` instead of writing to them.
3. Connector dispatch was a hardcoded `isinstance` chain with no plugin extensibility.

## What changed

### Uniform, low-memory chunk processing
- `DocumentChunk.for_transport()` is the single rule for crossing a process boundary (refs only, fetcher stripped). Both the CLI `mp.Pool` workers and the Ray converter replica use it.
- New `convert/chunk_execution.py::open_chunk_sources()` — one lazy fetch path shared by CLI workers and Ray. Documents are fetched **one at a time** as the converter pulls them, so peak memory is bounded to a single in-flight document regardless of batch size.
- `cli/multiproc.py` now ships the transport chunk to subprocesses and streams chunks into the pool. **Removed** the O(N²) per-subprocess source re-enumeration and the full-batch `list(chunk.iter_documents())`.

### One storage-export path
- New `convert/export.py` single-sources the materialize+upload primitive.
- `convert/results.py` routes **all** storage targets (S3 / local / Google Drive / external) through `get_target_processor()`. Previously only S3 went through the factory; local/gdrive silently produced a zip. (net −190 lines in results.py from de-duplication.)

### Pluggy connector factory
- `connectors/connector_factory.py` mirrors docling's `BaseFactory`: registry keyed by config-model type, discovered via the `docling_jobkit` setuptools entry-point group. Built-ins listed in `connectors/plugins/defaults.py`.
- Each processor declares `get_config_types()`. `create_instance` resolves exact → isinstance → `issubclass(registered, type(config))`, so the bare `S3Coordinates` used by the Ray fan-out still resolves to the processor registered under `S3SourceRequest`.
- `get_source_processor`/`get_target_processor` are now thin wrappers over cached factories — existing call sites unchanged.

### Dynamic unions + orchestrator allowlist
- `datamodel/dynamic_unions.py`: `build_job_config_model` (CLI parses external connector `kind`s from YAML under `--allow-external-plugins`) and `install_dynamic_unions` (rebinds `Task.target` for workers).
- `allowed_target_kinds` on each orchestrator config + `BaseOrchestrator._validate_target` raising `TargetNotAllowedError` at `enqueue` (fail-fast, non-retryable).

### Docs
- `docs/connectors.md` — connector-authoring guide.

## Reviewer notes
- **Behavior fix**: orchestrators now actually write `LocalPathTarget`/`GoogleDriveTarget` outputs (previously raised/zipped). S3 layout and behavior are unchanged.
- **Incidental fix**: `google_drive_source_processor.py` raised `NameError` on import (a `TYPE_CHECKING`-only generic param used at runtime); fixed with a forward-ref string so the plugin can list it.
- **Scope decisions (deliberate):**
  - `ResultsProcessor` keeps its CLI-only extras (pdf/pages/parquet) rather than a full merge, to preserve CLI byte-output parity. The shared materialize+upload primitive is used by the orchestrator path; full CLI delegation is a follow-up.
  - `Task.sources` dynamic rebinding is left as follow-up (it's a non-discriminated union). External **targets** work in orchestrators; external **sources** via the orchestrator API would need that follow-up.
- **RQ workers**: to accept external connector configs, `install_dynamic_unions(allow_external_plugins=True)` must run at worker bootstrap before any `Task(**kwargs)` (documented in `docs/connectors.md`).

## Verification
- `ruff` + `mypy` clean on all touched files.
- New `tests/test_connector_factory.py` (factory dispatch incl. bare-base fallback, external-plugin registration + dynamic union, transport-chunk fetcher stripping, lazy one-at-a-time fetch, allowlist) — all green.
- Targeted suites pass: results/export, chunking, source/http processors, local-path, CLI validation, local orchestrator.
- Remaining full-suite failures observed locally are environmental (optional model backends `mlx-vlm`/`onnxruntime` not installed; Redis/S3 servers not running) — left for CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
