### PR TITLE
fix: added type definition to chunks for typed chunk records

### DIFF
--- a/docling_jobkit/cli/local.py
+++ b/docling_jobkit/cli/local.py
@@ -27,9 +27,9 @@ from docling_jobkit.datamodel.task_sources import (
     TaskLocalPathSource,
 )
 from docling_jobkit.datamodel.task_targets import (
+    AstraDBTarget,
     GoogleDriveTarget,
     LocalPathTarget,
-    AstraDBTarget
 )
 
 console = Console()

--- a/docling_jobkit/connectors/astradb_helper.py
+++ b/docling_jobkit/connectors/astradb_helper.py
@@ -2,6 +2,7 @@ import logging
 from pathlib import Path
 
 from docling_jobkit.datamodel.astradb_coords import AstraDBCoordinates
+from docling_jobkit.datamodel.result import ChunkedDocumentResultItem
 
 _BATCH_SIZE = 20
 
@@ -44,7 +45,7 @@ def build_chunk_records(raw: bytes, source_name: str) -> list[dict]:
 
     # TODO: add chunking_options on AstraDBCoordinates
     options = HybridChunkerOptions()
-    chunks = list(
+    chunks: list[ChunkedDocumentResultItem] = list(
         DocumentChunkerManager().chunk_document(
             document=doc,
             # filename is used only for the filename field on each chunk item.
@@ -87,7 +88,7 @@ def insert_records(collection, records: list[dict], source_name: str) -> None:
     if not records:
         return
 
-    total_batches = (len(records) + _BATCH_SIZE - 1 ) // _BATCH_SIZE
+    total_batches = (len(records) + _BATCH_SIZE - 1) // _BATCH_SIZE
     for i in range(0, len(records), _BATCH_SIZE):
         batch = records[i : i + _BATCH_SIZE]
         collection.insert_many(batch, ordered=False)
@@ -99,6 +100,4 @@ def insert_records(collection, records: list[dict], source_name: str) -> None:
             source_name,
         )
 
-    logging.info(
-        "AstraDB: inserted %d chunks for '%s'", len(records), source_name
-    )
+    logging.info("AstraDB: inserted %d chunks for '%s'", len(records), source_name)

--- a/docling_jobkit/convert/results.py
+++ b/docling_jobkit/convert/results.py
@@ -526,8 +526,9 @@ def _upload_document_to_storage_target(
         export_doctags=export_doctags,
         image_export_mode=image_export_mode,
         md_page_break_placeholder=md_page_break_placeholder,
-        target_filename_fn=lambda source,
-        artifact_filename: f"{source.source_key}/{artifact_filename}",
+        target_filename_fn=lambda source, artifact_filename: (
+            f"{source.source_key}/{artifact_filename}"
+        ),
     )
 
 
@@ -631,27 +632,30 @@ def _process_remote_exportable_results(
                     callback_invoker=callback_invoker,
                     debug_error_details=debug_error_details,
                     callback_mode=callback_mode,
-                    upload_document=lambda _source: _upload_document_as_presigned_artifact(
-                        task=task,
-                        exportable_document=exportable_document,
-                        response_index=idx,
-                        output_dir=output_dir,
-                        target_processor=target_processor,
-                        export_json=export_json,
-                        export_html=export_html,
-                        export_md=export_md,
-                        export_txt=export_txt,
-                        export_doctags=export_doctags,
-                        image_export_mode=image_export_mode,
-                        md_page_break_placeholder=md_page_break_placeholder,
+                    upload_document=lambda _source: (
+                        _upload_document_as_presigned_artifact(
+                            task=task,
+                            exportable_document=exportable_document,
+                            response_index=idx,
+                            output_dir=output_dir,
+                            target_processor=target_processor,
+                            export_json=export_json,
+                            export_html=export_html,
+                            export_md=export_md,
+                            export_txt=export_txt,
+                            export_doctags=export_doctags,
+                            image_export_mode=image_export_mode,
+                            md_page_break_placeholder=md_page_break_placeholder,
+                        )
                     ),
-                    build_failure_result=lambda failed_document,
-                    source: target_processor.build_document_artifact_item(
-                        source=source,
-                        filename=failed_document.file.name,
-                        status=failed_document.status,
-                        errors=failed_document.errors,
-                        timings=failed_document.timings,
+                    build_failure_result=lambda failed_document, source: (
+                        target_processor.build_document_artifact_item(
+                            source=source,
+                            filename=failed_document.file.name,
+                            status=failed_document.status,
+                            errors=failed_document.errors,
+                            timings=failed_document.timings,
+                        )
                     ),
                 )
                 processed_docs.append(processed_doc)

--- a/tests/test_presigned_target_results.py
+++ b/tests/test_presigned_target_results.py
@@ -351,8 +351,8 @@ def test_presigned_callbacks_emit_document_completed_after_uploads(
     )
 
     callback_invoker = MagicMock()
-    callback_invoker.invoke_callbacks_async.side_effect = (
-        lambda **kwargs: events.append(("callback", kwargs["progress"]))
+    callback_invoker.invoke_callbacks_async.side_effect = lambda **kwargs: (
+        events.append(("callback", kwargs["progress"]))
     )
 
     process_exportable_results(


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->
## Summary
The chunks in `build_chunk_records` was missing a type definition leading to unknown types when hovering. This fix adds a type definition from `ChunkedDocumentResultItem` so all the fields in the chunks is typed 

## Changes
- Added type definition for chunks in **docling_jobkit/connectors/astradb_helper.py**