### PR TITLE
fix: guard task start transition before mutating Redis status

### DIFF
--- a/docling_jobkit/orchestrators/ray/redis_helper.py
+++ b/docling_jobkit/orchestrators/ray/redis_helper.py
@@ -91,8 +91,8 @@ return rel
 # ARGV[1] = "started", ARGV[2] = ISO timestamp
 _MARK_TASK_STARTED_LUA = """
 local cur = redis.call('HGET', KEYS[1], 'status')
-redis.call('HSET', KEYS[1], 'status', ARGV[1], 'last_update_at', ARGV[2], 'started_at', ARGV[2])
 if cur ~= 'started' and cur ~= 'success' and cur ~= 'failure' then
+    redis.call('HSET', KEYS[1], 'status', ARGV[1], 'last_update_at', ARGV[2], 'started_at', ARGV[2])
     redis.call('HINCRBY', KEYS[2], 'tasks_started_total', 1)
     return 1
 end

--- a/tests/test_ray_lifecycle_counters.py
+++ b/tests/test_ray_lifecycle_counters.py
@@ -130,10 +130,10 @@ class _FakeRedis:
         status, timestamp = argv[0], argv[1]
         task = self.hashes.setdefault(task_key, {})
         cur = task.get("status")
-        task["status"] = status
-        task["last_update_at"] = timestamp
-        task["started_at"] = timestamp
         if cur not in ("started", "success", "failure"):
+            task["status"] = status
+            task["last_update_at"] = timestamp
+            task["started_at"] = timestamp
             counters = self.hashes.setdefault(task_counters_key, {})
             counters["tasks_started_total"] = str(
                 int(counters.get("tasks_started_total", "0")) + 1
@@ -304,6 +304,21 @@ async def test_mark_task_started_noop_when_already_terminal() -> None:
     assert transitioned is False
     counters = await manager.get_tenant_task_counters("tenant-a")
     assert counters.tasks_started_total == 0
+    # Status must not be overwritten back to 'started'
+    assert fake.hashes["task:t1"]["status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_mark_task_started_does_not_overwrite_failure_status() -> None:
+    manager, fake = _manager()
+    fake.hashes["task:t1"] = {"status": "failure"}
+
+    transitioned = await manager.mark_task_started("t1", "tenant-a")
+
+    assert transitioned is False
+    counters = await manager.get_tenant_task_counters("tenant-a")
+    assert counters.tasks_started_total == 0
+    assert fake.hashes["task:t1"]["status"] == "failure"
 
 
 # --- terminal -------------------------------------------------------------


### PR DESCRIPTION
Summary

This PR fixes the Redis Lua script that marks a task as started.

Previously, the script updated the task status to started before checking whether the task was already in a terminal state. This meant a task that had already reached success or failure could be incorrectly overwritten back to started.

The HSET is now moved inside the transition guard so that status and timestamp fields are only updated when the task is genuinely transitioning into started.

Changes
Read the current task status before mutating Redis state.
Skip updates when the task is already started, success, or failure.
Only increment tasks_started_total on a real transition into started.
Testing
Verified that tasks in success or failure are not overwritten.
Verified that retries for already started tasks do not increment the counter again.
Verified that non-terminal tasks still transition to started and increment the counter once.
