### PR TITLE
feat: azure blob storage connector

### DIFF
--- a/dev/configs/run_azure_example.yaml
+++ b/dev/configs/run_azure_example.yaml
@@ -4,14 +4,16 @@ options:
     - json
 
 sources:
-  - kind: local_path
-    path: "input_documents"
-    pattern: "*.pdf"
-    recursive: false
+  - kind: azure_blob
+    account_name: "storage-account"
+    container: "input"
+    connection_string: "DefaultEndpointsProtocol=https;AccountName=your-account-name;AccountKey=your-account-key;EndpointSuffix=core.windows.net"
+    blob_prefix: "" # empty for all blobs, or remove
+    max_num_elements: 10 # can remove to get all blobs
 
 target:
   kind: azure_blob
   account_name: "storage-account"
-  container: "input"
+  container: "output"
   connection_string: "DefaultEndpointsProtocol=https;AccountName=your-account-name;AccountKey=your-account-key;EndpointSuffix=core.windows.net"
   blob_prefix: "converted/"

--- a/dev/configs/run_azure_example.yaml
+++ b/dev/configs/run_azure_example.yaml
@@ -1,0 +1,17 @@
+options:
+  do_ocr: false
+  to_formats:
+    - json
+
+sources:
+  - kind: local_path
+    path: "input_documents"
+    pattern: "*.pdf"
+    recursive: false
+
+target:
+  kind: azure_blob
+  account_name: "storage-account"
+  container: "input"
+  connection_string: "DefaultEndpointsProtocol=https;AccountName=your-account-name;AccountKey=your-account-key;EndpointSuffix=core.windows.net"
+  blob_prefix: "converted/"

--- a/docling_jobkit/connectors/azure_blob_helper.py
+++ b/docling_jobkit/connectors/azure_blob_helper.py
@@ -1,0 +1,22 @@
+"""Azure Blob Storage connection management and utilities."""
+
+import logging
+
+from azure.storage.blob import BlobServiceClient, ContainerClient
+
+from docling_jobkit.datamodel.azure_blob_coords import AzureBlobCoordinates
+
+_log = logging.getLogger(__name__)
+
+# Suppress verbose Azure SDK HTTP logging
+logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(
+    logging.WARNING
+)
+
+
+def get_azure_blob_connection(
+    coords: AzureBlobCoordinates,
+) -> tuple[BlobServiceClient, ContainerClient]:
+    service_client = BlobServiceClient.from_connection_string(coords.connection_string)
+    container_client = service_client.get_container_client(coords.container)
+    return service_client, container_client

--- a/docling_jobkit/connectors/azure_blob_helper.py
+++ b/docling_jobkit/connectors/azure_blob_helper.py
@@ -1,12 +1,8 @@
-"""Azure Blob Storage connection management and utilities."""
-
 import logging
 
 from azure.storage.blob import BlobServiceClient, ContainerClient
 
 from docling_jobkit.datamodel.azure_blob_coords import AzureBlobCoordinates
-
-_log = logging.getLogger(__name__)
 
 # Suppress verbose Azure SDK HTTP logging
 logging.getLogger("azure.core.pipeline.policies.http_logging_policy").setLevel(

--- a/docling_jobkit/connectors/azure_blob_source_processor.py
+++ b/docling_jobkit/connectors/azure_blob_source_processor.py
@@ -1,0 +1,148 @@
+"""Azure Blob Storage source processor."""
+
+import logging
+from datetime import datetime
+from io import BytesIO
+from typing import Iterator
+
+from azure.core.exceptions import ResourceNotFoundError, ServiceRequestError
+from pydantic import BaseModel
+from typing_extensions import override
+
+from docling_core.types.io import DocumentStream
+
+from docling_jobkit.connectors.azure_blob_helper import get_azure_blob_connection
+from docling_jobkit.connectors.source_processor import (
+    BaseSourceProcessor,
+    SourceDocumentRef,
+)
+from docling_jobkit.convert.materialization import (
+    SourceLimitExceededError,
+    normalize_max_file_size,
+)
+from docling_jobkit.datamodel.azure_blob_coords import AzureBlobCoordinates
+
+_log = logging.getLogger(__name__)
+
+
+class AzureBlobFileIdentifier(BaseModel):
+    name: str  # blob name ~= s3 key
+    size: int
+    last_modified: datetime | None = None
+
+
+class AzureBlobSourceProcessor(
+    BaseSourceProcessor[AzureBlobCoordinates, AzureBlobFileIdentifier]
+):
+    def __init__(self, coords: AzureBlobCoordinates):
+        super().__init__(coords)
+        self._coords = coords
+
+    @classmethod
+    def get_config_types(cls) -> tuple[type[BaseModel], ...]:
+        # Note: Using TaskAzureBlobSource (not AzureBlobSourceRequest) to follow
+        # the naming pattern for connectors defined in docling-jobkit (Google Drive, Local Path)
+        # S3 has S3SourceRequest defined in docling core library. No azure equivalent.
+
+        from docling_jobkit.datamodel.task_sources import TaskAzureBlobSource
+
+        return (TaskAzureBlobSource,)
+
+    def _initialize(self):
+        self._service_client, self._container_client = get_azure_blob_connection(
+            self._coords
+        )
+        _log.info(
+            "Connected to Azure Blob Storage: azure://%s/%s",
+            self._coords.account_name,
+            self._coords.container,
+        )
+
+    def _finalize(self):
+        self._service_client.close()
+
+    def _list_document_ids(self) -> Iterator[AzureBlobFileIdentifier]:
+        yielded = 0
+        max_num_elements = self._coords.max_num_elements
+
+        for blob in self._container_client.list_blobs(
+            name_starts_with=self._coords.blob_prefix or None
+        ):
+            if max_num_elements is not None and yielded >= max_num_elements:
+                return
+
+            yielded += 1
+            yield AzureBlobFileIdentifier(
+                name=blob.name,
+                size=blob.size or 0,
+                last_modified=blob.last_modified,
+            )
+
+    def _count_documents(self) -> int:
+        total = 0
+        max_num_elements = self._coords.max_num_elements
+
+        for blob in self._container_client.list_blobs(
+            name_starts_with=self._coords.blob_prefix or None
+        ):
+            if max_num_elements is not None and total >= max_num_elements:
+                return max_num_elements
+            total += 1
+
+        return total
+
+    @override
+    def _make_document_ref(
+        self, identifier: AzureBlobFileIdentifier, source_index: int
+    ) -> SourceDocumentRef[AzureBlobFileIdentifier]:
+        return SourceDocumentRef(
+            id=identifier,
+            source_index=source_index,
+            source_uri=f"azure://{self._coords.account_name}/{self._coords.container}/{identifier.name}",
+            filename=identifier.name,
+        )
+
+    def _fetch_document_by_id(
+        self,
+        identifier: AzureBlobFileIdentifier,
+        *,
+        max_file_size: int | None = None,
+    ) -> DocumentStream:
+        limit = normalize_max_file_size(max_file_size)
+        if limit is not None and identifier.size > limit:
+            raise SourceLimitExceededError(
+                f"Source '{identifier.name}' exceeds max_file_size={limit} bytes"
+            )
+
+        _log.info(
+            "Downloading from azure://%s/%s/%s",
+            self._coords.account_name,
+            self._coords.container,
+            identifier.name,
+        )
+        buffer = BytesIO()
+        try:
+            blob_client = self._container_client.get_blob_client(identifier.name)
+            download_stream = blob_client.download_blob()
+            download_stream.readinto(buffer)
+        except (ResourceNotFoundError, ServiceRequestError):
+            _log.warning(
+                "Failed to download azure://%s/%s/%s",
+                self._coords.account_name,
+                self._coords.container,
+                identifier.name,
+                exc_info=True,
+            )
+            raise
+
+        buffer.seek(0)
+        return DocumentStream(name=identifier.name, stream=buffer)
+
+    def _fetch_documents(
+        self, *, max_file_size: int | None = None
+    ) -> Iterator[DocumentStream]:
+        for blob_id in self._list_document_ids():
+            yield self._fetch_document_by_id(
+                blob_id,
+                max_file_size=max_file_size,
+            )

--- a/docling_jobkit/connectors/azure_blob_source_processor.py
+++ b/docling_jobkit/connectors/azure_blob_source_processor.py
@@ -1,5 +1,3 @@
-"""Azure Blob Storage source processor."""
-
 import logging
 from datetime import datetime
 from io import BytesIO
@@ -21,6 +19,7 @@ from docling_jobkit.convert.materialization import (
     normalize_max_file_size,
 )
 from docling_jobkit.datamodel.azure_blob_coords import AzureBlobCoordinates
+from docling_jobkit.datamodel.task_sources import TaskAzureBlobSource
 
 _log = logging.getLogger(__name__)
 
@@ -43,8 +42,6 @@ class AzureBlobSourceProcessor(
         # Note: Using TaskAzureBlobSource (not AzureBlobSourceRequest) to follow
         # the naming pattern for connectors defined in docling-jobkit (Google Drive, Local Path)
         # S3 has S3SourceRequest defined in docling core library. No azure equivalent.
-
-        from docling_jobkit.datamodel.task_sources import TaskAzureBlobSource
 
         return (TaskAzureBlobSource,)
 

--- a/docling_jobkit/connectors/azure_blob_target_processor.py
+++ b/docling_jobkit/connectors/azure_blob_target_processor.py
@@ -1,5 +1,3 @@
-"""Azure Blob Storage target processor."""
-
 import logging
 from pathlib import Path
 from typing import BinaryIO
@@ -13,6 +11,7 @@ from docling_jobkit.connectors.azure_blob_upload_support import (
 )
 from docling_jobkit.connectors.target_processor import BaseTargetProcessor
 from docling_jobkit.datamodel.azure_blob_coords import AzureBlobCoordinates
+from docling_jobkit.datamodel.task_targets import AzureBlobTarget
 
 _log = logging.getLogger(__name__)
 
@@ -24,8 +23,6 @@ class AzureBlobTargetProcessor(BaseTargetProcessor):
 
     @classmethod
     def get_config_types(cls) -> tuple[type[BaseModel], ...]:
-        from docling_jobkit.datamodel.task_targets import AzureBlobTarget
-
         return (AzureBlobTarget,)
 
     def _initialize(self):

--- a/docling_jobkit/connectors/azure_blob_target_processor.py
+++ b/docling_jobkit/connectors/azure_blob_target_processor.py
@@ -1,0 +1,92 @@
+"""Azure Blob Storage target processor."""
+
+import logging
+from pathlib import Path
+from typing import BinaryIO
+
+from pydantic import BaseModel
+
+from docling_jobkit.connectors.azure_blob_helper import get_azure_blob_connection
+from docling_jobkit.connectors.azure_blob_upload_support import (
+    upload_azure_blob_file,
+    upload_azure_blob_object,
+)
+from docling_jobkit.connectors.target_processor import BaseTargetProcessor
+from docling_jobkit.datamodel.azure_blob_coords import AzureBlobCoordinates
+
+_log = logging.getLogger(__name__)
+
+
+class AzureBlobTargetProcessor(BaseTargetProcessor):
+    def __init__(self, coords: AzureBlobCoordinates):
+        super().__init__()
+        self._coords = coords
+
+    @classmethod
+    def get_config_types(cls) -> tuple[type[BaseModel], ...]:
+        from docling_jobkit.datamodel.task_targets import AzureBlobTarget
+
+        return (AzureBlobTarget,)
+
+    def _initialize(self):
+        self._service_client, self._container_client = get_azure_blob_connection(
+            self._coords
+        )
+
+    def _finalize(self):
+        self._service_client.close()
+
+    def _build_full_blob_name(self, target_filename: str) -> str:
+        return (
+            f"{self._coords.blob_prefix}{target_filename}"
+            if self._coords.blob_prefix
+            else target_filename
+        )
+
+    def build_artifact_uri(self, target_filename: str) -> str:
+        full_name = self._build_full_blob_name(target_filename)
+        return (
+            f"azure://{self._coords.account_name}/{self._coords.container}/{full_name}"
+        )
+
+    def upload_file(
+        self,
+        filename: str | Path,
+        target_filename: str,
+        content_type: str,
+    ) -> None:
+        """Upload a local file from disk into Azure Blob Storage."""
+        full_name = self._build_full_blob_name(target_filename)
+        blob_client = self._container_client.get_blob_client(full_name)
+        _log.info(
+            "Uploading to azure://%s/%s/%s",
+            self._coords.account_name,
+            self._coords.container,
+            full_name,
+        )
+        upload_azure_blob_file(
+            blob_client,
+            filename=filename,
+            content_type=content_type,
+        )
+
+    def upload_object(
+        self,
+        obj: str | bytes | BinaryIO,
+        target_filename: str,
+        content_type: str,
+    ) -> None:
+        """Upload an in-memory object into Azure Blob Storage."""
+        full_name = self._build_full_blob_name(target_filename)
+        blob_client = self._container_client.get_blob_client(full_name)
+        _log.info(
+            "Uploading to azure://%s/%s/%s",
+            self._coords.account_name,
+            self._coords.container,
+            full_name,
+        )
+        upload_azure_blob_object(
+            blob_client,
+            obj=obj,
+            content_type=content_type,
+        )

--- a/docling_jobkit/connectors/azure_blob_upload_support.py
+++ b/docling_jobkit/connectors/azure_blob_upload_support.py
@@ -1,5 +1,3 @@
-"""Azure Blob Storage upload utilities."""
-
 from io import BytesIO
 from pathlib import Path
 from typing import BinaryIO

--- a/docling_jobkit/connectors/azure_blob_upload_support.py
+++ b/docling_jobkit/connectors/azure_blob_upload_support.py
@@ -1,0 +1,47 @@
+"""Azure Blob Storage upload utilities."""
+
+from io import BytesIO
+from pathlib import Path
+from typing import BinaryIO
+
+from azure.storage.blob import BlobClient, ContentSettings
+
+
+def upload_azure_blob_file(
+    blob_client: BlobClient,
+    filename: str | Path,
+    content_type: str,
+    metadata: dict[str, str] | None = None,
+) -> None:
+    content_settings = ContentSettings(content_type=content_type)
+
+    with open(filename, "rb") as data:
+        blob_client.upload_blob(
+            data,
+            overwrite=True,
+            content_settings=content_settings,
+            metadata=metadata,
+        )
+
+
+def upload_azure_blob_object(
+    blob_client: BlobClient,
+    obj: str | bytes | BinaryIO,
+    content_type: str,
+    metadata: dict[str, str] | None = None,
+) -> None:
+    if isinstance(obj, str):
+        data: BinaryIO = BytesIO(obj.encode())
+    elif isinstance(obj, bytes):
+        data = BytesIO(obj)
+    else:
+        data = obj
+
+    content_settings = ContentSettings(content_type=content_type)
+
+    blob_client.upload_blob(
+        data,
+        overwrite=True,
+        content_settings=content_settings,
+        metadata=metadata,
+    )

--- a/docling_jobkit/connectors/plugins/defaults.py
+++ b/docling_jobkit/connectors/plugins/defaults.py
@@ -13,6 +13,9 @@ even when the ``gdrive`` extra is not installed.
 
 
 def source_connectors():
+    from docling_jobkit.connectors.azure_blob_source_processor import (
+        AzureBlobSourceProcessor,
+    )
     from docling_jobkit.connectors.google_drive_source_processor import (
         GoogleDriveSourceProcessor,
     )
@@ -26,6 +29,7 @@ def source_connectors():
         "source_connectors": [
             HttpSourceProcessor,
             S3SourceProcessor,
+            AzureBlobSourceProcessor,
             LocalPathSourceProcessor,
             GoogleDriveSourceProcessor,
         ]
@@ -33,6 +37,9 @@ def source_connectors():
 
 
 def target_connectors():
+    from docling_jobkit.connectors.azure_blob_target_processor import (
+        AzureBlobTargetProcessor,
+    )
     from docling_jobkit.connectors.google_drive_target_processor import (
         GoogleDriveTargetProcessor,
     )
@@ -47,6 +54,7 @@ def target_connectors():
     return {
         "target_connectors": [
             S3TargetProcessor,
+            AzureBlobTargetProcessor,
             LocalPathTargetProcessor,
             HttpPutTargetProcessor,
             GoogleDriveTargetProcessor,

--- a/docling_jobkit/convert/results.py
+++ b/docling_jobkit/convert/results.py
@@ -526,8 +526,9 @@ def _upload_document_to_storage_target(
         export_doctags=export_doctags,
         image_export_mode=image_export_mode,
         md_page_break_placeholder=md_page_break_placeholder,
-        target_filename_fn=lambda source,
-        artifact_filename: f"{source.source_key}/{artifact_filename}",
+        target_filename_fn=lambda source, artifact_filename: (
+            f"{source.source_key}/{artifact_filename}"
+        ),
     )
 
 
@@ -631,27 +632,30 @@ def _process_remote_exportable_results(
                     callback_invoker=callback_invoker,
                     debug_error_details=debug_error_details,
                     callback_mode=callback_mode,
-                    upload_document=lambda _source: _upload_document_as_presigned_artifact(
-                        task=task,
-                        exportable_document=exportable_document,
-                        response_index=idx,
-                        output_dir=output_dir,
-                        target_processor=target_processor,
-                        export_json=export_json,
-                        export_html=export_html,
-                        export_md=export_md,
-                        export_txt=export_txt,
-                        export_doctags=export_doctags,
-                        image_export_mode=image_export_mode,
-                        md_page_break_placeholder=md_page_break_placeholder,
+                    upload_document=lambda _source: (
+                        _upload_document_as_presigned_artifact(
+                            task=task,
+                            exportable_document=exportable_document,
+                            response_index=idx,
+                            output_dir=output_dir,
+                            target_processor=target_processor,
+                            export_json=export_json,
+                            export_html=export_html,
+                            export_md=export_md,
+                            export_txt=export_txt,
+                            export_doctags=export_doctags,
+                            image_export_mode=image_export_mode,
+                            md_page_break_placeholder=md_page_break_placeholder,
+                        )
                     ),
-                    build_failure_result=lambda failed_document,
-                    source: target_processor.build_document_artifact_item(
-                        source=source,
-                        filename=failed_document.file.name,
-                        status=failed_document.status,
-                        errors=failed_document.errors,
-                        timings=failed_document.timings,
+                    build_failure_result=lambda failed_document, source: (
+                        target_processor.build_document_artifact_item(
+                            source=source,
+                            filename=failed_document.file.name,
+                            status=failed_document.status,
+                            errors=failed_document.errors,
+                            timings=failed_document.timings,
+                        )
                     ),
                 )
                 processed_docs.append(processed_doc)

--- a/docling_jobkit/datamodel/azure_blob_coords.py
+++ b/docling_jobkit/datamodel/azure_blob_coords.py
@@ -1,0 +1,37 @@
+"""Azure Blob Storage coordinates for source and target configuration."""
+
+from typing import Annotated
+
+from pydantic import BaseModel, Field
+
+
+class AzureBlobCoordinates(BaseModel):
+    """Azure Blob Storage connection coordinates."""
+
+    account_name: Annotated[
+        str,
+        Field(description="Azure Storage account name"),
+    ]
+
+    container: Annotated[
+        str,
+        Field(description="Azure Blob container name"),
+    ]
+
+    connection_string: Annotated[
+        str,
+        Field(description="Azure Storage connection string for authentication"),
+    ]
+
+    blob_prefix: Annotated[
+        str,
+        Field(default="", description="Prefix for blob names"),
+    ] = ""
+
+    max_num_elements: Annotated[
+        int | None,
+        Field(default=None, description="Maximum number of blobs to process"),
+    ] = None
+
+
+__all__ = ["AzureBlobCoordinates"]

--- a/docling_jobkit/datamodel/azure_blob_coords.py
+++ b/docling_jobkit/datamodel/azure_blob_coords.py
@@ -1,13 +1,9 @@
-"""Azure Blob Storage coordinates for source and target configuration."""
-
 from typing import Annotated
 
 from pydantic import BaseModel, Field
 
 
 class AzureBlobCoordinates(BaseModel):
-    """Azure Blob Storage connection coordinates."""
-
     account_name: Annotated[
         str,
         Field(description="Azure Storage account name"),

--- a/docling_jobkit/datamodel/task_sources.py
+++ b/docling_jobkit/datamodel/task_sources.py
@@ -9,7 +9,12 @@ from docling.datamodel.service.requests import (
     S3SourceRequest,
 )
 
+from docling_jobkit.datamodel.azure_blob_coords import AzureBlobCoordinates
 from docling_jobkit.datamodel.google_drive_coords import GoogleDriveCoordinates
+
+
+class TaskAzureBlobSource(AzureBlobCoordinates):
+    kind: Literal["azure_blob"] = "azure_blob"
 
 
 class TaskGoogleDriveSource(GoogleDriveCoordinates):
@@ -70,12 +75,14 @@ TaskSource = Annotated[
     FileSourceRequest
     | HttpSourceRequest
     | S3SourceRequest
+    | TaskAzureBlobSource
     | TaskGoogleDriveSource
     | TaskLocalPathSource,
     Field(discriminator="kind"),
 ]
 
 __all__ = [
+    "TaskAzureBlobSource",
     "TaskGoogleDriveSource",
     "TaskLocalPathSource",
     "TaskSource",

--- a/docling_jobkit/datamodel/task_targets.py
+++ b/docling_jobkit/datamodel/task_targets.py
@@ -11,7 +11,12 @@ from docling.datamodel.service.targets import (
     ZipTarget,
 )
 
+from docling_jobkit.datamodel.azure_blob_coords import AzureBlobCoordinates
 from docling_jobkit.datamodel.google_drive_coords import GoogleDriveCoordinates
+
+
+class AzureBlobTarget(AzureBlobCoordinates):
+    kind: Literal["azure_blob"] = "azure_blob"
 
 
 class GoogleDriveTarget(GoogleDriveCoordinates):
@@ -43,6 +48,7 @@ TaskTarget = Annotated[
     InBodyTarget
     | ZipTarget
     | S3Target
+    | AzureBlobTarget
     | PresignedUrlTarget
     | GoogleDriveTarget
     | PutTarget
@@ -51,6 +57,7 @@ TaskTarget = Annotated[
 ]
 
 __all__ = [
+    "AzureBlobTarget",
     "GoogleDriveTarget",
     "InBodyTarget",
     "LocalPathTarget",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,9 @@ gdrive = [
     "google-api-python-client>=2.183.0",
     "google-auth-oauthlib>=1.2.2",
 ]
+azure = [
+    "azure-storage-blob>=12.19.0",
+]
 
 [dependency-groups]
 dev = [

--- a/tests/test_azure_blob_source_processor.py
+++ b/tests/test_azure_blob_source_processor.py
@@ -1,0 +1,202 @@
+"""Unit tests for Azure Blob Storage source processor."""
+
+from datetime import datetime, timezone
+from io import BytesIO
+from unittest.mock import MagicMock
+
+import pytest
+from azure.core.exceptions import ResourceNotFoundError
+
+from docling_core.types.io import DocumentStream
+
+from docling_jobkit.connectors.azure_blob_source_processor import (
+    AzureBlobFileIdentifier,
+    AzureBlobSourceProcessor,
+)
+from docling_jobkit.convert.materialization import SourceLimitExceededError
+from docling_jobkit.datamodel.azure_blob_coords import AzureBlobCoordinates
+
+
+@pytest.fixture
+def azure_coords() -> AzureBlobCoordinates:
+    return AzureBlobCoordinates(
+        account_name="testaccount",
+        container="testcontainer",
+        connection_string="DefaultEndpointsProtocol=https;AccountName=testaccount;AccountKey=dGVzdGtleQ==;EndpointSuffix=core.windows.net",
+        blob_prefix="",
+    )
+
+
+def test_azure_blob_document_ref_preserves_canonical_uri(azure_coords):
+    processor = AzureBlobSourceProcessor(azure_coords)
+    ref = processor._make_document_ref(
+        AzureBlobFileIdentifier(
+            name="incoming/doc.pdf",
+            size=123,
+            last_modified=datetime(2026, 6, 2, 10, 0, 0, tzinfo=timezone.utc),
+        ),
+        source_index=5,
+    )
+
+    assert ref.source_index == 5
+    assert ref.source_uri == "azure://testaccount/testcontainer/incoming/doc.pdf"
+    assert ref.filename == "incoming/doc.pdf"
+
+
+def test_azure_blob_list_respects_max_num_elements(azure_coords):
+    capped_coords = azure_coords.model_copy(update={"max_num_elements": 3})
+    processor = AzureBlobSourceProcessor(capped_coords)
+
+    mock_blob1 = MagicMock()
+    mock_blob1.name = "incoming/a.pdf"
+    mock_blob1.size = 100
+    mock_blob1.last_modified = None
+
+    mock_blob2 = MagicMock()
+    mock_blob2.name = "incoming/b.pdf"
+    mock_blob2.size = 200
+    mock_blob2.last_modified = None
+
+    mock_blob3 = MagicMock()
+    mock_blob3.name = "incoming/c.pdf"
+    mock_blob3.size = 300
+    mock_blob3.last_modified = None
+
+    mock_blob4 = MagicMock()
+    mock_blob4.name = "incoming/d.pdf"
+    mock_blob4.size = 400
+    mock_blob4.last_modified = None
+
+    processor._container_client = MagicMock()
+    processor._container_client.list_blobs.return_value = [
+        mock_blob1,
+        mock_blob2,
+        mock_blob3,
+        mock_blob4,
+    ]
+
+    doc_ids = list(processor._list_document_ids())
+
+    assert len(doc_ids) == 3
+    assert [doc_id.name for doc_id in doc_ids] == [
+        "incoming/a.pdf",
+        "incoming/b.pdf",
+        "incoming/c.pdf",
+    ]
+
+
+def test_azure_blob_count_clips_to_max_num_elements(azure_coords):
+    capped_coords = azure_coords.model_copy(update={"max_num_elements": 3})
+    processor = AzureBlobSourceProcessor(capped_coords)
+
+    mock_blobs = []
+    for i in range(5):
+        mock_blob = MagicMock()
+        mock_blob.name = f"file{i}.pdf"
+        mock_blob.size = 100
+        mock_blobs.append(mock_blob)
+
+    processor._container_client = MagicMock()
+    processor._container_client.list_blobs.return_value = mock_blobs
+
+    assert processor._count_documents() == 3
+
+
+def test_azure_blob_iterate_documents_respects_max_num_elements(azure_coords):
+    capped_coords = azure_coords.model_copy(update={"max_num_elements": 2})
+    processor = AzureBlobSourceProcessor(capped_coords)
+    processor._initialized = True
+
+    mock_blobs = []
+    for i in range(3):
+        mock_blob = MagicMock()
+        mock_blob.name = f"file{i}.pdf"
+        mock_blob.size = 100
+        mock_blob.last_modified = None
+        mock_blobs.append(mock_blob)
+
+    processor._container_client = MagicMock()
+    processor._container_client.list_blobs.return_value = mock_blobs
+    processor._fetch_document_by_id = MagicMock(
+        side_effect=lambda identifier, *, max_file_size=None: DocumentStream(
+            name=identifier.name,
+            stream=BytesIO(b"content"),
+        )
+    )
+
+    docs = list(processor.iterate_documents())
+
+    assert len(docs) == 2
+    assert [doc.name for doc in docs] == ["file0.pdf", "file1.pdf"]
+    assert processor._fetch_document_by_id.call_count == 2
+
+
+def test_azure_blob_fetch_rejects_oversized_before_download(azure_coords):
+    processor = AzureBlobSourceProcessor(azure_coords)
+    processor._container_client = MagicMock()
+
+    identifier = AzureBlobFileIdentifier(
+        name="incoming/too-large.pdf",
+        size=9,
+        last_modified=None,
+    )
+
+    with pytest.raises(SourceLimitExceededError, match="max_file_size=8"):
+        processor._fetch_document_by_id(identifier, max_file_size=8)
+
+    processor._container_client.get_blob_client.assert_not_called()
+
+
+def test_azure_blob_fetch_logs_and_reraises_error(azure_coords, caplog):
+    processor = AzureBlobSourceProcessor(azure_coords)
+
+    mock_blob_client = MagicMock()
+    mock_download_stream = MagicMock()
+    mock_download_stream.readinto.side_effect = ResourceNotFoundError("Blob not found")
+    mock_blob_client.download_blob.return_value = mock_download_stream
+
+    processor._container_client = MagicMock()
+    processor._container_client.get_blob_client.return_value = mock_blob_client
+
+    identifier = AzureBlobFileIdentifier(
+        name="incoming/missing.pdf",
+        size=100,
+        last_modified=None,
+    )
+
+    with caplog.at_level("WARNING"):
+        with pytest.raises(ResourceNotFoundError):
+            processor._fetch_document_by_id(identifier)
+
+    assert any(
+        "incoming/missing.pdf" in record.message
+        and azure_coords.container in record.message
+        for record in caplog.records
+    )
+
+
+def test_azure_blob_list_with_prefix(azure_coords):
+    coords_with_prefix = azure_coords.model_copy(update={"blob_prefix": "pdfs/"})
+    processor = AzureBlobSourceProcessor(coords_with_prefix)
+
+    processor._container_client = MagicMock()
+    processor._container_client.list_blobs.return_value = []
+
+    list(processor._list_document_ids())
+
+    processor._container_client.list_blobs.assert_called_once_with(
+        name_starts_with="pdfs/"
+    )
+
+
+def test_azure_blob_list_without_prefix(azure_coords):
+    processor = AzureBlobSourceProcessor(azure_coords)
+
+    processor._container_client = MagicMock()
+    processor._container_client.list_blobs.return_value = []
+
+    list(processor._list_document_ids())
+
+    processor._container_client.list_blobs.assert_called_once_with(
+        name_starts_with=None
+    )

--- a/tests/test_azure_blob_source_processor.py
+++ b/tests/test_azure_blob_source_processor.py
@@ -1,5 +1,3 @@
-"""Unit tests for Azure Blob Storage source processor."""
-
 from datetime import datetime, timezone
 from io import BytesIO
 from unittest.mock import MagicMock

--- a/tests/test_azure_blob_target_processor.py
+++ b/tests/test_azure_blob_target_processor.py
@@ -1,5 +1,3 @@
-"""Unit tests for Azure Blob Storage target processor."""
-
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 

--- a/tests/test_azure_blob_target_processor.py
+++ b/tests/test_azure_blob_target_processor.py
@@ -1,0 +1,134 @@
+"""Unit tests for Azure Blob Storage target processor."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from docling_jobkit.connectors.azure_blob_target_processor import (
+    AzureBlobTargetProcessor,
+)
+from docling_jobkit.datamodel.azure_blob_coords import AzureBlobCoordinates
+
+
+@pytest.fixture
+def azure_coords() -> AzureBlobCoordinates:
+    return AzureBlobCoordinates(
+        account_name="testaccount",
+        container="testcontainer",
+        connection_string="DefaultEndpointsProtocol=https;AccountName=testaccount;AccountKey=dGVzdGtleQ==;EndpointSuffix=core.windows.net",
+        blob_prefix="",
+    )
+
+
+def test_azure_blob_build_artifact_uri_without_prefix(azure_coords):
+    processor = AzureBlobTargetProcessor(azure_coords)
+
+    uri = processor.build_artifact_uri("output/document.json")
+
+    assert uri == "azure://testaccount/testcontainer/output/document.json"
+
+
+def test_azure_blob_build_artifact_uri_with_prefix(azure_coords):
+    coords_with_prefix = azure_coords.model_copy(update={"blob_prefix": "converted/"})
+    processor = AzureBlobTargetProcessor(coords_with_prefix)
+
+    uri = processor.build_artifact_uri("output/document.json")
+
+    assert uri == "azure://testaccount/testcontainer/converted/output/document.json"
+
+
+def test_azure_blob_upload_file(azure_coords):
+    processor = AzureBlobTargetProcessor(azure_coords)
+
+    mock_blob_client = MagicMock()
+    processor._container_client = MagicMock()
+    processor._container_client.get_blob_client.return_value = mock_blob_client
+
+    with patch(
+        "docling_jobkit.connectors.azure_blob_target_processor.upload_azure_blob_file"
+    ) as mock_upload:
+        processor.upload_file(
+            filename=Path("/tmp/test.json"),
+            target_filename="output/test.json",
+            content_type="application/json",
+        )
+
+        processor._container_client.get_blob_client.assert_called_once_with(
+            "output/test.json"
+        )
+        mock_upload.assert_called_once_with(
+            mock_blob_client,
+            filename=Path("/tmp/test.json"),
+            content_type="application/json",
+        )
+
+
+def test_azure_blob_upload_file_with_prefix(azure_coords):
+    coords_with_prefix = azure_coords.model_copy(update={"blob_prefix": "converted/"})
+    processor = AzureBlobTargetProcessor(coords_with_prefix)
+
+    mock_blob_client = MagicMock()
+    processor._container_client = MagicMock()
+    processor._container_client.get_blob_client.return_value = mock_blob_client
+
+    with patch(
+        "docling_jobkit.connectors.azure_blob_target_processor.upload_azure_blob_file"
+    ):
+        processor.upload_file(
+            filename=Path("/tmp/test.json"),
+            target_filename="output/test.json",
+            content_type="application/json",
+        )
+
+        processor._container_client.get_blob_client.assert_called_once_with(
+            "converted/output/test.json"
+        )
+
+
+def test_azure_blob_upload_object(azure_coords):
+    processor = AzureBlobTargetProcessor(azure_coords)
+
+    mock_blob_client = MagicMock()
+    processor._container_client = MagicMock()
+    processor._container_client.get_blob_client.return_value = mock_blob_client
+
+    with patch(
+        "docling_jobkit.connectors.azure_blob_target_processor.upload_azure_blob_object"
+    ) as mock_upload:
+        processor.upload_object(
+            obj=b"test content",
+            target_filename="output/test.json",
+            content_type="application/json",
+        )
+
+        processor._container_client.get_blob_client.assert_called_once_with(
+            "output/test.json"
+        )
+        mock_upload.assert_called_once_with(
+            mock_blob_client,
+            obj=b"test content",
+            content_type="application/json",
+        )
+
+
+def test_azure_blob_upload_object_with_prefix(azure_coords):
+    coords_with_prefix = azure_coords.model_copy(update={"blob_prefix": "converted/"})
+    processor = AzureBlobTargetProcessor(coords_with_prefix)
+
+    mock_blob_client = MagicMock()
+    processor._container_client = MagicMock()
+    processor._container_client.get_blob_client.return_value = mock_blob_client
+
+    with patch(
+        "docling_jobkit.connectors.azure_blob_target_processor.upload_azure_blob_object"
+    ):
+        processor.upload_object(
+            obj="test string",
+            target_filename="output/test.txt",
+            content_type="text/plain",
+        )
+
+        processor._container_client.get_blob_client.assert_called_once_with(
+            "converted/output/test.txt"
+        )

--- a/tests/test_connector_factory.py
+++ b/tests/test_connector_factory.py
@@ -41,7 +41,7 @@ def test_builtin_source_connectors_registered():
 def test_builtin_target_connectors_registered():
     factory = get_target_connector_factory()
     assert set(factory.registered_kinds) == {
-        "azure_blob"
+        "azure_blob",
         "s3",
         "local_path",
         "put",

--- a/tests/test_connector_factory.py
+++ b/tests/test_connector_factory.py
@@ -29,6 +29,7 @@ from docling_jobkit.datamodel.task_targets import GoogleDriveTarget, LocalPathTa
 def test_builtin_source_connectors_registered():
     factory = get_source_connector_factory()
     assert set(factory.registered_kinds) == {
+        "azure_blob",
         "file",
         "http",
         "s3",
@@ -40,6 +41,7 @@ def test_builtin_source_connectors_registered():
 def test_builtin_target_connectors_registered():
     factory = get_target_connector_factory()
     assert set(factory.registered_kinds) == {
+        "azure_blob"
         "s3",
         "local_path",
         "put",

--- a/tests/test_presigned_target_results.py
+++ b/tests/test_presigned_target_results.py
@@ -351,8 +351,8 @@ def test_presigned_callbacks_emit_document_completed_after_uploads(
     )
 
     callback_invoker = MagicMock()
-    callback_invoker.invoke_callbacks_async.side_effect = (
-        lambda **kwargs: events.append(("callback", kwargs["progress"]))
+    callback_invoker.invoke_callbacks_async.side_effect = lambda **kwargs: (
+        events.append(("callback", kwargs["progress"]))
     )
 
     process_exportable_results(

--- a/uv.lock
+++ b/uv.lock
@@ -186,7 +186,7 @@ name = "aiohttp-cors"
 version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp" },
+    { name = "aiohttp", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/d89e846a5444b3d5eb8985a6ddb0daef3774928e1bfbce8e84ec97b0ffa7/aiohttp_cors-0.8.1.tar.gz", hash = "sha256:ccacf9cb84b64939ea15f859a146af1f662a6b1d68175754a07315e305fb1403", size = 38626, upload-time = "2025-03-31T14:16:20.048Z" }
 wheels = [
@@ -306,6 +306,34 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/38/c7d9c3e746209a1a695c13e3aa7d817229e84a85d0a84271f313d1befdd3/av-17.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1284addf3c0dd939887a9722dc30df2241a97471ad52c3c507e31583ae22ff02", size = 39490680, upload-time = "2026-06-07T05:52:48.887Z" },
     { url = "https://files.pythonhosted.org/packages/a1/25/9d42da561b7b8f7dabdfaebba07b52977bee58c5c7e4285ac991abcfaa72/av-17.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:ec630be6321b04e317862f6082e84812bbd801e55a3c2298312e3fc8a0a4af4f", size = 28355673, upload-time = "2026-06-07T05:52:51.614Z" },
     { url = "https://files.pythonhosted.org/packages/a8/41/562a61d5a61fba3ffb273a115e249f1d8471b9515c59fcc38b4b9deda238/av-17.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:b41647e42884bf543b8e8d0a1dabd4d1b006c99183eb1a2d7afc5b01f73eeff4", size = 21324700, upload-time = "2026-06-07T05:52:53.972Z" },
+]
+
+[[package]]
+name = "azure-core"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a6/f3/b416179e408990df5db0d516283022dde0f5d0111d98c1a848e41853e81c/azure_core-1.41.0.tar.gz", hash = "sha256:f46ff5dfcd230f25cf1c19e8a34b8dc08a337b2503e268bb600a16c00db8ad5a", size = 381042, upload-time = "2026-05-07T23:30:54.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/db/325c6d7312d2200251c52323878281045aaffcb5586612296484e4280eaa/azure_core-1.41.0-py3-none-any.whl", hash = "sha256:522b4011e8180b1a3dcd2024396a4e7fe9ac37fb8597db47163d230b5efe892d", size = 220920, upload-time = "2026-05-07T23:30:56.357Z" },
+]
+
+[[package]]
+name = "azure-storage-blob"
+version = "12.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "cryptography" },
+    { name = "isodate" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/48/84a820d898267f662b5c06f7cd76fdb8a9e272b44aa9376cef3ec0f6a294/azure_storage_blob-12.30.0.tar.gz", hash = "sha256:2cd74d4d5731e5eb6b8d5c5056ee115a5e88f8fdf22517b739836fda685018be", size = 618229, upload-time = "2026-06-08T11:45:35.575Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/0b/e106f0fd7fa785867d9ffcc47dc9e6237c0e58f51058473b777487a98edc/azure_storage_blob-12.30.0-py3-none-any.whl", hash = "sha256:d415ac50b67a8da6b3ae7e9f1014b1b55cd7aafa0b8d4ca9b380568dc7360423", size = 435610, upload-time = "2026-06-08T11:45:37.213Z" },
 ]
 
 [[package]]
@@ -702,15 +730,15 @@ name = "codeflare-sdk"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "executing" },
-    { name = "ipywidgets" },
-    { name = "kube-authkit" },
-    { name = "kubernetes" },
-    { name = "openshift-client" },
-    { name = "pydantic" },
-    { name = "ray", extra = ["data", "default"] },
-    { name = "rich" },
+    { name = "cryptography", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "executing", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "ipywidgets", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "kube-authkit", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "kubernetes", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "openshift-client", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pydantic", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "ray", extra = ["data", "default"], marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "rich", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9f/f9/ac5105afcc86295d80dec7d44b040dbb2344669218f06a6f0d74d9fe462e/codeflare_sdk-0.37.0.tar.gz", hash = "sha256:2106118d9341db7e329da59f296bc635c08e365d4a644013bb9a55ce38c54da5", size = 172362, upload-time = "2026-05-08T13:23:03.292Z" }
 wheels = [
@@ -731,7 +759,7 @@ name = "coloredlogs"
 version = "15.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "humanfriendly" },
+    { name = "humanfriendly", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
 wheels = [
@@ -743,7 +771,7 @@ name = "colorful"
 version = "0.5.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/82/31/109ef4bedeb32b4202e02ddb133162457adc4eb890a9ed9c05c9dd126ed0/colorful-0.5.8.tar.gz", hash = "sha256:bb16502b198be2f1c42ba3c52c703d5f651d826076817185f0294c1a549a7445", size = 209361, upload-time = "2025-10-29T11:53:21.663Z" }
 wheels = [
@@ -951,7 +979,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/21/8464d133752951c154feafb3b65c297e7d80f301183d220bec4c830f1441/cuda_bindings-13.3.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:120fcc53d57903df529c3486962c56528cba5b7d6c57c99537320ed9922c8b86", size = 6073403, upload-time = "2026-05-29T23:11:36.22Z" },
@@ -986,34 +1014,34 @@ wheels = [
 
 [package.optional-dependencies]
 cudart = [
-    { name = "nvidia-cuda-runtime" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cufft = [
-    { name = "nvidia-cufft" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cufile = [
-    { name = "nvidia-cufile" },
+    { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 curand = [
-    { name = "nvidia-curand" },
+    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx" },
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
 [[package]]
@@ -1021,21 +1049,21 @@ name = "datasets"
 version = "5.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "dill" },
-    { name = "filelock" },
-    { name = "fsspec", extra = ["http"] },
-    { name = "httpx" },
-    { name = "huggingface-hub" },
-    { name = "multiprocess" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "packaging" },
-    { name = "pandas" },
-    { name = "pyarrow" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "tqdm" },
-    { name = "xxhash" },
+    { name = "dill", marker = "sys_platform == 'darwin'" },
+    { name = "filelock", marker = "sys_platform == 'darwin'" },
+    { name = "fsspec", extra = ["http"], marker = "sys_platform == 'darwin'" },
+    { name = "httpx", marker = "sys_platform == 'darwin'" },
+    { name = "huggingface-hub", marker = "sys_platform == 'darwin'" },
+    { name = "multiprocess", marker = "sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and sys_platform == 'darwin'" },
+    { name = "packaging", marker = "sys_platform == 'darwin'" },
+    { name = "pandas", marker = "sys_platform == 'darwin'" },
+    { name = "pyarrow", marker = "sys_platform == 'darwin'" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin'" },
+    { name = "requests", marker = "sys_platform == 'darwin'" },
+    { name = "tqdm", marker = "sys_platform == 'darwin'" },
+    { name = "xxhash", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d9/85/ce4f780c32f7e36d71257f1c27e8ba898ebe379cb54f211f5f2013f2c219/datasets-5.0.0.tar.gz", hash = "sha256:83dbbbdb07a33b82192b8c419deb18739b138ee2ce1a322d55ce6b100954ec1a", size = 631708, upload-time = "2026-06-05T13:18:26.124Z" }
 wheels = [
@@ -1167,6 +1195,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+azure = [
+    { name = "azure-storage-blob" },
+]
 gdrive = [
     { name = "google-api-python-client" },
     { name = "google-auth-oauthlib" },
@@ -1214,6 +1245,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "azure-storage-blob", marker = "extra == 'azure'", specifier = ">=12.19.0" },
     { name = "boto3", specifier = "~=1.35" },
     { name = "codeflare-sdk", marker = "python_full_version >= '3.11' and python_full_version < '3.14' and extra == 'ray'", specifier = ">=0.20.0" },
     { name = "docling-slim", extras = ["models-onnxruntime"], marker = "extra == 'onnxruntime'", specifier = ">=2.94.0,<3.0.0" },
@@ -1233,7 +1265,7 @@ requires-dist = [
     { name = "rq", marker = "extra == 'rq'", specifier = "~=2.4" },
     { name = "typer", specifier = ">=0.12.5,<1" },
 ]
-provides-extras = ["vlm", "onnxruntime", "rq", "ray", "gdrive"]
+provides-extras = ["vlm", "onnxruntime", "rq", "ray", "gdrive", "azure"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1397,7 +1429,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1430,11 +1462,11 @@ name = "fastapi"
 version = "0.138.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "annotated-doc" },
-    { name = "pydantic" },
-    { name = "starlette" },
-    { name = "typing-extensions" },
-    { name = "typing-inspection" },
+    { name = "annotated-doc", marker = "python_full_version < '3.14' or sys_platform == 'darwin'" },
+    { name = "pydantic", marker = "python_full_version < '3.14' or sys_platform == 'darwin'" },
+    { name = "starlette", marker = "python_full_version < '3.14' or sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14' or sys_platform == 'darwin'" },
+    { name = "typing-inspection", marker = "python_full_version < '3.14' or sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8a/c9/5e8defe249899c0dc900643695fc07829a67fc88b4ff2cdb03fcbdbf5a4b/fastapi-0.138.1.tar.gz", hash = "sha256:96e3702dce09ee0dce48856135620d3d865ca684a79fe7513fd7b13a12f82862", size = 419646, upload-time = "2026-06-25T15:40:42.115Z" }
 wheels = [
@@ -1599,7 +1631,7 @@ wheels = [
 
 [package.optional-dependencies]
 http = [
-    { name = "aiohttp" },
+    { name = "aiohttp", marker = "sys_platform == 'darwin'" },
 ]
 
 [[package]]
@@ -1714,7 +1746,7 @@ name = "grpcio"
 version = "1.81.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b0/b5/1ff353970a87eda4c98251e34d2dfd214abd4982dc89119c9252a2a482d2/grpcio-1.81.1.tar.gz", hash = "sha256:6fa10a767143a5e82e8eaab53918af0cd8909a57a27f8cb2288b80a613ac671b", size = 13026582, upload-time = "2026-06-11T12:46:51.673Z" }
 wheels = [
@@ -2019,7 +2051,7 @@ name = "humanfriendly"
 version = "10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
+    { name = "pyreadline3", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
 wheels = [
@@ -2079,18 +2111,18 @@ name = "ipython"
 version = "9.14.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "ipython-pygments-lexers" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "psutil", marker = "sys_platform != 'emscripten'" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12' or python_full_version >= '3.14'" },
+    { name = "colorama", marker = "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "jedi", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pexpect", marker = "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "psutil", marker = "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'emscripten'" },
+    { name = "pygments", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "stack-data", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "traitlets", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e2/23/3a27530575643c8bb7bfc757a28e2e7ef80092afbf59a2bc5716320b6602/ipython-9.14.1.tar.gz", hash = "sha256:f913bf74df06d458e46ced84ca506c23797590d594b236fe60b14df213291e7b", size = 4433457, upload-time = "2026-06-05T08:12:34.921Z" }
 wheels = [
@@ -2102,7 +2134,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments" },
+    { name = "pygments", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -2114,15 +2146,24 @@ name = "ipywidgets"
 version = "8.1.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "comm" },
-    { name = "ipython" },
-    { name = "jupyterlab-widgets" },
-    { name = "traitlets" },
-    { name = "widgetsnbextension" },
+    { name = "comm", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "ipython", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "jupyterlab-widgets", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "traitlets", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "widgetsnbextension", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bd/c6/2a746b6a339c17d81fa40f17f74d13d732ffdc3cca65340ecfdf1eee675c/ipywidgets-8.1.2.tar.gz", hash = "sha256:d0b9b41e49bae926a866e613a39b0f0097745d2b9f1f3dd406641b4a57ec42c9", size = 116492, upload-time = "2024-02-08T15:31:29.801Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/70/1a/7edeedb1c089d63ccd8bd5c0612334774e90cf9337de9fe6c82d90081791/ipywidgets-8.1.2-py3-none-any.whl", hash = "sha256:bbe43850d79fb5e906b14801d6c01402857996864d1e5b6fa62dd2ee35559f60", size = 139411, upload-time = "2024-02-08T15:31:21.503Z" },
+]
+
+[[package]]
+name = "isodate"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
 ]
 
 [[package]]
@@ -2166,7 +2207,7 @@ name = "jedi"
 version = "0.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "parso" },
+    { name = "parso", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/46/b7/a3635f6a2d7cf5b5dd98064fc1d5fbbafcb25477bcea204a3a92145d158b/jedi-0.20.0.tar.gz", hash = "sha256:c3f4ccbd276696f4b19c54618d4fb18f9fc24b0aef02acf704b23f487daa1011", size = 3119416, upload-time = "2026-05-01T23:38:47.814Z" }
 wheels = [
@@ -2284,10 +2325,10 @@ name = "kube-authkit"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "kubernetes" },
-    { name = "pyjwt" },
-    { name = "requests" },
-    { name = "urllib3" },
+    { name = "kubernetes", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pyjwt", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "requests", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "urllib3", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/11/69/3890e8934aab209f5b02c11409e906a507005202caea2b40901d44a101de/kube_authkit-0.4.0.tar.gz", hash = "sha256:1df61ac392fca96c8f5ae8c3d6e9918f1e1655d212434b3c3da5f92cc23b660d", size = 106762, upload-time = "2026-02-18T15:56:51.161Z" }
 wheels = [
@@ -2299,16 +2340,16 @@ name = "kubernetes"
 version = "36.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiohttp" },
-    { name = "certifi" },
-    { name = "durationpy" },
-    { name = "python-dateutil" },
-    { name = "pyyaml" },
-    { name = "requests" },
-    { name = "requests-oauthlib" },
-    { name = "six" },
-    { name = "urllib3" },
-    { name = "websocket-client" },
+    { name = "aiohttp", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "certifi", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "durationpy", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "requests", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "requests-oauthlib", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "six", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "urllib3", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "websocket-client", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2f/57/8b538af5076bc3372949d76f70ba3449bdfe52f9e6488170fa5d4f7cbe70/kubernetes-36.0.2.tar.gz", hash = "sha256:03551fcb49cae1f708f63624041e37403545b7aaed10cbf54e2b01a37a5438e3", size = 2336738, upload-time = "2026-06-01T18:20:30.785Z" }
 wheels = [
@@ -2657,7 +2698,7 @@ name = "matplotlib-inline"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "traitlets" },
+    { name = "traitlets", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bd/c0/9f7c9a46090390368a4d7bcb76bb87a4a36c421e4c0792cdb53486ffac7a/matplotlib_inline-0.2.2.tar.gz", hash = "sha256:72f3fe8fce36b70d4a5b612f899090cd0401deddc4ea90e1572b9f4bfb058c79", size = 8150, upload-time = "2026-05-08T17:33:33.49Z" }
 wheels = [
@@ -2678,7 +2719,7 @@ name = "miniaudio"
 version = "1.71"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi" },
+    { name = "cffi", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d8/d5/e5439dc08561f73656bfeb3340fc64ab63163e101426593d8fb9a025ff1e/miniaudio-1.71.tar.gz", hash = "sha256:ff51e2887bb673e2e757752b586b3dc924d59aa5fbcae9bbc45f4a111bd3262b", size = 1116480, upload-time = "2026-04-29T21:20:38.182Z" }
 wheels = [
@@ -2694,7 +2735,7 @@ name = "mlx"
 version = "0.31.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mlx-metal" },
+    { name = "mlx-metal", marker = "sys_platform == 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/29/7c/c16d52494a1ba6d90443f31fa26bc810bf878d532dfa9a7a13f49ef9542d/mlx-0.31.2-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:b29cf940f34205f09bb552ac60465ae833c4ae640b52777c6d725ddbad8461ca", size = 586942, upload-time = "2026-04-22T03:14:21.97Z" },
@@ -2719,18 +2760,18 @@ name = "mlx-audio"
 version = "0.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub" },
-    { name = "miniaudio" },
-    { name = "mlx" },
-    { name = "mlx-lm" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "sounddevice" },
-    { name = "tqdm" },
-    { name = "transformers" },
+    { name = "huggingface-hub", marker = "sys_platform == 'darwin'" },
+    { name = "miniaudio", marker = "sys_platform == 'darwin'" },
+    { name = "mlx", marker = "sys_platform == 'darwin'" },
+    { name = "mlx-lm", marker = "sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and sys_platform == 'darwin'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform == 'darwin'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' and sys_platform == 'darwin'" },
+    { name = "scipy", version = "1.18.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and sys_platform == 'darwin'" },
+    { name = "sounddevice", marker = "sys_platform == 'darwin'" },
+    { name = "tqdm", marker = "sys_platform == 'darwin'" },
+    { name = "transformers", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/af/1e/f712c9f7997e5051c4da3b658f38162203bb703c750741984c8358c8b897/mlx_audio-0.4.4.tar.gz", hash = "sha256:d751e5f477517e4e7f04de5567318e2fe91b4606af5d7e4b2973603c4777814a", size = 1386491, upload-time = "2026-06-06T15:32:03.504Z" }
 wheels = [
@@ -2742,14 +2783,14 @@ name = "mlx-lm"
 version = "0.31.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jinja2" },
-    { name = "mlx" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "protobuf" },
-    { name = "pyyaml" },
-    { name = "sentencepiece" },
-    { name = "transformers" },
+    { name = "jinja2", marker = "sys_platform == 'darwin'" },
+    { name = "mlx", marker = "sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and sys_platform == 'darwin'" },
+    { name = "protobuf", marker = "sys_platform == 'darwin'" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin'" },
+    { name = "sentencepiece", marker = "sys_platform == 'darwin'" },
+    { name = "transformers", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/84/94/9a38d6b0c6fcca995b9136c94eb7da1e9c5165652edf228b96b29960fa7a/mlx_lm-0.31.3.tar.gz", hash = "sha256:61eb0e3ba09444f77f874aff295401d7ccd20b39495cbbce0c782a15474ce733", size = 304318, upload-time = "2026-04-22T07:37:27.922Z" }
 wheels = [
@@ -2771,22 +2812,22 @@ name = "mlx-vlm"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "datasets" },
-    { name = "fastapi" },
-    { name = "llguidance" },
-    { name = "miniaudio" },
-    { name = "mlx" },
-    { name = "mlx-audio" },
-    { name = "mlx-lm" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
-    { name = "opencv-python" },
-    { name = "pillow" },
-    { name = "requests" },
-    { name = "starlette" },
-    { name = "tqdm" },
-    { name = "transformers" },
-    { name = "uvicorn" },
+    { name = "datasets", marker = "sys_platform == 'darwin'" },
+    { name = "fastapi", marker = "sys_platform == 'darwin'" },
+    { name = "llguidance", marker = "sys_platform == 'darwin'" },
+    { name = "miniaudio", marker = "sys_platform == 'darwin'" },
+    { name = "mlx", marker = "sys_platform == 'darwin'" },
+    { name = "mlx-audio", marker = "sys_platform == 'darwin'" },
+    { name = "mlx-lm", marker = "sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and sys_platform == 'darwin'" },
+    { name = "opencv-python", marker = "sys_platform == 'darwin'" },
+    { name = "pillow", marker = "sys_platform == 'darwin'" },
+    { name = "requests", marker = "sys_platform == 'darwin'" },
+    { name = "starlette", marker = "sys_platform == 'darwin'" },
+    { name = "tqdm", marker = "sys_platform == 'darwin'" },
+    { name = "transformers", marker = "sys_platform == 'darwin'" },
+    { name = "uvicorn", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a3/60/e774080c90dd5a9d6ed51e3ff1c145243199048714bbca61cdf65e278a69/mlx_vlm-0.6.3.tar.gz", hash = "sha256:f5541eb7c22345a951f7fb78376ed80e8e42bd7c179fb0daa40a21592c7b2adb", size = 1360405, upload-time = "2026-06-10T18:06:34.457Z" }
 wheels = [
@@ -3382,7 +3423,7 @@ name = "nvidia-cublas"
 version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -3421,7 +3462,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -3433,7 +3474,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -3463,9 +3504,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'darwin'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -3477,7 +3518,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -3556,13 +3597,13 @@ name = "onnxruntime"
 version = "1.23.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "coloredlogs" },
-    { name = "flatbuffers" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "packaging" },
-    { name = "protobuf" },
-    { name = "sympy" },
+    { name = "coloredlogs", marker = "python_full_version < '3.14' and sys_platform == 'darwin'" },
+    { name = "flatbuffers", marker = "python_full_version < '3.14' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'darwin'" },
+    { name = "packaging", marker = "python_full_version < '3.14' and sys_platform == 'darwin'" },
+    { name = "protobuf", marker = "python_full_version < '3.14' and sys_platform == 'darwin'" },
+    { name = "sympy", marker = "python_full_version < '3.14' and sys_platform == 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/35/d6/311b1afea060015b56c742f3531168c1644650767f27ef40062569960587/onnxruntime-1.23.2-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:a7730122afe186a784660f6ec5807138bf9d792fa1df76556b27307ea9ebcbe3", size = 17195934, upload-time = "2025-10-27T23:06:14.143Z" },
@@ -3580,13 +3621,13 @@ name = "onnxruntime-gpu"
 version = "1.23.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "coloredlogs" },
-    { name = "flatbuffers" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "packaging" },
-    { name = "protobuf" },
-    { name = "sympy" },
+    { name = "coloredlogs", marker = "python_full_version < '3.14' and sys_platform != 'darwin'" },
+    { name = "flatbuffers", marker = "python_full_version < '3.14' and sys_platform != 'darwin'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform != 'darwin'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'darwin'" },
+    { name = "packaging", marker = "python_full_version < '3.14' and sys_platform != 'darwin'" },
+    { name = "protobuf", marker = "python_full_version < '3.14' and sys_platform != 'darwin'" },
+    { name = "sympy", marker = "python_full_version < '3.14' and sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/ae/39283748c68a96be4f5f8a9561e0e3ca92af1eae6c2b1c07fb1da5f65cd1/onnxruntime_gpu-1.23.2-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:18de50c6c8eea50acc405ea13d299aec593e46478d7a22cd32cdbbdf7c42899d", size = 300525411, upload-time = "2025-10-22T16:56:08.415Z" },
@@ -3605,9 +3646,9 @@ name = "opencensus"
 version = "0.11.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "google-api-core" },
-    { name = "opencensus-context" },
-    { name = "six" },
+    { name = "google-api-core", marker = "python_full_version < '3.14'" },
+    { name = "opencensus-context", marker = "python_full_version < '3.14'" },
+    { name = "six", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/15/a7/a46dcffa1b63084f9f17fe3c8cb20724c4c8f91009fd0b2cfdb27d5d2b35/opencensus-0.11.4.tar.gz", hash = "sha256:cbef87d8b8773064ab60e5c2a1ced58bbaa38a6d052c41aec224958ce544eff2", size = 64966, upload-time = "2024-01-03T18:04:07.085Z" }
 wheels = [
@@ -3659,9 +3700,9 @@ name = "openshift-client"
 version = "1.0.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "paramiko" },
-    { name = "pyyaml" },
-    { name = "six" },
+    { name = "paramiko", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pyyaml", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "six", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/61/4d/96d40621a88e430127f98467b6ef67ff2e39f2d33b9740ea0e470cf2b8bc/openshift-client-1.0.18.tar.gz", hash = "sha256:be3979440cfd96788146a3a1650dabe939d4d516eea0b39f87e66d2ab39495b1", size = 78332, upload-time = "2022-09-13T22:08:36.769Z" }
 wheels = [
@@ -3673,7 +3714,7 @@ name = "opentelemetry-api"
 version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/cc/e4c9584181f86494df0f6bdec1a4f3280c50db44704dc2a407e994fc87bb/opentelemetry_api-1.43.0.tar.gz", hash = "sha256:107d0d03857ea8fc7c5fcbbbd83f800c281f0d560553d61c1d675fccfd1761c1", size = 73476, upload-time = "2026-06-24T15:19:55.323Z" }
 wheels = [
@@ -3685,9 +3726,9 @@ name = "opentelemetry-exporter-prometheus"
 version = "0.64b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-sdk" },
-    { name = "prometheus-client" },
+    { name = "opentelemetry-api", marker = "python_full_version < '3.14'" },
+    { name = "opentelemetry-sdk", marker = "python_full_version < '3.14'" },
+    { name = "prometheus-client", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/97/b3/f778f705289ea5f1c54589ae4494d318c9cede052f18ca33979fda0ef016/opentelemetry_exporter_prometheus-0.64b0.tar.gz", hash = "sha256:96fec79be9527cb9dc994d7e663051df35161eb936fe2d41954725e4595abbc1", size = 16405, upload-time = "2026-06-24T15:20:02.278Z" }
 wheels = [
@@ -3699,7 +3740,7 @@ name = "opentelemetry-proto"
 version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "protobuf" },
+    { name = "protobuf", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e0/b9/d357faefb40bda1d4799913e6af611171ff22a2dedcb93576bc92242d056/opentelemetry_proto-1.43.0.tar.gz", hash = "sha256:224778df17e1f3fafeaaa21d874236ca5f6ffc2f86e0899298ec7351aac27924", size = 46481, upload-time = "2026-06-24T15:20:07.625Z" }
 wheels = [
@@ -3711,9 +3752,9 @@ name = "opentelemetry-sdk"
 version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "typing-extensions" },
+    { name = "opentelemetry-api", marker = "python_full_version < '3.14'" },
+    { name = "opentelemetry-semantic-conventions", marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/3e/eb/5041074274ac0956b03637cc039d434569112468e875eddfcc9a0674ce06/opentelemetry_sdk-1.43.0.tar.gz", hash = "sha256:d8187c81c162df9913e4003dd6485f7390d9a24fc17026ec7387b8b8218b08e9", size = 254744, upload-time = "2026-06-24T15:20:08.467Z" }
 wheels = [
@@ -3725,8 +3766,8 @@ name = "opentelemetry-semantic-conventions"
 version = "0.64b0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "typing-extensions" },
+    { name = "opentelemetry-api", marker = "python_full_version < '3.14'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5a/30/5f26df29509eccd86b99b481ac9ffa39da49ba9577cc69071c552ae30447/opentelemetry_semantic_conventions-0.64b0.tar.gz", hash = "sha256:72f76fb2d1582d9d033dd1fcd84532e961e6ff3d90d24ba6fabc72975a83864c", size = 148340, upload-time = "2026-06-24T15:20:09.267Z" }
 wheels = [
@@ -3809,10 +3850,10 @@ name = "paramiko"
 version = "5.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "bcrypt" },
-    { name = "cryptography" },
-    { name = "invoke" },
-    { name = "pynacl" },
+    { name = "bcrypt", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "cryptography", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "invoke", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pynacl", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/62/93/dcc25d52f49022ae6175d15e6bd751f1acc99b98bc61fc55e5155a7be2e7/paramiko-5.0.0.tar.gz", hash = "sha256:36763b5b95c2a0dcfdf1abc48e48156ee425b21efe2f0e787c2dd5a95c0e5e79", size = 1548586, upload-time = "2026-05-09T18:28:52.256Z" }
 wheels = [
@@ -3864,7 +3905,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess" },
+    { name = "ptyprocess", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -4039,7 +4080,7 @@ name = "prompt-toolkit"
 version = "3.0.52"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "wcwidth" },
+    { name = "wcwidth", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
 wheels = [
@@ -4566,7 +4607,7 @@ name = "pynacl"
 version = "1.6.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "cffi", marker = "python_full_version >= '3.11' and python_full_version < '3.14' and platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d9/9a/4019b524b03a13438637b11538c82781a5eda427394380381af8f04f467a/pynacl-1.6.2.tar.gz", hash = "sha256:018494d6d696ae03c7e656e5e74cdfd8ea1326962cc401bcf018f1ed8436811c", size = 3511692, upload-time = "2026-01-01T17:48:10.851Z" }
 wheels = [
@@ -4949,14 +4990,14 @@ name = "ray"
 version = "2.54.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "filelock" },
-    { name = "jsonschema" },
-    { name = "msgpack" },
-    { name = "packaging" },
-    { name = "protobuf" },
-    { name = "pyyaml" },
-    { name = "requests" },
+    { name = "click", marker = "python_full_version < '3.14'" },
+    { name = "filelock", marker = "python_full_version < '3.14'" },
+    { name = "jsonschema", marker = "python_full_version < '3.14'" },
+    { name = "msgpack", marker = "python_full_version < '3.14'" },
+    { name = "packaging", marker = "python_full_version < '3.14'" },
+    { name = "protobuf", marker = "python_full_version < '3.14'" },
+    { name = "pyyaml", marker = "python_full_version < '3.14'" },
+    { name = "requests", marker = "python_full_version < '3.14'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/cf/9a6e33b59e1a12428b4fbd6cc38f7e32d116ccde4c72e15c3f76a22bf36d/ray-2.54.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:2ea650e648acc6e76edd98c694657fd1fcb1cd97700d944a7d20da90269e9810", size = 70088753, upload-time = "2026-03-25T22:40:08.213Z" },
@@ -4978,46 +5019,46 @@ wheels = [
 
 [package.optional-dependencies]
 data = [
-    { name = "fsspec" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "pandas" },
-    { name = "pyarrow" },
+    { name = "fsspec", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pandas", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pyarrow", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 default = [
-    { name = "aiohttp" },
-    { name = "aiohttp-cors" },
-    { name = "colorful" },
-    { name = "grpcio" },
-    { name = "opencensus" },
-    { name = "opentelemetry-exporter-prometheus" },
-    { name = "opentelemetry-proto" },
-    { name = "opentelemetry-sdk" },
-    { name = "prometheus-client" },
-    { name = "py-spy" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "smart-open" },
-    { name = "virtualenv" },
+    { name = "aiohttp", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "aiohttp-cors", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "colorful", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "grpcio", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "opencensus", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "opentelemetry-exporter-prometheus", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "opentelemetry-proto", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "opentelemetry-sdk", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "prometheus-client", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "py-spy", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pydantic", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "requests", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "smart-open", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "virtualenv", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 serve = [
-    { name = "aiohttp" },
-    { name = "aiohttp-cors" },
-    { name = "colorful" },
-    { name = "fastapi" },
-    { name = "grpcio" },
-    { name = "opencensus" },
-    { name = "opentelemetry-exporter-prometheus" },
-    { name = "opentelemetry-proto" },
-    { name = "opentelemetry-sdk" },
-    { name = "prometheus-client" },
-    { name = "py-spy" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "smart-open" },
-    { name = "starlette" },
-    { name = "uvicorn", extra = ["standard"] },
-    { name = "virtualenv" },
-    { name = "watchfiles" },
+    { name = "aiohttp", marker = "python_full_version < '3.14'" },
+    { name = "aiohttp-cors", marker = "python_full_version < '3.14'" },
+    { name = "colorful", marker = "python_full_version < '3.14'" },
+    { name = "fastapi", marker = "python_full_version < '3.14'" },
+    { name = "grpcio", marker = "python_full_version < '3.14'" },
+    { name = "opencensus", marker = "python_full_version < '3.14'" },
+    { name = "opentelemetry-exporter-prometheus", marker = "python_full_version < '3.14'" },
+    { name = "opentelemetry-proto", marker = "python_full_version < '3.14'" },
+    { name = "opentelemetry-sdk", marker = "python_full_version < '3.14'" },
+    { name = "prometheus-client", marker = "python_full_version < '3.14'" },
+    { name = "py-spy", marker = "python_full_version < '3.14'" },
+    { name = "pydantic", marker = "python_full_version < '3.14'" },
+    { name = "requests", marker = "python_full_version < '3.14'" },
+    { name = "smart-open", marker = "python_full_version < '3.14'" },
+    { name = "starlette", marker = "python_full_version < '3.14'" },
+    { name = "uvicorn", extra = ["standard"], marker = "python_full_version < '3.14'" },
+    { name = "virtualenv", marker = "python_full_version < '3.14'" },
+    { name = "watchfiles", marker = "python_full_version < '3.14'" },
 ]
 
 [[package]]
@@ -5668,7 +5709,7 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -5728,7 +5769,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -5809,7 +5850,7 @@ resolution-markers = [
     "python_full_version == '3.14.*' and sys_platform != 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [
@@ -5860,8 +5901,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'darwin'" },
+    { name = "jeepney", marker = "sys_platform != 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -6012,7 +6053,7 @@ name = "smart-open"
 version = "7.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "wrapt" },
+    { name = "wrapt", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/db/c6/22e7a2acd5d27941e85e0d7ede398da5abe2e4677d2265c924157247c32e/smart_open-7.7.1.tar.gz", hash = "sha256:9414ba5733e28309f29b28a303b0f1054ad23fe0275f1a1b600c80a724f4bd1a", size = 54952, upload-time = "2026-06-26T07:56:35.309Z" }
 wheels = [
@@ -6033,7 +6074,7 @@ name = "sounddevice"
 version = "0.5.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi" },
+    { name = "cffi", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2a/f9/2592608737553638fca98e21e54bfec40bf577bb98a61b2770c912aab25e/sounddevice-0.5.5.tar.gz", hash = "sha256:22487b65198cb5bf2208755105b524f78ad173e5ab6b445bdab1c989f6698df3", size = 143191, upload-time = "2026-01-23T18:36:43.529Z" }
 wheels = [
@@ -6055,9 +6096,9 @@ name = "stack-data"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "asttokens" },
-    { name = "executing" },
-    { name = "pure-eval" },
+    { name = "asttokens", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "executing", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "pure-eval", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
 wheels = [
@@ -6069,7 +6110,7 @@ name = "starlette"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
+    { name = "anyio", marker = "python_full_version < '3.14' or sys_platform == 'darwin'" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
@@ -6569,8 +6610,8 @@ name = "uvicorn"
 version = "0.49.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "h11" },
+    { name = "click", marker = "python_full_version < '3.14' or sys_platform == 'darwin'" },
+    { name = "h11", marker = "python_full_version < '3.14' or sys_platform == 'darwin'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
@@ -6580,13 +6621,13 @@ wheels = [
 
 [package.optional-dependencies]
 standard = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "httptools" },
-    { name = "python-dotenv" },
-    { name = "pyyaml" },
-    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
-    { name = "watchfiles" },
-    { name = "websockets" },
+    { name = "colorama", marker = "python_full_version < '3.14' and sys_platform == 'win32'" },
+    { name = "httptools", marker = "python_full_version < '3.14'" },
+    { name = "python-dotenv", marker = "python_full_version < '3.14'" },
+    { name = "pyyaml", marker = "python_full_version < '3.14'" },
+    { name = "uvloop", marker = "python_full_version < '3.14' and platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles", marker = "python_full_version < '3.14'" },
+    { name = "websockets", marker = "python_full_version < '3.14'" },
 ]
 
 [[package]]
@@ -6654,7 +6695,7 @@ name = "watchfiles"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
+    { name = "anyio", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/41/5e1a4bb12aac5f1493fa1bdc11154eca3b258ca4eba65d39c473fe19d8e9/watchfiles-1.2.0.tar.gz", hash = "sha256:c995fba777f1ea992f090f9236e9284cf7a5d1a0130dd5a3d82c598cacd76838", size = 108252, upload-time = "2026-05-18T04:32:04.251Z" }
 wheels = [


### PR DESCRIPTION
 New connector for Azure Blob storage. Mirrors patterns set by existing S3 connector. Uses official azure-blob SDK. 

Tested with local CLI. See run_azure_example.yaml for use pattern. 

Auth is done with just the storage-account's connection string for simplicity. Should migrate to a proper managed identity before deployment. (Other connectors will need this work too). 

Includes basic test coverage for the target and source processors.