### PR TITLE
feat: Added Retry with Exponential backoff, pagination, and a initial connection check to filenet connector

### DIFF
--- a/docling_jobkit/connectors/filenet_helper.py
+++ b/docling_jobkit/connectors/filenet_helper.py
@@ -48,6 +48,28 @@ def _execute_graphql_query(
     return payload.get("data", {})
 
 
+def check_connection(coords: FileNetCoordinates, auth_header: str) -> None:
+    """Verify connectivity, credentials, and repository before processing (fail fast)"""
+    query = """
+    query ($repo: String!) {
+        documents(
+            repositoryIdentifier: $repo
+            pageSize: 1
+        ) {
+            pageInfo {
+                totalCount
+            }
+        }
+    }
+    """
+
+    graphql_url = f"{coords.base_url.rstrip('/')}/graphql"
+
+    _execute_graphql_query(
+        graphql_url, auth_header, query, {"repo": coords.repository_id}
+    )
+
+
 def list_repository_documents(
     coords: FileNetCoordinates,
     auth_header: str,

--- a/docling_jobkit/connectors/filenet_helper.py
+++ b/docling_jobkit/connectors/filenet_helper.py
@@ -1,14 +1,61 @@
 import base64
 import json
 import logging
+import time
 from io import BytesIO
-from typing import Iterator
+from typing import Callable, Iterator, TypeVar
 
 import requests
 
 from docling_jobkit.datamodel.filenet_coords import FileNetCoordinates
 
 _log = logging.getLogger(__name__)
+
+_MAX_RETRIES = 3
+_BACKOFF_BASE_S = 0.5
+_RETRYABLE_4XX_STATUS = {429}
+
+T = TypeVar("T")
+
+
+# I dont think we need to add jitter/randomness for the cli case but maybe for distributed version
+# TODO: add logic to extract Retry-After header sent in http header by external api on 429 telling us
+# after how much time the rate limit will be dropped and we are good to retry
+def _with_exponential_retry(fn: Callable[[], T], operation: str) -> T:
+    """helper for exponential retries on transient errors"""
+    for attempt in range(_MAX_RETRIES + 1):
+        try:
+            result = fn()
+            if isinstance(result, requests.Response):
+                result.raise_for_status()
+
+            return result
+        except (requests.Timeout, requests.ConnectionError):
+            if attempt == _MAX_RETRIES:
+                raise
+        except requests.HTTPError as exc:
+            status = exc.response.status_code if exc.response is not None else None
+            # 4xx are permanent (except 429) so we bail immediately
+            if (
+                status is not None
+                and status < 500
+                and status not in _RETRYABLE_4XX_STATUS
+            ):
+                raise
+            if attempt == _MAX_RETRIES:
+                raise
+
+        wait = _BACKOFF_BASE_S * (2**attempt)
+        logging.warning(
+            "FileNet: %s transient error, retry %d/%d in %.1fs",
+            operation,
+            attempt + 1,
+            _MAX_RETRIES,
+            wait,
+        )
+        time.sleep(wait)
+
+    raise AssertionError("unreachable")
 
 
 def get_filenet_auth_header(username: str, api_key: str) -> str:
@@ -24,20 +71,22 @@ def _execute_graphql_query(
     variables: dict | None = None,
 ) -> dict:
     """Execute a GraphQL query against FileNet API."""
-    response = requests.post(
-        graphql_url,
-        headers={
-            "Authorization": auth_header,
-            "Content-Type": "application/json",
-        },
-        json={
-            "query": query,
-            "variables": variables or {},
-        },
-        timeout=30,
+    response = _with_exponential_retry(
+        lambda: requests.post(
+            graphql_url,
+            headers={
+                "Authorization": auth_header,
+                "Content-Type": "application/json",
+            },
+            json={
+                "query": query,
+                "variables": variables or {},
+            },
+            timeout=30,
+        ),
+        "GraphQL query",
     )
 
-    response.raise_for_status()
     payload = response.json()
 
     if "errors" in payload:
@@ -284,16 +333,17 @@ def download_document(
 
     _log.debug("Downloading from: %s", full_url)
 
-    response = requests.get(
-        full_url,
-        headers={
-            "Authorization": auth_header,
-        },
-        stream=True,
-        timeout=300,
+    response = _with_exponential_retry(
+        lambda: requests.get(
+            full_url,
+            headers={
+                "Authorization": auth_header,
+            },
+            stream=True,
+            timeout=300,
+        ),
+        "document download",
     )
-
-    response.raise_for_status()
 
     buffer = BytesIO()
     for chunk in response.iter_content(chunk_size=1024 * 1024):

--- a/docling_jobkit/connectors/filenet_helper.py
+++ b/docling_jobkit/connectors/filenet_helper.py
@@ -195,15 +195,18 @@ def list_repository_documents(
     )
 
     doc_count = 0
-    for doc in _paginate_documents(graphql_url, auth_header, data.get("documents", {})):
-        doc_count += 1
-        yield doc
-
-    _log.info(
-        "Listed %d documents from repository %s",
-        doc_count,
-        coords.repository_id,
-    )
+    try:
+        for doc in _paginate_documents(
+            graphql_url, auth_header, data.get("documents", {})
+        ):
+            doc_count += 1
+            yield doc
+    finally:
+        _log.info(
+            "Listed %d documents from repository %s",
+            doc_count,
+            coords.repository_id,
+        )
 
 
 def list_folder_documents(
@@ -247,16 +250,17 @@ def list_folder_documents(
     contained = data.get("folder", {}).get("containedDocuments", {})
 
     doc_count = 0
-    for doc in _paginate_documents(graphql_url, auth_header, contained):
-        doc_count += 1
-        yield doc
-
-    _log.info(
-        "Listed %d documents from folder %s in repository %s",
-        doc_count,
-        folder_id,
-        coords.repository_id,
-    )
+    try:
+        for doc in _paginate_documents(graphql_url, auth_header, contained):
+            doc_count += 1
+            yield doc
+    finally:
+        _log.info(
+            "Listed %d documents from folder %s in repository %s",
+            doc_count,
+            folder_id,
+            coords.repository_id,
+        )
 
 
 def get_document_metadata(

--- a/docling_jobkit/connectors/filenet_helper.py
+++ b/docling_jobkit/connectors/filenet_helper.py
@@ -48,6 +48,43 @@ def _execute_graphql_query(
     return payload.get("data", {})
 
 
+def _paginate_documents(
+    graphql_url: str,
+    auth_header: str,
+    first_set: dict,  # a DocumentSet: {documents, pageInfo}
+) -> Iterator[dict]:
+    """Yield documents from a DocumentSet, paginating via pageInfo.token + moreDocuments."""
+    page = 1
+    current = first_set
+
+    while True:
+        for doc in current.get("documents", []):
+            yield doc
+
+        token = (current.get("pageInfo") or {}).get("token")
+        if not token:
+            return
+
+        page += 1
+        query = """
+        query ($token: String!) {
+            moreDocuments(token: $token) {
+                documents {
+                    id
+                    name
+                }
+                pageInfo {
+                    token
+                }
+            }
+        }
+        """
+
+        data = _execute_graphql_query(graphql_url, auth_header, query, {"token": token})
+
+        current = data.get("moreDocuments", {})
+
+
 def check_connection(coords: FileNetCoordinates, auth_header: str) -> None:
     """Verify connectivity, credentials, and repository before processing (fail fast)"""
     query = """
@@ -56,6 +93,9 @@ def check_connection(coords: FileNetCoordinates, auth_header: str) -> None:
             repositoryIdentifier: $repo
             pageSize: 1
         ) {
+            documents {
+                id
+            }
             pageInfo {
                 totalCount
             }
@@ -75,7 +115,7 @@ def list_repository_documents(
     auth_header: str,
     page_size: int = 1000,
 ) -> Iterator[dict]:
-    """List all documents in a FileNet repository."""
+    """List all documents in a FileNet repository, paginating across all pages."""
     query = """
     query ($repo: String!, $pageSize: Int) {
       documents(
@@ -85,6 +125,9 @@ def list_repository_documents(
         documents {
           id
           name
+        }
+        pageInfo {
+            token
         }
       }
     }
@@ -102,15 +145,16 @@ def list_repository_documents(
         },
     )
 
-    documents = data.get("documents", {}).get("documents", [])
+    doc_count = 0
+    for doc in _paginate_documents(graphql_url, auth_header, data.get("documents", {})):
+        doc_count += 1
+        yield doc
+
     _log.info(
         "Listed %d documents from repository %s",
-        len(documents),
+        doc_count,
         coords.repository_id,
     )
-
-    for doc in documents:
-        yield doc
 
 
 def list_folder_documents(
@@ -118,7 +162,7 @@ def list_folder_documents(
     auth_header: str,
     folder_id: str,
 ) -> Iterator[dict]:
-    """List all documents in a specific FileNet folder."""
+    """List all documents in a specific FileNet folder, paginating across all pages"""
     query = """
     query ($repo: String!, $folder: String!) {
       folder(
@@ -130,6 +174,9 @@ def list_folder_documents(
           documents {
             id
             name
+          }
+          pageInfo {
+            token
           }
         }
       }
@@ -148,18 +195,19 @@ def list_folder_documents(
         },
     )
 
-    folder_data = data.get("folder", {})
-    documents = folder_data.get("containedDocuments", {}).get("documents", [])
+    contained = data.get("folder", {}).get("containedDocuments", {})
+
+    doc_count = 0
+    for doc in _paginate_documents(graphql_url, auth_header, contained):
+        doc_count += 1
+        yield doc
 
     _log.info(
         "Listed %d documents from folder %s in repository %s",
-        len(documents),
+        doc_count,
         folder_id,
         coords.repository_id,
     )
-
-    for doc in documents:
-        yield doc
 
 
 def get_document_metadata(

--- a/docling_jobkit/connectors/filenet_source_processor.py
+++ b/docling_jobkit/connectors/filenet_source_processor.py
@@ -7,6 +7,7 @@ from typing_extensions import override
 from docling_core.types.io import DocumentStream
 
 from docling_jobkit.connectors.filenet_helper import (
+    check_connection,
     download_document,
     get_document_metadata,
     get_filenet_auth_header,
@@ -54,6 +55,8 @@ class FileNetSourceProcessor(
             self._coords.api_key.get_secret_value(),
         )
         self._graphql_url = f"{self._coords.base_url.rstrip('/')}/graphql"
+
+        check_connection(self._coords, self._auth_header)
         _log.info(
             "Connected to FileNet: %s (repository: %s)",
             self._coords.base_url,

--- a/tests/test_filenet_helper.py
+++ b/tests/test_filenet_helper.py
@@ -1,10 +1,90 @@
-from unittest.mock import MagicMock, patch
+from typing import Any
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+import requests
 
 from docling_jobkit.connectors import filenet_helper
 from docling_jobkit.connectors.filenet_helper import (
+    _execute_graphql_query,
+    _with_exponential_retry,
     list_folder_documents,
     list_repository_documents,
 )
+
+# _with_exponential_retry tests
+
+
+def _make_http_exc(status_code: int) -> requests.HTTPError:
+    """helper to create the http exception with the specified status code"""
+    response = MagicMock()
+    response.status_code = status_code
+
+    return requests.HTTPError(response=response)
+
+
+@pytest.mark.parametrize(
+    "transient_exc",
+    [
+        requests.Timeout("timed out"),
+        requests.ConnectionError("connection refused"),
+        _make_http_exc(503),  # 5xx errors are transient
+        _make_http_exc(429),  # 429 is transient: rate-limit
+    ],
+)
+def test_exp_backoff_retries_on_transient_error_then_succeeds(
+    transient_exc: Any,
+) -> None:
+    """It should not fail immediately and retry if transient"""
+    fn = MagicMock(side_effect=[transient_exc, "ok"])
+    with patch("docling_jobkit.connectors.filenet_helper.time.sleep"):
+        assert _with_exponential_retry(fn, "op") == "ok"
+
+    assert fn.call_count == 2
+
+
+def test_exp_backoff_raises_immediately_on_4xx() -> None:
+    """Any 4xx error (except 429) is not considered a transient error so it should raise immediately"""
+    fn = MagicMock(side_effect=_make_http_exc(403))
+    with patch("docling_jobkit.connectors.filenet_helper.time.sleep"):
+        with pytest.raises(requests.HTTPError):
+            _with_exponential_retry(fn, "op")
+
+    fn.assert_called_once()
+
+
+def test_exp_backoff_sequence() -> None:
+    """It should do proper exp backoff wait properly (increases each time)"""
+    fn = MagicMock(side_effect=requests.Timeout("timed out"))
+    with patch("docling_jobkit.connectors.filenet_helper.time.sleep") as mock_sleep:
+        with pytest.raises(requests.Timeout):
+            _with_exponential_retry(fn, "op")
+
+    assert mock_sleep.call_args_list == [call(0.5), call(1.0), call(2.0)]
+
+
+# _execute_graphql_query tests
+
+
+def test_graphql_errors_payload_raises_immediately_without_retry() -> None:
+    """GraphQL 200 response with errors key is a perm error and shouldn't retry"""
+    ok_res = MagicMock()
+    ok_res.json.return_value = {"errors": [{"message": "Invalid identifier"}]}
+
+    with patch("docling_jobkit.connectors.filenet_helper.time.sleep") as mock_sleep:
+        with patch(
+            "docling_jobkit.connectors.filenet_helper.requests.post",
+            return_value=ok_res,
+        ):
+            with pytest.raises(RuntimeError, match="GraphQL query failed"):
+                _execute_graphql_query(
+                    "https://{host}/content-services-graphql", "auth", "query { }"
+                )
+
+    mock_sleep.assert_not_called()
+
+
+# pagination tests
 
 
 def _document_set(ids: list[str], token: str | None) -> dict:

--- a/tests/test_filenet_helper.py
+++ b/tests/test_filenet_helper.py
@@ -1,0 +1,62 @@
+from unittest.mock import MagicMock, patch
+
+from docling_jobkit.connectors import filenet_helper
+from docling_jobkit.connectors.filenet_helper import (
+    list_folder_documents,
+    list_repository_documents,
+)
+
+
+def _document_set(ids: list[str], token: str | None) -> dict:
+    return {
+        "documents": [{"id": i, "name": f"{i}.pdf"} for i in ids],
+        "pageInfo": {"token": token},
+    }
+
+
+def test_list_repository_documents_paginates_across_pages() -> None:
+    with patch.object(
+        filenet_helper,
+        "_execute_graphql_query",
+        side_effect=[
+            {"documents": _document_set(["1"], "tok-1")},
+            {"moreDocuments": _document_set(["2"], "tok-2")},
+            {"moreDocuments": _document_set(["3"], None)},
+        ],
+    ) as mock_query:
+        docs = list(list_repository_documents(MagicMock(), "auth", page_size=1))
+
+    assert [d["id"] for d in docs] == ["1", "2", "3"]  # ordering
+    assert mock_query.call_count == 3
+
+    assert mock_query.call_args_list[1].args[3] == {"token": "tok-1"}
+    assert mock_query.call_args_list[2].args[3] == {"token": "tok-2"}
+
+
+def test_list_folder_documents_paginates_across_pages() -> None:
+    with patch.object(
+        filenet_helper,
+        "_execute_graphql_query",
+        side_effect=[
+            {"folder": {"containedDocuments": _document_set(["1"], "tok-1")}},
+            {"moreDocuments": _document_set(["2"], None)},
+        ],
+    ) as mock_query:
+        docs = list(list_folder_documents(MagicMock(), "auth", "/folder"))
+
+    assert [d["id"] for d in docs] == ["1", "2"]
+    assert mock_query.call_count == 2
+
+    assert mock_query.call_args_list[1].args[3] == {"token": "tok-1"}
+
+
+def test_pagination_stops_on_empty_token_without_extra_calls() -> None:
+    with patch.object(
+        filenet_helper,
+        "_execute_graphql_query",
+        side_effect=[{"documents": _document_set(["1", "2"], None)}],
+    ) as mock_query:
+        docs = list(list_repository_documents(MagicMock(), "auth"))
+
+    assert [d["id"] for d in docs] == ["1", "2"]
+    assert mock_query.call_count == 1

--- a/tests/test_filenet_source_processor.py
+++ b/tests/test_filenet_source_processor.py
@@ -9,9 +9,12 @@ from docling_jobkit.connectors.filenet_source_processor import FileNetSourceProc
 
 def test_initialize_does_not_log_connected_on_probe_failure(caplog) -> None:
     processor = FileNetSourceProcessor(MagicMock())
-    with patch("requests.post", side_effect=requests.ConnectionError("DNS failure")):
-        with pytest.raises(requests.ConnectionError):
-            processor._initialize()
+    with patch("docling_jobkit.connectors.filenet_helper.time.sleep"):
+        with patch(
+            "requests.post", side_effect=requests.ConnectionError("DNS failure")
+        ):
+            with pytest.raises(requests.ConnectionError):
+                processor._initialize()
 
     assert "Connected to FileNet" not in caplog.text
 

--- a/tests/test_filenet_source_processor.py
+++ b/tests/test_filenet_source_processor.py
@@ -1,0 +1,31 @@
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from docling_jobkit.connectors.filenet_source_processor import FileNetSourceProcessor
+
+
+def test_initialize_does_not_log_connected_on_probe_failure(caplog) -> None:
+    processor = FileNetSourceProcessor(MagicMock())
+    with patch("requests.post", side_effect=requests.ConnectionError("DNS failure")):
+        with pytest.raises(requests.ConnectionError):
+            processor._initialize()
+
+    assert "Connected to FileNet" not in caplog.text
+
+
+def test_initialize_logs_connected_after_successful_probe(caplog) -> None:
+    mock_response = MagicMock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = {
+        "data": {"documents": {"pageInfo": {"totalCount": 0}}}
+    }
+    processor = FileNetSourceProcessor(MagicMock())
+
+    with caplog.at_level(logging.INFO):
+        with patch("requests.post", return_value=mock_response):
+            processor._initialize()
+
+    assert "Connected to FileNet" in caplog.text


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->
## Summary
This pr improves the FileNet connector with a fail-fast connection check on startup, full pagination across document sets via moreDocuments, and an exponential backoff retry helper that retries on transient network errors

## Changes
- `docling_jobkit/connectors/filenet_helper.py`: added check_connection, _paginate_documents, and _with_exponential_retry. Also wrapped _execute_graphql_query and download_document with retry
- `docling_jobkit/connectors/filenet_source_processor.py`: add check_connection to _initialize
- `tests/test_filenet_helper.py`: added unit tests for the new retry and pagination
- `tests/test_filenet_source_processor.py`: unit tests for source processor initialization and connection check
