### PR TITLE
Feat: Added support for AstraDB embeddings 

### DIFF
--- a/dev/configs/run_astradb_example.yaml
+++ b/dev/configs/run_astradb_example.yaml
@@ -13,8 +13,11 @@ target:
   token: "AstraCS:{xxx}"
   keyspace: "default_keyspace"
   collection_name: "example_collection"
-  embedding_config: 
-    embedding_provider: ollama
+
+  enable_external_provider: true
+
+  external_provider_config: 
+    provider: ollama
 
     ollama:
       embedding_model: "nomic-embed-text"

--- a/docling_jobkit/connectors/astradb_helper.py
+++ b/docling_jobkit/connectors/astradb_helper.py
@@ -63,7 +63,9 @@ def _with_exponential_retry(fn: Callable[[], T], operation: str) -> T:
     raise last_exc  # type: ignore[misc]
 
 
-def get_collection(coords: AstraDBCoordinates, emb_dim: int) -> Collection:
+def get_collection(
+    coords: AstraDBCoordinates, emb_dim: int | None = None
+) -> Collection:
     """
     fetch the collection from AstraDB to save the document chunks to
     If the specified collection doesn't exist, it will create the collection on AstraDB
@@ -76,16 +78,27 @@ def get_collection(coords: AstraDBCoordinates, emb_dim: int) -> Collection:
         keyspace=coords.keyspace,
     )
 
+    if coords.enable_external_provider:
+        definition = (
+            CollectionDefinition.builder()
+            .with_vector_dimension(emb_dim)
+            .with_vector_metric(VectorMetric.COSINE)
+            .build()
+        )
+    else:
+        # Note: embedding model is hardcoded for now but could all users to toggle this in the
+        # future via config file
+        definition = (
+            CollectionDefinition.builder()
+            .with_vector_service("nvidia", "NV-Embed-QA")
+            .build()
+        )
+
     # idempotent, if collection exists it will just return status ok
     collection = _with_exponential_retry(
         lambda: db.create_collection(
             coords.collection_name,
-            definition=(
-                CollectionDefinition.builder()
-                .with_vector_dimension(emb_dim)
-                .with_vector_metric(VectorMetric.COSINE)
-                .build()
-            ),
+            definition=definition,
         ),
         "create_collection",
     )
@@ -102,43 +115,47 @@ def build_records_from_chunks(
     chunks: list[ChunkedDocumentResultItem],
     doc_id: str,
     source_name: str,
-    emb_model: str,
-    emb_kwargs: dict,
+    emb_model: str | None = None,
+    emb_kwargs: dict | None = None,
     emb_max_tokens: int | None = None,
 ) -> list[dict]:
     """Convert pre-built chunk items into AstraDB insertion records."""
-    # one batch chunk text embedding call
-    texts = [chunk.text for chunk in chunks]
-    try:
-        embeddings = generate_text_embedding(
-            emb_model, texts, emb_max_tokens, **emb_kwargs
-        )
-    except EmbeddingError:
-        # since embeddings are required before writing to AstraDB, fail entire document
-        # instead of inserting chunks with no embeddings
-        logging.exception("AstraDB: embedding failed for '%s'", source_name)
-        raise
+    if emb_model is not None:
+        # one batch chunk text embedding call
+        texts = [chunk.text for chunk in chunks]
+        try:
+            embeddings = generate_text_embedding(
+                emb_model, texts, emb_max_tokens, **(emb_kwargs or {})
+            )
+        except EmbeddingError:
+            # since embeddings are required before writing to AstraDB, fail entire document
+            # instead of inserting chunks with no embeddings
+            logging.exception("AstraDB: embedding failed for '%s'", source_name)
+            raise
 
     records = []
     for i, chunk in enumerate(chunks):
-        records.append(
-            {
-                # TODO: Think more on id generation
-                "_id": f"{doc_id}:chunk:{chunk.chunk_index}",
-                "doc_id": doc_id,
-                "source_name": source_name,
-                "filename": chunk.filename,
-                "chunk_index": chunk.chunk_index,
-                "text": chunk.text,
-                "$vector": embeddings[i],
-                "num_tokens": chunk.num_tokens,
-                "headings": chunk.headings or [],
-                "captions": chunk.captions or [],
-                "page_numbers": chunk.page_numbers or [],
-                "doc_items": chunk.doc_items or [],
-                "metadata": chunk.metadata or {},
-            }
-        )
+        record = {
+            # TODO: Think more on id generation
+            "_id": f"{doc_id}:chunk:{chunk.chunk_index}",
+            "doc_id": doc_id,
+            "source_name": source_name,
+            "filename": chunk.filename,
+            "chunk_index": chunk.chunk_index,
+            "text": chunk.text,
+            "num_tokens": chunk.num_tokens,
+            "headings": chunk.headings or [],
+            "captions": chunk.captions or [],
+            "page_numbers": chunk.page_numbers or [],
+            "doc_items": chunk.doc_items or [],
+            "metadata": chunk.metadata or {},
+        }
+        if emb_model is not None:
+            record["$vector"] = embeddings[i]
+        else:
+            record["$vectorize"] = chunk.text
+        records.append(record)
+
     return records
 
 

--- a/docling_jobkit/connectors/astradb_target_processor.py
+++ b/docling_jobkit/connectors/astradb_target_processor.py
@@ -33,42 +33,60 @@ class AstraDBTargetProcessor(BaseTargetProcessor):
     def _initialize(self) -> None:
         from docling_jobkit.connectors.astradb_helper import get_collection
         from docling_jobkit.convert.chunking import DocumentChunkerManager
-        from docling_jobkit.convert.embedding import generate_text_embedding
 
-        emb_config = self._coords.embedding_config
-        provider = emb_config.embedding_provider
+        # these args are only necessary if the user chooses to use the external embedding provider
+        if self._coords.enable_external_provider:
+            from docling_jobkit.convert.embedding import generate_text_embedding
 
-        if provider == "ollama":
-            self._embedding_model = f"ollama/{emb_config.ollama.embedding_model}"
-            self._embedding_kwargs = {"api_base": emb_config.ollama.endpoint}
-            self._max_tokens = (
-                2000  # ollama specifically has a max_tokens of 2000 instead of 8000
+            if not self._coords.external_provider_config:
+                raise RuntimeError(
+                    "external_provider_config is required when enable_external_provider is true"
+                )
+            external_emb_config = self._coords.external_provider_config
+            provider = external_emb_config.provider
+
+            if provider == "ollama":
+                self._embedding_model = (
+                    f"ollama/{external_emb_config.ollama.embedding_model}"
+                )
+                self._embedding_kwargs = {
+                    "api_base": external_emb_config.ollama.endpoint
+                }
+                self._max_tokens = (
+                    2000  # ollama specifically has a max_tokens of 2000 instead of 8000
+                )
+            elif provider == "openai":
+                self._embedding_model = (
+                    f"openai/{external_emb_config.openai.embedding_model}"
+                )
+                self._embedding_kwargs = {
+                    "api_key": external_emb_config.openai.api_key.get_secret_value()
+                }
+            elif provider == "watsonx":
+                self._embedding_model = (
+                    f"watsonx/{external_emb_config.watsonx.embedding_model}"
+                )
+                self._embedding_kwargs = {
+                    "api_key": external_emb_config.watsonx.api_key.get_secret_value(),
+                    "api_base": external_emb_config.watsonx.endpoint,
+                    "project_id": external_emb_config.watsonx.project_id,
+                }
+
+            if not self._embedding_model:
+                raise RuntimeError("Embedding model was not set")
+
+            emb_dim = len(
+                generate_text_embedding(
+                    self._embedding_model, ["test"], **self._embedding_kwargs
+                )[0]
             )
-        elif provider == "openai":
-            self._embedding_model = f"openai/{emb_config.openai.embedding_model}"
-            self._embedding_kwargs = {
-                "api_key": emb_config.openai.api_key.get_secret_value()
-            }
-        elif provider == "watsonx":
-            self._embedding_model = f"watsonx/{emb_config.watsonx.embedding_model}"
-            self._embedding_kwargs = {
-                "api_key": emb_config.watsonx.api_key.get_secret_value(),
-                "api_base": emb_config.watsonx.endpoint,
-                "project_id": emb_config.watsonx.project_id,
-            }
+            if not emb_dim:
+                raise RuntimeError("Could not determine embedding dimension from model")
 
-        if not self._embedding_model:
-            raise RuntimeError("Embedding model was not set")
+            self._collection = get_collection(self._coords, emb_dim)
+        else:
+            self._collection = get_collection(self._coords)
 
-        emb_dim = len(
-            generate_text_embedding(
-                self._embedding_model, ["test"], **self._embedding_kwargs
-            )[0]
-        )
-        if not emb_dim:
-            raise RuntimeError("Could not determine embedding dimension from model")
-
-        self._collection = get_collection(self._coords, emb_dim)
         self._chunker_manager = DocumentChunkerManager()
 
     def _finalize(self) -> None:
@@ -90,8 +108,8 @@ class AstraDBTargetProcessor(BaseTargetProcessor):
             insert_records,
         )
 
-        if not self._embedding_model:
-            raise RuntimeError("Embedding model not initialized")
+        if not self._collection:
+            raise RuntimeError("Collection not initialized")
 
         if not chunks:
             logging.warning("AstraDB: no chunks to insert for '%s'", source_name)

--- a/docling_jobkit/datamodel/astradb_coords.py
+++ b/docling_jobkit/datamodel/astradb_coords.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Literal
 
-from pydantic import BaseModel, Field, HttpUrl, SecretStr
+from pydantic import BaseModel, Field, HttpUrl, SecretStr, StrictBool
 
 
 class OllamaEmbeddingCoordinates(BaseModel):
@@ -91,7 +91,7 @@ class WatsonXEmbeddingCoordinates(BaseModel):
 class EmbeddingConfig(BaseModel):
     """Embedding provider selection and per-provider configuration."""
 
-    embedding_provider: Annotated[
+    provider: Annotated[
         Literal["ollama", "openai", "watsonx"],
         Field(description="Embedding provider to use."),
     ]
@@ -153,9 +153,21 @@ class AstraDBCoordinates(BaseModel):
         ),
     ]
 
-    embedding_config: Annotated[
-        EmbeddingConfig,
+    enable_external_provider: Annotated[
+        StrictBool,
         Field(
-            description="Embedding provider selection and configuration.",
+            description=(
+                "boolean toggle to enable or disable external embedding provider support"
+                "If disabled, uses astradb embedded embeddings"
+                "If enabled uses the external embedding provider defined in the config file"
+            )
         ),
     ]
+
+    external_provider_config: Annotated[
+        EmbeddingConfig | None,
+        Field(
+            default=None,
+            description="External embedding provider selection and configuration. Required when enable_external_provider is true.",
+        ),
+    ] = None

--- a/tests/test_astradb_helper.py
+++ b/tests/test_astradb_helper.py
@@ -64,6 +64,21 @@ def test_build_records_propagates_embedding_error(
             )
 
 
+def test_build_records_uses_vectorize_when_no_emb_model(
+    mock_chunks: list[ChunkedDocumentResultItem],
+) -> None:
+    """When emb_model is None, records use $vectorize instead of $vector and no embedding is called."""
+    with patch(
+        "docling_jobkit.connectors.astradb_helper.generate_text_embedding"
+    ) as mock_embed:
+        records = build_records_from_chunks(mock_chunks, "doc1", "source.pdf")
+
+    mock_embed.assert_not_called()
+    assert "$vectorize" in records[0]
+    assert "$vector" not in records[0]
+    assert records[0]["$vectorize"] == mock_chunks[0].text
+
+
 # exponential backoff test stuff
 
 
@@ -168,30 +183,33 @@ def test_insert_records_conflict_falls_back_to_update_one() -> None:
 
 # get_collection
 
+_BASE_COORDS = {
+    "api_endpoint": "https://abc123.apps.astra.datastax.com",
+    "token": "AstraCS:test_token",
+    "keyspace": "test_keyspace",
+    "collection_name": "test_collection",
+}
 
-def test_get_collection_uses_token_and_returns_collection() -> None:
-    """get_collection should authenticate with the token and return the collection."""
-    from docling_jobkit.datamodel.astradb_coords import AstraDBCoordinates
 
-    coords = AstraDBCoordinates.model_validate(
-        {
-            "api_endpoint": "https://abc123.apps.astra.datastax.com",
-            "token": "AstraCS:test_token",
-            "keyspace": "test_keyspace",
-            "collection_name": "test_collection",
-        }
-    )
-
+def _make_mock_astra_client() -> tuple[MagicMock, MagicMock, MagicMock]:
     mock_collection = MagicMock()
     mock_db = MagicMock()
     mock_db.create_collection.return_value = mock_collection
     mock_client = MagicMock()
     mock_client.get_database.return_value = mock_db
+    return mock_client, mock_db, mock_collection
 
-    with patch(
-        "astrapy.DataAPIClient",
-        return_value=mock_client,
-    ):
+
+def test_get_collection_uses_token_and_returns_collection() -> None:
+    """get_collection authenticates with the token and returns the collection."""
+    from docling_jobkit.datamodel.astradb_coords import AstraDBCoordinates
+
+    coords = AstraDBCoordinates.model_validate(
+        {**_BASE_COORDS, "enable_external_provider": True}
+    )
+    mock_client, mock_db, mock_collection = _make_mock_astra_client()
+
+    with patch("astrapy.DataAPIClient", return_value=mock_client):
         result = get_collection(coords, emb_dim=768)
 
     mock_client.get_database.assert_called_once_with(
@@ -199,3 +217,55 @@ def test_get_collection_uses_token_and_returns_collection() -> None:
     )
     mock_db.create_collection.assert_called_once()
     assert result is mock_collection
+
+
+def test_get_collection_uses_cosine_dim_when_external_enabled() -> None:
+    """When enable_external_provider=True, collection definition uses vector dimension + cosine."""
+    from docling_jobkit.datamodel.astradb_coords import AstraDBCoordinates
+
+    coords = AstraDBCoordinates.model_validate(
+        {**_BASE_COORDS, "enable_external_provider": True}
+    )
+    mock_client, mock_db, _ = _make_mock_astra_client()
+    mock_builder = MagicMock()
+    mock_builder.with_vector_dimension.return_value = mock_builder
+    mock_builder.with_vector_metric.return_value = mock_builder
+    mock_builder.build.return_value = MagicMock()
+
+    with (
+        patch("astrapy.DataAPIClient", return_value=mock_client),
+        patch(
+            "docling_jobkit.connectors.astradb_helper.CollectionDefinition"
+        ) as mock_defn,
+    ):
+        mock_defn.builder.return_value = mock_builder
+        get_collection(coords, emb_dim=768)
+
+    mock_builder.with_vector_dimension.assert_called_once_with(768)
+    mock_builder.with_vector_metric.assert_called_once()
+    mock_builder.with_vector_service.assert_not_called()
+
+
+def test_get_collection_uses_vector_service_when_external_disabled() -> None:
+    """When enable_external_provider=False, collection definition uses nvidia vector service."""
+    from docling_jobkit.datamodel.astradb_coords import AstraDBCoordinates
+
+    coords = AstraDBCoordinates.model_validate(
+        {**_BASE_COORDS, "enable_external_provider": False}
+    )
+    mock_client, mock_db, _ = _make_mock_astra_client()
+    mock_builder = MagicMock()
+    mock_builder.with_vector_service.return_value = mock_builder
+    mock_builder.build.return_value = MagicMock()
+
+    with (
+        patch("astrapy.DataAPIClient", return_value=mock_client),
+        patch(
+            "docling_jobkit.connectors.astradb_helper.CollectionDefinition"
+        ) as mock_defn,
+    ):
+        mock_defn.builder.return_value = mock_builder
+        get_collection(coords)
+
+    mock_builder.with_vector_service.assert_called_once_with("nvidia", "NV-Embed-QA")
+    mock_builder.with_vector_dimension.assert_not_called()

--- a/tests/test_astradb_target_processor.py
+++ b/tests/test_astradb_target_processor.py
@@ -19,6 +19,23 @@ def coords() -> AstraDBCoordinates:
             "keyspace": "test_keyspace",
             "collection_name": "test_collection",
             "enable_external_provider": False,
+            "external_provider_config": {
+                "provider": "ollama",
+                "ollama": {
+                    "endpoint": "http://localhost:11434",
+                    "embedding_model": "nomic-embed-text",
+                },
+                "openai": {
+                    "api_key": "sk-test",
+                    "embedding_model": "text-embedding-3-small",
+                },
+                "watsonx": {
+                    "api_key": "wx-test",
+                    "endpoint": "https://us-south.ml.cloud.ibm.com",
+                    "project_id": "proj-id",
+                    "embedding_model": "ibm/granite",
+                },
+            },
         }
     )
 
@@ -168,3 +185,99 @@ def test_chunk_and_upload_delegates_to_upload_chunks(
     mock_upload.assert_called_once_with(
         mock_chunks, doc_id="abc123", source_name="doc.pdf"
     )
+
+
+def test_chunk_and_upload_skips_when_document_is_none(
+    coords: AstraDBCoordinates,
+) -> None:
+    """chunk_and_upload returns early when document is None."""
+    processor = _make_initialized_processor(coords)
+    exportable = MagicMock()
+    exportable.status = ConversionStatus.SUCCESS
+    exportable.document = None
+
+    with patch.object(processor, "upload_chunks") as mock_upload:
+        processor.chunk_and_upload(exportable)
+
+    mock_upload.assert_not_called()
+
+
+def test_chunk_and_upload_skips_when_no_chunks_produced(
+    coords: AstraDBCoordinates,
+) -> None:
+    """chunk_and_upload returns early without calling upload_chunks when chunking yields nothing."""
+    processor = _make_initialized_processor(coords)
+    processor._chunker_manager.chunk_document.return_value = iter([])
+
+    exportable = MagicMock()
+    exportable.status = ConversionStatus.SUCCESS
+    exportable.file.name = "doc.pdf"
+    exportable.document.origin.binary_hash = "abc123"
+
+    with patch.object(processor, "upload_chunks") as mock_upload:
+        processor.chunk_and_upload(exportable)
+
+    mock_upload.assert_not_called()
+
+
+# _initialize
+
+
+def test_initialize_without_external_provider(coords: AstraDBCoordinates) -> None:
+    """_initialize with enable_external_provider=False calls get_collection without emb_dim."""
+    processor = AstraDBTargetProcessor(coords)
+    mock_collection = MagicMock()
+
+    with (
+        patch(
+            "docling_jobkit.connectors.astradb_helper.get_collection",
+            return_value=mock_collection,
+        ) as mock_get_coll,
+        patch("docling_jobkit.convert.chunking.DocumentChunkerManager"),
+    ):
+        processor._initialize()
+
+    mock_get_coll.assert_called_once_with(coords)
+    assert processor._collection is mock_collection
+    assert processor._embedding_model is None
+
+
+def test_initialize_with_external_provider_missing_config_raises() -> None:
+    """When enable_external_provider=True but no external_provider_config, raises RuntimeError."""
+    coords_no_config = AstraDBCoordinates.model_validate(
+        {
+            "api_endpoint": "https://abc123.apps.astra.datastax.com",
+            "token": "AstraCS:test_token",
+            "keyspace": "test_keyspace",
+            "collection_name": "test_collection",
+            "enable_external_provider": True,
+        }
+    )
+    processor = AstraDBTargetProcessor(coords_no_config)
+    with pytest.raises(RuntimeError, match="external_provider_config is required"):
+        processor._initialize()
+
+
+def test_initialize_with_external_provider_ollama(coords: AstraDBCoordinates) -> None:
+    """_initialize with ollama sets the right embedding model, endpoint kwargs, and max_tokens."""
+    coords_enabled = coords.model_copy(update={"enable_external_provider": True})
+    processor = AstraDBTargetProcessor(coords_enabled)
+    mock_collection = MagicMock()
+
+    with (
+        patch(
+            "docling_jobkit.convert.embedding.generate_text_embedding",
+            return_value=[[0.1] * 768],
+        ),
+        patch(
+            "docling_jobkit.connectors.astradb_helper.get_collection",
+            return_value=mock_collection,
+        ),
+        patch("docling_jobkit.convert.chunking.DocumentChunkerManager"),
+    ):
+        processor._initialize()
+
+    assert processor._embedding_model == "ollama/nomic-embed-text"
+    assert processor._embedding_kwargs == {"api_base": "http://localhost:11434"}
+    assert processor._max_tokens == 2000
+    assert processor._collection is mock_collection

--- a/tests/test_astradb_target_processor.py
+++ b/tests/test_astradb_target_processor.py
@@ -18,6 +18,7 @@ def coords() -> AstraDBCoordinates:
             "token": "AstraCS:test_token",
             "keyspace": "test_keyspace",
             "collection_name": "test_collection",
+            "enable_external_provider": False,
         }
     )
 
@@ -98,6 +99,8 @@ def test_upload_chunks_happy_path(
         doc_id="doc1",
         source_name="doc.pdf",
         emb_model=processor._embedding_model,
+        emb_kwargs=processor._embedding_kwargs,
+        emb_max_tokens=processor._max_tokens,
     )
     mock_insert.assert_called_once_with(
         processor._collection, mock_records, source_name="doc.pdf"


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->
## Summary
Previously the astradb connector only supported external astradb embedding providers like ollama, openai, and watsonx. This pr adds a new config flag that when enabled, uses astradb build in embeddings (via nvidia NV-Embed-QA model) and uses external providers when disabled. This allows users who don't have access to external embedding providers to be able to use embeddings

Note: AstraDB embedding model is hardcoded for now but could be updated to allow for user configuration 