### PR TITLE
fix: propagate picture description/classification options to office formats

### DIFF
--- a/docling_jobkit/convert/manager.py
+++ b/docling_jobkit/convert/manager.py
@@ -44,9 +44,16 @@ from docling.datamodel.vlm_engine_options import (
 )
 from docling.document_converter import (
     DocumentConverter,
+    ExcelFormatOption,
     FormatOption,
+    HTMLFormatOption,
     ImageFormatOption,
+    OdpFormatOption,
+    OdsFormatOption,
+    OdtFormatOption,
     PdfFormatOption,
+    PowerpointFormatOption,
+    WordFormatOption,
 )
 from docling.models.factories import (
     get_layout_factory,
@@ -473,6 +480,34 @@ class DoclingConverterManager:
                 InputFormat.PDF: pdf_format_option,
                 InputFormat.IMAGE: image_format_option,
             }
+
+            # Propagate picture description/classification/chart-extraction
+            # options to SimplePipeline-based office formats too. Without this,
+            # do_picture_description and friends are silently ignored for
+            # DOCX/PPTX/XLSX/HTML/ODT/ODS/ODP, even though SimplePipeline runs
+            # the same enrichment stage as the PDF pipeline.
+            office_pipeline_options = pdf_format_option.pipeline_options
+            format_options[InputFormat.DOCX] = WordFormatOption(
+                pipeline_options=office_pipeline_options
+            )
+            format_options[InputFormat.PPTX] = PowerpointFormatOption(
+                pipeline_options=office_pipeline_options
+            )
+            format_options[InputFormat.XLSX] = ExcelFormatOption(
+                pipeline_options=office_pipeline_options
+            )
+            format_options[InputFormat.HTML] = HTMLFormatOption(
+                pipeline_options=office_pipeline_options
+            )
+            format_options[InputFormat.ODT] = OdtFormatOption(
+                pipeline_options=office_pipeline_options
+            )
+            format_options[InputFormat.ODS] = OdsFormatOption(
+                pipeline_options=office_pipeline_options
+            )
+            format_options[InputFormat.ODP] = OdpFormatOption(
+                pipeline_options=office_pipeline_options
+            )
 
             return DocumentConverter(format_options=format_options)
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -12,6 +12,15 @@ from docling.datamodel.pipeline_options import (
     ProcessingPipeline,
     VlmPipelineOptions,
 )
+from docling.document_converter import (
+    ExcelFormatOption,
+    HTMLFormatOption,
+    OdpFormatOption,
+    OdsFormatOption,
+    OdtFormatOption,
+    PowerpointFormatOption,
+    WordFormatOption,
+)
 from docling.pipeline.vlm_pipeline import VlmPipeline
 from docling_core.types.doc import ImageRefMode, PictureClassificationLabel
 
@@ -347,3 +356,42 @@ def test_image_pipeline_uses_vlm_pipeline_when_requested():
     img_opt = converter.format_to_options[InputFormat.IMAGE]
     assert img_opt.pipeline_cls == VlmPipeline
     assert isinstance(img_opt.pipeline_options, VlmPipelineOptions)
+
+
+def test_picture_description_options_propagate_to_office_formats():
+    """do_picture_description (and the rest of the
+    picture description / classification / chart extraction options) must
+    reach the SimplePipeline-based office formats too, not just PDF/IMAGE.
+    """
+    m = DoclingConverterManager(config=DoclingConverterManagerConfig())
+    opts = ConvertDocumentsOptions(
+        do_picture_description=True,
+        picture_description_api={
+            "url": "http://localhost:8000/v1/chat/completions",
+            "params": {"model": "test-model"},
+        },
+    )
+
+    with pytest.warns(DeprecationWarning):
+        pipeline_opts = m.get_pdf_pipeline_opts(opts)
+
+    converter = m.get_converter(pipeline_opts)
+    pdf_picture_opts = pipeline_opts.pipeline_options.picture_description_options
+
+    office_format_to_option_cls = {
+        InputFormat.DOCX: WordFormatOption,
+        InputFormat.PPTX: PowerpointFormatOption,
+        InputFormat.XLSX: ExcelFormatOption,
+        InputFormat.HTML: HTMLFormatOption,
+        InputFormat.ODT: OdtFormatOption,
+        InputFormat.ODS: OdsFormatOption,
+        InputFormat.ODP: OdpFormatOption,
+    }
+    for input_format, option_cls in office_format_to_option_cls.items():
+        format_option = converter.format_to_options[input_format]
+        assert isinstance(format_option, option_cls)
+        assert format_option.pipeline_options.do_picture_description is True
+        assert (
+            format_option.pipeline_options.picture_description_options
+            == pdf_picture_opts
+        )


### PR DESCRIPTION
DoclingConverterManager only built custom FormatOptions for InputFormat.PDF/IMAGE, so request-level do_picture_description, do_picture_classification, do_chart_extraction (and their *_options) were silently ignored for DOCX/PPTX/XLSX/HTML/ODT/ODS/ODP, even though SimplePipeline (used for all of these) runs the same common enrichment stage as the PDF pipeline and fully supports them.

Reuse the already-parsed PDF pipeline_options when building the office FormatOptions so picture description (local or API-based), picture classification, and chart extraction now work for these formats too.

Resolves #145.

<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
-->
