### PR TITLE
fix: serialization of custom options

### DIFF
--- a/docling_jobkit/orchestrators/ray/redis_helper.py
+++ b/docling_jobkit/orchestrators/ray/redis_helper.py
@@ -254,7 +254,7 @@ class RedisStateManager:
 
         queue_key = f"tenant:{tenant_id}:tasks"
         task_counters_key = f"tenant:{tenant_id}:task_counters"
-        task_json = json.dumps(dump_model_with_secrets(task))
+        task_json = json.dumps(dump_model_with_secrets(task, serialize_as_any=True))
 
         # Push the task and bump the monotonic enqueued counter atomically so the
         # counter can never drift from the queue contents.

--- a/tests/test_orchestrator_serialization.py
+++ b/tests/test_orchestrator_serialization.py
@@ -78,3 +78,68 @@ def test_dump_model_with_secrets_restores_google_drive_credentials():
     payload = dump_model_with_secrets(task, serialize_as_any=True)
 
     assert payload["sources"][0]["credentials"]["client_secret"] == "super-secret"
+
+
+def test_dump_model_preserves_api_engine_options_subclass_fields():
+    """Ray Redis enqueue uses serialize_as_any=True; engine_options subclass fields must survive.
+
+    Regression test for: ApiVlmEngineOptions.url and .params being silently dropped
+    when the task is serialized without serialize_as_any=True because the declared
+    field type is BaseVlmEngineOptions (the base class), causing Pydantic to use only
+    the base-class schema for serialization and discarding all subclass-only fields.
+    """
+
+    from docling.datamodel.pipeline_options import (
+        PictureDescriptionVlmEngineOptions,
+        ResponseFormat,
+        VlmModelSpec,
+    )
+    from docling.datamodel.service.options import ConvertDocumentsOptions
+    from docling.datamodel.service.targets import InBodyTarget
+    from docling.datamodel.service.tasks import TaskType
+    from docling.datamodel.vlm_engine_options import ApiVlmEngineOptions
+
+    from docling_jobkit.datamodel.task import Task
+
+    task = Task(
+        task_id="task-api-engine",
+        task_type=TaskType.CONVERT,
+        target=InBodyTarget(),
+        convert_options=ConvertDocumentsOptions(
+            do_picture_description=True,
+            picture_description_custom_config=PictureDescriptionVlmEngineOptions(
+                engine_options=ApiVlmEngineOptions(
+                    url="http://127.0.0.1:8881/v1/chat/completions",
+                    params={"model": "granite-vision-4-1-4b"},
+                ),
+                model_spec=VlmModelSpec(
+                    name="granite-vision-4-1-4b",
+                    default_repo_id="ibm-granite/granite-vision-4.1-4b",
+                    prompt="Describe this image.",
+                    response_format=ResponseFormat.PLAINTEXT,
+                ),
+            ),
+        ),
+    )
+
+    # This is what Ray Redis enqueue does; serialize_as_any=True is required so
+    # that Pydantic serialises the concrete ApiVlmEngineOptions subclass (with
+    # url, params, …) rather than just the BaseVlmEngineOptions base fields.
+    payload = dump_model_with_secrets(task, serialize_as_any=True)
+    engine_opts_dict = payload["convert_options"]["picture_description_custom_config"][
+        "engine_options"
+    ]
+
+    # url and params must survive the serialization round-trip
+    assert engine_opts_dict["url"] == "http://127.0.0.1:8881/v1/chat/completions"
+    assert engine_opts_dict["params"] == {"model": "granite-vision-4-1-4b"}
+    assert engine_opts_dict["engine_type"] == "api"
+
+    # Without serialize_as_any the subclass fields are silently dropped
+    payload_no_any = dump_model_with_secrets(task, serialize_as_any=False)
+    engine_opts_base = payload_no_any["convert_options"][
+        "picture_description_custom_config"
+    ]["engine_options"]
+    assert "url" not in engine_opts_base, (
+        "Without serialize_as_any=True, url should be missing (demonstrating the bug)"
+    )


### PR DESCRIPTION
## Fix silent dropping of `ApiVlmEngineOptions` subclass fields during Ray Redis task enqueue

### Description

When a `Task` containing `ApiVlmEngineOptions` (or any other subclass of `BaseVlmEngineOptions`) was enqueued via the Ray Redis orchestrator, the subclass-specific fields (e.g., `url`, `params`) were **silently dropped** during serialization.

**Root cause:** The declared field type for `engine_options` is the base class `BaseVlmEngineOptions`. Without `serialize_as_any=True`, Pydantic uses only the base-class schema for serialization and discards all fields that exist exclusively on the concrete subclass. The call to `dump_model_with_secrets` in `redis_helper.py` was missing the `serialize_as_any=True` argument.

**Fix:** Pass `serialize_as_any=True` to `dump_model_with_secrets` when serializing the task for the Redis queue, consistent with how it is already used elsewhere (e.g., in the Google Drive credentials serialization path).

**Changes:**
- `docling_jobkit/orchestrators/ray/redis_helper.py` — add `serialize_as_any=True` to the `dump_model_with_secrets` call used during task enqueue.
- `tests/test_orchestrator_serialization.py` — add a regression test that:
  - Verifies `url`, `params`, and `engine_type` survive the serialization round-trip **with** `serialize_as_any=True`.
  - Documents (and asserts) that `url` is indeed silently dropped **without** `serialize_as_any=True`, confirming the original bug.