### PR TITLE
fix: validate custom picture_description/vlm/code_formula presets

### DIFF
--- a/docling_jobkit/convert/manager.py
+++ b/docling_jobkit/convert/manager.py
@@ -823,6 +823,24 @@ class DoclingConverterManager:
                 f"Allowed engines: {', '.join(allowed_engines)}"
             )
 
+    def _instantiate_custom_preset_options(
+        self, config_dict: dict, options_model: Type[BaseModel]
+    ) -> BaseModel:
+        """Validate a raw custom-preset dict into its options model.
+
+        Custom presets come from admin config (e.g. env vars) as plain dicts, so
+        they need the same engine_options instantiation and model validation
+        that the custom_config request path already applies.
+        """
+        config_dict = config_dict.copy()
+        if "engine_options" in config_dict and isinstance(
+            config_dict["engine_options"], dict
+        ):
+            config_dict["engine_options"] = self._instantiate_engine_options(
+                config_dict["engine_options"]
+            )
+        return options_model.model_validate(config_dict)
+
     def _get_options_from_preset(
         self,
         preset_id: str,
@@ -830,6 +848,7 @@ class DoclingConverterManager:
         preset_type: str,
         allowed_engines: Optional[list[str]],
         from_preset_func: Optional[Callable[[str], Any]] = None,
+        custom_options_model: Optional[Type[BaseModel]] = None,
     ) -> Any:
         """Generic method to get options from preset with engine validation.
 
@@ -839,6 +858,8 @@ class DoclingConverterManager:
             preset_type: Human-readable type name for error messages
             allowed_engines: List of allowed engine types (None means all allowed)
             from_preset_func: Optional function to create options from preset_id (e.g., VlmConvertOptions.from_preset)
+            custom_options_model: Options model used to validate a custom preset that is
+                still a raw dict (e.g. PictureDescriptionVlmEngineOptions)
 
         Returns:
             Options object or preset_id string (for legacy handling)
@@ -865,7 +886,12 @@ class DoclingConverterManager:
                 return preset_info["preset_id"]
         else:  # custom preset
             # Use admin-configured preset
-            preset_options = preset_info["options"]
+            preset_options: Any = preset_info["options"]
+
+            if isinstance(preset_options, dict) and custom_options_model is not None:
+                preset_options = self._instantiate_custom_preset_options(
+                    preset_options, custom_options_model
+                )
 
             # Validate engine is allowed (only for options that have engine_options)
             if allowed_engines is not None and hasattr(
@@ -921,29 +947,14 @@ class DoclingConverterManager:
         """Parse VLM options from preset OR custom config."""
         # Option 1: Preset (recommended)
         if request.vlm_pipeline_preset:
-            result = self._get_options_from_preset(
+            return self._get_options_from_preset(
                 request.vlm_pipeline_preset,
                 self.vlm_preset_registry,
                 "VLM",
                 self.config.allowed_vlm_engines,
                 VlmConvertOptions.from_preset,
+                VlmConvertOptions,
             )
-
-            # Custom presets return raw dicts - convert to VlmConvertOptions
-            if isinstance(result, dict):
-                config_dict = result.copy()
-
-                # Instantiate the correct engine options class
-                if "engine_options" in config_dict and isinstance(
-                    config_dict["engine_options"], dict
-                ):
-                    config_dict["engine_options"] = self._instantiate_engine_options(
-                        config_dict["engine_options"]
-                    )
-
-                return VlmConvertOptions.model_validate(config_dict)
-
-            return result
 
         # Option 2: Custom config (if allowed)
         if request.vlm_pipeline_custom_config:
@@ -1003,6 +1014,7 @@ class DoclingConverterManager:
                 "Picture description",
                 self.config.allowed_picture_description_engines,
                 PictureDescriptionVlmEngineOptions.from_preset,
+                PictureDescriptionVlmEngineOptions,
             )
 
         if request.picture_description_custom_config:
@@ -1058,6 +1070,7 @@ class DoclingConverterManager:
                 "Code/formula",
                 self.config.allowed_code_formula_engines,
                 CodeFormulaVlmOptions.from_preset,
+                CodeFormulaVlmOptions,
             )
 
         if request.code_formula_custom_config:

--- a/tests/test_converter_manager.py
+++ b/tests/test_converter_manager.py
@@ -292,6 +292,154 @@ class TestOptionsParsingPreset:
         assert options is not None
 
 
+def _raw_engine_options() -> dict:
+    return {
+        "engine_type": "api",
+        "url": "http://localhost:8000/v1/chat/completions",
+        "params": {"model": "some-model"},
+    }
+
+
+def _raw_model_spec() -> dict:
+    return {
+        "name": "some-model",
+        "default_repo_id": "some-model",
+        "prompt": "Describe this image.",
+        "response_format": "plaintext",
+    }
+
+
+class TestCustomPresetByNameOptionsParsing:
+    """Custom presets registered by name arrive as raw dicts and must be
+    validated into their options model, not returned as-is (#191)."""
+
+    def test_picture_description_custom_preset_by_name(self):
+        """Custom picture_description preset resolves to a validated options object."""
+        from docling.datamodel.pipeline_options import (
+            PictureDescriptionVlmEngineOptions,
+        )
+
+        config = DoclingConverterManagerConfig(
+            custom_picture_description_presets={
+                "my_preset": {
+                    "picture_area_threshold": 0.0,
+                    "engine_options": _raw_engine_options(),
+                    "model_spec": _raw_model_spec(),
+                    "prompt": "Describe this image.",
+                }
+            },
+        )
+        manager = DoclingConverterManager(config)
+
+        request = ConvertDocumentsOptions(picture_description_preset="my_preset")
+        options = manager._parse_picture_description_options(request)
+
+        assert isinstance(options, PictureDescriptionVlmEngineOptions)
+
+    def test_picture_description_custom_preset_area_threshold_assignable(self):
+        """Reproduces #191: assigning picture_area_threshold must not raise
+        AttributeError on a dict."""
+        config = DoclingConverterManagerConfig(
+            default_picture_description_preset="my_preset",
+            custom_picture_description_presets={
+                "my_preset": {
+                    "picture_area_threshold": 0.0,
+                    "engine_options": _raw_engine_options(),
+                    "model_spec": _raw_model_spec(),
+                    "prompt": "Describe this image.",
+                }
+            },
+        )
+        manager = DoclingConverterManager(config)
+
+        request = ConvertDocumentsOptions(
+            picture_description_preset="my_preset",
+            picture_description_area_threshold=0.2,
+        )
+        pipeline_options = manager._parse_standard_pdf_opts(request, None)
+
+        assert (
+            pipeline_options.picture_description_options.picture_area_threshold == 0.2
+        )
+
+    def test_code_formula_custom_preset_by_name(self):
+        """Custom code_formula preset resolves to a validated options object."""
+        from docling.datamodel.pipeline_options import CodeFormulaVlmOptions
+
+        config = DoclingConverterManagerConfig(
+            custom_code_formula_presets={
+                "my_preset": {
+                    "engine_options": _raw_engine_options(),
+                    "model_spec": _raw_model_spec(),
+                }
+            },
+        )
+        manager = DoclingConverterManager(config)
+
+        request = ConvertDocumentsOptions(code_formula_preset="my_preset")
+        options = manager._parse_code_formula_options(request)
+
+        assert isinstance(options, CodeFormulaVlmOptions)
+
+    def test_vlm_custom_preset_by_name(self):
+        """Non-regression: VLM custom preset by name already worked and must keep working."""
+        from docling.datamodel.pipeline_options import VlmConvertOptions
+
+        config = DoclingConverterManagerConfig(
+            custom_vlm_presets={
+                "my_preset": {
+                    "engine_options": _raw_engine_options(),
+                    "model_spec": {**_raw_model_spec(), "response_format": "doctags"},
+                }
+            },
+        )
+        manager = DoclingConverterManager(config)
+
+        request = ConvertDocumentsOptions(vlm_pipeline_preset="my_preset")
+        options = manager._parse_vlm_options(request)
+
+        assert isinstance(options, VlmConvertOptions)
+
+    def test_picture_description_custom_preset_engine_not_allowed(self):
+        """Engine allowlist must still apply once the dict is validated."""
+        config = DoclingConverterManagerConfig(
+            allowed_picture_description_engines=["mlx"],
+            custom_picture_description_presets={
+                "my_preset": {
+                    "engine_options": _raw_engine_options(),
+                    "model_spec": _raw_model_spec(),
+                }
+            },
+        )
+        manager = DoclingConverterManager(config)
+
+        request = ConvertDocumentsOptions(picture_description_preset="my_preset")
+        with pytest.raises(ValueError, match="not allowed"):
+            manager._parse_picture_description_options(request)
+
+    def test_picture_description_custom_config_non_regression(self):
+        """picture_description_custom_config (not by-name preset) must keep working."""
+        from docling.datamodel.pipeline_options import (
+            PictureDescriptionVlmEngineOptions,
+        )
+
+        config = DoclingConverterManagerConfig(
+            allow_custom_picture_description_config=True,
+        )
+        manager = DoclingConverterManager(config)
+
+        request = ConvertDocumentsOptions(
+            picture_description_custom_config={
+                "engine_options": _raw_engine_options(),
+                "model_spec": _raw_model_spec(),
+                "prompt": "Describe this image.",
+            }
+        )
+        options = manager._parse_picture_description_options(request)
+
+        assert isinstance(options, PictureDescriptionVlmEngineOptions)
+
+
 class TestOptionsParsingCustomConfig:
     """Test options parsing from custom configs."""
 


### PR DESCRIPTION
_get_options_from_preset returned custom-preset dicts unconverted for picture_description and code_formula, so the first attribute access on the resulting options downstream, picture_area_threshold in the reported case, crashed with AttributeError instead of hitting a real options object. The hasattr(preset_options, "engine_options") check right above it was also silently broken for the same reason, since hasattr on a dict is always False, so the engine allowlist got skipped for every custom preset too. vlm_pipeline_preset turned out not to share the bug the same way, it already had its own post-hoc dict conversion after calling into _get_options_from_preset, just duplicated separately from the pattern the picture_description_custom_config path uses.

This adds a custom_options_model parameter to _get_options_from_preset, mirroring the from_preset_func parameter it already takes for the built-in-preset branch, and validates custom dicts into that model before returning them. All three preset types (vlm, picture_description, code_formula) now go through the same conversion, and the now-redundant dict handling in _parse_vlm_options is folded into it. layout, ocr, table_structure and picture_classification presets already converted their custom dicts correctly and are untouched.

Added tests for the custom-preset-by-name path on picture_description and code_formula (the actual crash), a non-regression test for vlm's custom-by-name path, one confirming the engine allowlist is enforced once the dict is validated, and one confirming picture_description_custom_config still works unchanged.

**Issue resolved by this Pull Request:**
Resolves #191
