### PR TITLE
fix: reported expected doc count in callbacks

### DIFF
--- a/docling_jobkit/orchestrators/local/worker.py
+++ b/docling_jobkit/orchestrators/local/worker.py
@@ -106,6 +106,7 @@ class AsyncLocalWorker:
                             work_dir=workdir,
                             s3_presigned_config=self.orchestrator.config.s3_presigned_config,
                             callback_invoker=callback_invoker,
+                            expected_doc_count=len(convert_sources),
                             allow_external_plugins=cm.config.allow_external_plugins,
                             chunker_manager=DocumentChunkerManager(),
                             chunking_options=chunking_options,
@@ -117,6 +118,7 @@ class AsyncLocalWorker:
                             work_dir=workdir,
                             chunker_manager=self.orchestrator.chunker_manager,
                             callback_invoker=callback_invoker,
+                            expected_doc_count=len(convert_sources),
                         )
                     else:
                         raise RuntimeError(f"Unsupported task type: {task.task_type}")

--- a/docling_jobkit/orchestrators/rq/worker.py
+++ b/docling_jobkit/orchestrators/rq/worker.py
@@ -183,6 +183,7 @@ def _run_docling_task(
                         s3_presigned_config=orchestrator_config.s3_presigned_config,
                         callback_invoker=callback_invoker,
                         debug_error_details=orchestrator_config.debug_error_details,
+                        expected_doc_count=len(convert_sources),
                         allow_external_plugins=(
                             orchestrator_config.allow_external_plugins
                         ),
@@ -197,6 +198,7 @@ def _run_docling_task(
                         work_dir=workdir,
                         callback_invoker=callback_invoker,
                         debug_error_details=orchestrator_config.debug_error_details,
+                        expected_doc_count=len(convert_sources),
                     )
             else:
                 raise RuntimeError(f"Unsupported task type: {task.task_type}")


### PR DESCRIPTION
Propagates the expected doc count to the workers, then used for the task progress call backs.