### PR TITLE
fix: added retry logic + exponential backoff to create_collection, insert_many, and update_one

### DIFF
--- a/docling_jobkit/connectors/astradb_helper.py
+++ b/docling_jobkit/connectors/astradb_helper.py
@@ -1,20 +1,70 @@
 import logging
+import time
+from typing import Callable, TypeVar
 
-from astrapy.exceptions import CollectionInsertManyException
-
+import httpx
 from astrapy import Collection
-from astrapy.info import CollectionDefinition
 from astrapy.constants import VectorMetric
-from docling_jobkit.datamodel.astradb_coords import AstraDBCoordinates
-from docling_jobkit.datamodel.result import ChunkedDocumentResultItem
+from astrapy.exceptions import (
+    CollectionInsertManyException,
+    DataAPIHttpException,
+    DataAPITimeoutException,
+)
+from astrapy.info import CollectionDefinition
 from sentence_transformers import SentenceTransformer
 
 from docling_jobkit.convert.embedding import EmbeddingError, generate_text_embedding
+from docling_jobkit.datamodel.astradb_coords import AstraDBCoordinates
+from docling_jobkit.datamodel.result import ChunkedDocumentResultItem
 
-_BATCH_SIZE = 20 # max astra can do in one insert_many
+_BATCH_SIZE = 20  # max astra can do in one insert_many
+_MAX_RETRIES = 3
+_RETRYABLE_4XX_STATUS = frozenset(
+    {408, 429}
+)  # 429 rate limit, 408 request timeout are transient 4xx errors
+_BACKOFF_BASE = 1.0  # min time that exponential backoff waits
+
+T = TypeVar("T")
 
 
-def get_collection(coords: AstraDBCoordinates) -> Collection:
+# I dont think we need to add jitter/randomness for the cli case but maybe for distributed version
+# TODO: add logic to extract retry after header sent in http header by external api on 429 telling us
+# after how much time the rate limit will be dropped and we are good to retry
+def _with_exponential_retry(fn: Callable[[], T], operation: str) -> T:
+    """helper for exponential retries on transient errors"""
+    last_exc: Exception | None = None
+    for attempt in range(_MAX_RETRIES + 1):
+        try:
+            return fn()
+        except DataAPITimeoutException as exc:  # Transient error: network/conn timeout
+            last_exc = exc
+        except DataAPIHttpException as exc:
+            status = exc.httpx_error.response.status_code
+            if (
+                status < 500 and status not in _RETRYABLE_4XX_STATUS
+            ):  # 4xx errors are permanent so we bail immediately
+                raise
+            last_exc = exc
+        except (
+            httpx.TransportError
+        ) as exc:  # connection refused / DNS / reset / protocol transient errors
+            last_exc = exc
+        if attempt < _MAX_RETRIES:
+            wait = _BACKOFF_BASE * (2**attempt)
+            logging.warning(
+                "AstraDB: %s transient error, retry %d/%d in %.1fs",
+                operation,
+                attempt + 1,
+                _MAX_RETRIES,
+                wait,
+            )
+            time.sleep(wait)
+
+    logging.error("AstraDB: %s failed after %d attempts", operation, _MAX_RETRIES + 1)
+    raise last_exc  # type: ignore[misc]
+
+
+def get_collection(coords: AstraDBCoordinates, emb_dim: int) -> Collection:
     """
     fetch the collection from AstraDB to save the document chunks to
     If the specified collection doesn't exist, it will create the collection on AstraDB
@@ -28,14 +78,17 @@ def get_collection(coords: AstraDBCoordinates) -> Collection:
     )
 
     # idempotent, if collection exists it will just return status ok
-    collection = db.create_collection(
-        coords.collection_name,
-        definition=(
-            CollectionDefinition.builder()
-            .with_vector_dimension(768)
-            .with_vector_metric(VectorMetric.COSINE)
-            .build()
+    collection = _with_exponential_retry(
+        lambda: db.create_collection(
+            coords.collection_name,
+            definition=(
+                CollectionDefinition.builder()
+                .with_vector_dimension(emb_dim)
+                .with_vector_metric(VectorMetric.COSINE)
+                .build()
+            ),
         ),
+        "create_collection",
     )
 
     logging.info(
@@ -100,15 +153,22 @@ def insert_records(collection, records: list[dict], source_name: str) -> None:
     for i in range(0, len(records), _BATCH_SIZE):
         batch = records[i : i + _BATCH_SIZE]
         try:
-            collection.insert_many(batch, ordered=False)
+            _with_exponential_retry(
+                lambda: collection.insert_many(batch, ordered=False), "insert_many"
+            )
         except CollectionInsertManyException as exc:
             inserted = set(exc.inserted_ids)
             for record in batch:
                 if record["_id"] not in inserted:
-                    collection.update_one(
-                        {"_id": record["_id"]},
-                        {"$set": {k: v for k, v in record.items() if k != "_id"}}, # can't update stable-id
-                        upsert=True,
+                    _with_exponential_retry(
+                        lambda: collection.update_one(
+                            {"_id": record["_id"]},
+                            {
+                                "$set": {k: v for k, v in record.items() if k != "_id"}
+                            },  # can't update stable-id
+                            upsert=True,
+                        ),
+                        "update_one",
                     )
         logging.debug(
             "AstraDB: upserted batch %d/%d (%d records) for '%s'",

--- a/docling_jobkit/connectors/astradb_target_processor.py
+++ b/docling_jobkit/connectors/astradb_target_processor.py
@@ -23,13 +23,19 @@ class AstraDBTargetProcessor(BaseTargetProcessor):
         return (AstraDBTarget,)
 
     def _initialize(self) -> None:
-        from docling_jobkit.connectors.astradb_helper import get_collection
         from sentence_transformers import SentenceTransformer
 
-        self._collection = get_collection(self._coords)
+        from docling_jobkit.connectors.astradb_helper import get_collection
+
         self._embedding_model = SentenceTransformer(
             "sentence-transformers/paraphrase-multilingual-mpnet-base-v2"
         )
+
+        emb_dim = self._embedding_model.get_embedding_dimension()
+        if not emb_dim:
+            raise RuntimeError("Could not determine embedding dimension from model")
+
+        self._collection = get_collection(self._coords, emb_dim)
 
     def _finalize(self) -> None:
         self._collection = None
@@ -48,7 +54,7 @@ class AstraDBTargetProcessor(BaseTargetProcessor):
 
         if not self._embedding_model:
             logging.error("embedding model not initialized")
-            raise
+            raise RuntimeError("Embedding model not initialized")
 
         if not chunks:
             logging.warning("AstraDB: no chunks to insert for '%s'", source_name)

--- a/tests/test_astradb_helper.py
+++ b/tests/test_astradb_helper.py
@@ -1,10 +1,18 @@
-from unittest.mock import MagicMock, patch
+from typing import Any, Callable
+from unittest.mock import MagicMock, call, patch
 
+import httpx
 import pytest
+from astrapy.exceptions import DataAPIHttpException, DataAPITimeoutException
 
-from docling_jobkit.connectors.astradb_helper import build_records_from_chunks
+from docling_jobkit.connectors.astradb_helper import (
+    _with_exponential_retry,
+    build_records_from_chunks,
+)
 from docling_jobkit.convert.embedding import EmbeddingError
 from docling_jobkit.datamodel.result import ChunkedDocumentResultItem
+
+# build_records_from_chunks test stuff
 
 
 @pytest.fixture
@@ -41,3 +49,63 @@ def test_build_records_propagates_embedding_error(
     ):
         with pytest.raises(EmbeddingError):
             build_records_from_chunks(mock_chunks, "doc1", "source.pdf", MagicMock())
+
+
+# exponential backoff test stuff
+
+
+def _make_http_exc(status_code: int) -> DataAPIHttpException:
+    """helper to create the http exception with the specified status code"""
+    httpx_error = MagicMock()
+    httpx_error.response.status_code = status_code
+
+    return DataAPIHttpException(
+        text="error", httpx_error=httpx_error, error_descriptors=[]
+    )
+
+
+def _make_timeout_exc() -> DataAPITimeoutException:
+    return DataAPITimeoutException(
+        text="timeout", timeout_type="connect", endpoint=None, raw_payload=None
+    )
+
+
+@pytest.mark.parametrize(
+    "transient_exc",
+    [
+        _make_timeout_exc(),
+        _make_http_exc(503),  # 5xx errors are transient
+        _make_http_exc(429),  # 429 is transient: rate-limit
+        _make_http_exc(408),
+        httpx.ConnectError("Connection refused"),
+    ],
+)
+def test_exp_backoff_retries_on_transient_error_then_succeeds(
+    transient_exc: Callable[[], Any],
+) -> None:
+    """It should not fail immediately and retry if transient"""
+    fn = MagicMock(side_effect=[transient_exc, "ok"])
+    with patch("docling_jobkit.connectors.astradb_helper.time.sleep"):
+        assert _with_exponential_retry(fn, "op") == "ok"
+
+    assert fn.call_count == 2
+
+
+def test_exp_backoff_raises_immediately_on_4xx() -> None:
+    """Any 4xx error is not considered a transient error so it should raise immediately"""
+    fn = MagicMock(side_effect=_make_http_exc(403))
+    with patch("docling_jobkit.connectors.astradb_helper.time.sleep"):
+        with pytest.raises(DataAPIHttpException):
+            _with_exponential_retry(fn, "op")
+
+    fn.assert_called_once()
+
+
+def test_exp_backoff_sequence() -> None:
+    """It should do proper exp backoff wait properly (increases each time)"""
+    fn = MagicMock(side_effect=_make_timeout_exc())
+    with patch("docling_jobkit.connectors.astradb_helper.time.sleep") as mock_sleep:
+        with pytest.raises(DataAPITimeoutException):
+            _with_exponential_retry(fn, "op")
+
+    assert mock_sleep.call_args_list == [call(1.0), call(2.0), call(4.0)]


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->
## Summary
Previously the network related methods that interact with astradb would just log and fail immediately without retries. This pr adds retry logic with exponential backoff for transient errors for `create_collection`, `insert_many`, and `update_one` so it will hopefully succeed after several retries

## Changes
- updated **docling-jobkit/connectors/astradb_helper.py** with a new exponential backoff retry method and wrapped the `create_collection`, `insert_many`, and `update_one` methods with it so they retry
- replaced hardcoded emb_dim with one derived from embedding model
- Added unit tests for the exponential backoff logic
