### PR TITLE
feat: kafka chunk target

### DIFF
--- a/dev/configs/run_kafka_chunks_example.yaml
+++ b/dev/configs/run_kafka_chunks_example.yaml
@@ -1,0 +1,23 @@
+# Test locally against dev/docker-compose.kafka.yaml:
+#   docker compose -f dev/docker-compose.kafka.yaml up -d
+#   docling-jobkit-local dev/configs/run_kafka_chunks_example.yaml
+
+options:
+  do_ocr: false
+
+sources:
+  - kind: local_path
+    path: ./input_documents/
+    recursive: true
+
+target:
+  kind: kafka_chunks
+  bootstrap_servers:
+    - localhost:29092  # host-reachable listener from docker-compose.kafka.yaml
+  topic: docling.chunks
+  key_mode: doc_id  # all chunks of a document land in one partition, ordered
+  # auth:
+  #   kind: sasl
+  #   mechanism: SCRAM-SHA-512
+  #   username: your-username
+  #   password: "your-password"

--- a/dev/configs/run_kafka_chunks_example.yaml
+++ b/dev/configs/run_kafka_chunks_example.yaml
@@ -18,6 +18,6 @@ target:
   key_mode: doc_id  # all chunks of a document land in one partition, ordered
   # auth:
   #   kind: sasl
-  #   mechanism: SCRAM-SHA-512
+  #   mechanism: PLAIN
   #   username: your-username
   #   password: "your-password"

--- a/dev/configs/run_kafka_chunks_example.yaml
+++ b/dev/configs/run_kafka_chunks_example.yaml
@@ -1,6 +1,6 @@
 # Test locally against dev/docker-compose.kafka.yaml:
-#   docker compose -f dev/docker-compose.kafka.yaml up -d
-#   docling-jobkit-local dev/configs/run_kafka_chunks_example.yaml
+# docker compose -f dev/docker-compose.kafka.yaml up -d
+# Kafka UI view at https://localhost:8080
 
 options:
   do_ocr: false

--- a/dev/configs/run_kafka_chunks_example.yaml
+++ b/dev/configs/run_kafka_chunks_example.yaml
@@ -15,9 +15,32 @@ target:
   bootstrap_servers:
     - localhost:29092  # host-reachable listener from docker-compose.kafka.yaml
   topic: docling.chunks
-  key_mode: doc_id  # all chunks of a document land in one partition, ordered
+  # All chunks of a document land in one partition, ordered (ordering needs
+  # acks: all, which enables the idempotent producer).
+  # Do NOT enable log compaction on the topic with this key mode: the broker
+  # would keep only the last chunk of each document.
+  key_mode: doc_id
   # auth:
   #   kind: sasl
   #   mechanism: PLAIN
   #   username: your-username
   #   password: "your-password"
+  # Defaults to SASL_SSL when 'auth' is set, PLAINTEXT otherwise. Set it
+  # explicitly for SCRAM over a trusted network (SASL_PLAINTEXT) or mTLS (SSL).
+  # security_protocol: SASL_SSL
+  # verify_certs: true
+  # Producer queue bounds (optional, these are the defaults). They cap
+  # librdkafka's *native* client-side buffers, whose own defaults are 1 GiB /
+  # 100 000 messages per worker.
+  # queue_max_kbytes: 65536
+  # queue_max_messages: 10000
+  # compression_type: lz4
+  # acks: all
+  # Field mappings (optional, these are the defaults)
+  text_field: "text"
+  metadata_field: "metadata"
+  doc_id_field: "doc_id"
+  chunk_index_field: "chunk_index"
+  chunk_id_field: "chunk_id"
+  page_field: "page_numbers"
+  headings_field: "headings"

--- a/dev/configs/run_kafka_chunks_example.yaml
+++ b/dev/configs/run_kafka_chunks_example.yaml
@@ -25,6 +25,10 @@ target:
   #   mechanism: PLAIN
   #   username: your-username
   #   password: "your-password"
+  #   # Optional: base64-encoded CA certificate for self-signed/internal CAs
+  #   # To encode locally: cat your_ca.crt | base64 | tr -d '\n'
+  #   # ca_cert: aAAAaaa...
+
   # Defaults to SASL_SSL when 'auth' is set, PLAINTEXT otherwise. Set it
   # explicitly for SCRAM over a trusted network (SASL_PLAINTEXT) or mTLS (SSL).
   # security_protocol: SASL_SSL

--- a/dev/configs/run_kafka_chunks_example.yaml
+++ b/dev/configs/run_kafka_chunks_example.yaml
@@ -1,6 +1,6 @@
 # Test locally against dev/docker-compose.kafka.yaml:
 # docker compose -f dev/docker-compose.kafka.yaml up -d
-# Kafka UI view at https://localhost:8080
+# Kafka UI view at http://localhost:8080
 
 options:
   do_ocr: false

--- a/dev/docker-compose.kafka.yaml
+++ b/dev/docker-compose.kafka.yaml
@@ -40,7 +40,7 @@ services:
         echo "Topics created:"
         kafka-topics --bootstrap-server broker:9092 --list
 
-  # UI view for Kafka messages https://localhost:8080
+  # UI view for Kafka messages http://localhost:8080
   kafka-ui:
     image: ghcr.io/kafbat/kafka-ui:latest
     container_name: kafka-ui

--- a/dev/docker-compose.kafka.yaml
+++ b/dev/docker-compose.kafka.yaml
@@ -40,6 +40,19 @@ services:
         echo "Topics created:"
         kafka-topics --bootstrap-server broker:9092 --list
 
+  # UI view for Kafka messages https://localhost:8080
+  kafka-ui:
+    image: ghcr.io/kafbat/kafka-ui:latest
+    container_name: kafka-ui
+    depends_on:
+      broker:
+        condition: service_healthy
+    ports:
+      - "8080:8080"
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: broker:9092
+
 networks:
   default:
     name: docling-kafka

--- a/dev/docker-compose.kafka.yaml
+++ b/dev/docker-compose.kafka.yaml
@@ -1,0 +1,45 @@
+services:
+  broker:
+    image: confluentinc/cp-kafka:7.9.0
+    container_name: broker
+    ports:
+      - "9092:9092"
+      # Host-reachable listener
+      - "29092:29092"
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,PLAINTEXT_HOST://0.0.0.0:29092,CONTROLLER://broker:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:9092,PLAINTEXT_HOST://localhost:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@broker:9093
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
+    healthcheck:
+      test: ["CMD", "kafka-topics", "--bootstrap-server", "broker:9092", "--list"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  kafka-init:
+    image: confluentinc/cp-kafka:7.9.0
+    depends_on:
+      broker:
+        condition: service_healthy
+    entrypoint: ["/bin/sh", "-c"]
+    command:
+      - |
+        kafka-topics --bootstrap-server broker:9092 \
+          --create --if-not-exists --topic docling.chunks \
+          --partitions 4 --replication-factor 1
+
+        echo "Topics created:"
+        kafka-topics --bootstrap-server broker:9092 --list
+
+networks:
+  default:
+    name: docling-kafka

--- a/docling_jobkit/connectors/kafka/__init__.py
+++ b/docling_jobkit/connectors/kafka/__init__.py
@@ -1,0 +1,1 @@
+"""Kafka target conector - streams chunks as messages/events"""

--- a/docling_jobkit/connectors/kafka/__init__.py
+++ b/docling_jobkit/connectors/kafka/__init__.py
@@ -1,1 +1,1 @@
-"""Kafka target conector - streams chunks as messages/events"""
+"""Kafka target connector - streams chunks as messages/events"""

--- a/docling_jobkit/connectors/kafka/helper.py
+++ b/docling_jobkit/connectors/kafka/helper.py
@@ -50,7 +50,7 @@ def build_producer_config(target: KafkaChunkTarget) -> dict[str, Any]:
 
         # Pass CA cert inline as PEM string (librdkafka ssl.ca.pem parameter)
         if auth.ca_cert is not None:
-            ca_pem = base64.b64decode(auth.ca_cert.get_secret_value()).decode("utf-8")
+            ca_pem = base64.b64decode(auth.ca_cert).decode("utf-8")
             config["ssl.ca.pem"] = ca_pem
 
     return config

--- a/docling_jobkit/connectors/kafka/helper.py
+++ b/docling_jobkit/connectors/kafka/helper.py
@@ -1,3 +1,4 @@
+import base64
 import logging
 from typing import Any
 
@@ -43,11 +44,14 @@ def build_producer_config(target: KafkaChunkTarget) -> dict[str, Any]:
 
     if target.auth is not None:
         auth = target.auth
-        config["sasl.mechanism"] = auth.mechanism  # PLAIN for Confluent Cloud API auth
+        config["sasl.mechanism"] = auth.mechanism
         config["sasl.username"] = auth.username
         config["sasl.password"] = auth.password.get_secret_value()
-        if auth.ca_cert_path:
-            config["ssl.ca.location"] = auth.ca_cert_path  # Optional: custom CA only
+
+        # Pass CA cert inline as PEM string (librdkafka ssl.ca.pem parameter)
+        if auth.ca_cert is not None:
+            ca_pem = base64.b64decode(auth.ca_cert.get_secret_value()).decode("utf-8")
+            config["ssl.ca.pem"] = ca_pem
 
     return config
 

--- a/docling_jobkit/connectors/kafka/helper.py
+++ b/docling_jobkit/connectors/kafka/helper.py
@@ -1,20 +1,48 @@
+import logging
 from typing import Any
 
 from docling_jobkit.connectors.kafka.models import KafkaChunkTarget
 
+_log = logging.getLogger(__name__)
+
 
 def build_producer_config(target: KafkaChunkTarget) -> dict[str, Any]:
     """Build confluent_kafka.Producer config dict from target model."""
+    protocol = target.effective_security_protocol
+
     config: dict[str, Any] = {
         "bootstrap.servers": ",".join(target.bootstrap_servers),
         "acks": target.acks,
+        # Bound librdkafka's internal queues.  Its defaults (1 GiB / 100 000
+        # messages) are native, per-worker memory on top of the models and the
+        # DoclingDocument; see KafkaChunkTarget for the full rationale.
+        "queue.buffering.max.kbytes": target.queue_max_kbytes,
+        "queue.buffering.max.messages": target.queue_max_messages,
+        "compression.type": target.compression_type,
+        "client.id": "docling-jobkit",
+        "security.protocol": protocol,
     }
 
-    if target.auth is None:
-        config["security.protocol"] = "PLAINTEXT"
-    else:
+    # The idempotent producer is what actually makes key_mode='doc_id' ordered:
+    # without it, up to 1 000 000 requests may be in flight per connection and
+    # a retry can reorder messages within a partition.  librdkafka rejects
+    # enable.idempotence together with acks != 'all', so honour the user's
+    # explicit choice of a weaker acks setting instead of failing at connect.
+    if target.acks == "all":
+        config["enable.idempotence"] = True
+    elif target.key_mode == "doc_id":
+        _log.warning(
+            "kafka: acks=%s disables the idempotent producer, so chunks of a "
+            "document may be reordered within their partition despite "
+            "key_mode='doc_id'. Use acks='all' if ordering matters.",
+            target.acks,
+        )
+
+    if protocol in ("SSL", "SASL_SSL"):
+        config["enable.ssl.certificate.verification"] = target.verify_certs
+
+    if target.auth is not None:
         auth = target.auth
-        config["security.protocol"] = "SASL_SSL"  # Always use SSL with SASL
         config["sasl.mechanism"] = auth.mechanism  # PLAIN for Confluent Cloud API auth
         config["sasl.username"] = auth.username
         config["sasl.password"] = auth.password.get_secret_value()

--- a/docling_jobkit/connectors/kafka/helper.py
+++ b/docling_jobkit/connectors/kafka/helper.py
@@ -1,0 +1,27 @@
+from typing import Any
+
+from docling_jobkit.connectors.kafka.models import KafkaChunkTarget
+
+
+def build_producer_config(target: KafkaChunkTarget) -> dict[str, Any]:
+    """Build confluent_kafka.Producer config dict from target model."""
+    config: dict[str, Any] = {
+        "bootstrap.servers": ",".join(target.bootstrap_servers),
+        "acks": target.acks,
+    }
+
+    if target.auth is None:
+        config["security.protocol"] = "PLAINTEXT"
+    else:
+        auth = target.auth
+        config["security.protocol"] = "SASL_SSL"  # Always use SSL with SASL
+        config["sasl.mechanism"] = auth.mechanism  # PLAIN for Confluent Cloud API auth
+        config["sasl.username"] = auth.username
+        config["sasl.password"] = auth.password.get_secret_value()
+        if auth.ca_cert_path:
+            config["ssl.ca.location"] = auth.ca_cert_path  # Optional: custom CA only
+
+    return config
+
+
+__all__ = ["build_producer_config"]

--- a/docling_jobkit/connectors/kafka/helper.py
+++ b/docling_jobkit/connectors/kafka/helper.py
@@ -22,6 +22,12 @@ def build_producer_config(target: KafkaChunkTarget) -> dict[str, Any]:
         "compression.type": target.compression_type,
         "client.id": "docling-jobkit",
         "security.protocol": protocol,
+        # Cap the per-message retry window so delivery callbacks fire before
+        # end_chunks()'s flush() deadline.  librdkafka's default is 300 000 ms;
+        # without this cap, any runtime delivery failure (auth expiry, broker
+        # eviction) would silently outlast the flush and surface only as a
+        # generic timeout instead of the real error.
+        "message.timeout.ms": int(target.delivery_timeout_seconds * 1000),
     }
 
     # The idempotent producer is what actually makes key_mode='doc_id' ordered:

--- a/docling_jobkit/connectors/kafka/models.py
+++ b/docling_jobkit/connectors/kafka/models.py
@@ -157,6 +157,18 @@ class KafkaChunkTarget(FieldMappings, ChunkFieldSlots):
         ),
     )
 
+    delivery_timeout_seconds: float = Field(
+        default=8.0,
+        gt=0.0,
+        description=(
+            "Per-message delivery timeout in seconds (librdkafka "
+            "'message.timeout.ms'). librdkafka will retry delivery until this "
+            "deadline expires, then fire the delivery callback with an error. "
+            "Must be shorter than the flush timeout (10 s) so that delivery "
+            "errors surface before the flush call gives up."
+        ),
+    )
+
     chunk_id_field: str = Field(
         default="chunk_id",
         description=(

--- a/docling_jobkit/connectors/kafka/models.py
+++ b/docling_jobkit/connectors/kafka/models.py
@@ -43,7 +43,7 @@ class KafkaSaslAuth(BaseModel):
     mechanism: Literal["PLAIN", "SCRAM-SHA-256", "SCRAM-SHA-512"] = "PLAIN"
     username: str
     password: SecretStr
-    ca_cert: Optional[SecretStr] = Field(
+    ca_cert: Optional[str] = Field(
         default=None,
         description=(
             "Base64-encoded CA certificate for TLS verification. Use this for "

--- a/docling_jobkit/connectors/kafka/models.py
+++ b/docling_jobkit/connectors/kafka/models.py
@@ -43,7 +43,13 @@ class KafkaSaslAuth(BaseModel):
     mechanism: Literal["PLAIN", "SCRAM-SHA-256", "SCRAM-SHA-512"] = "PLAIN"
     username: str
     password: SecretStr
-    ca_cert_path: Optional[str] = None  # Optional path to CA cert for TLS
+    ca_cert: Optional[SecretStr] = Field(
+        default=None,
+        description=(
+            "Base64-encoded CA certificate for TLS verification. Use this for "
+            "self-signed or internal CAs. Omit for publicly-trusted CAs."
+        ),
+    )
 
 
 class KafkaChunkTarget(FieldMappings, ChunkFieldSlots):

--- a/docling_jobkit/connectors/kafka/models.py
+++ b/docling_jobkit/connectors/kafka/models.py
@@ -1,0 +1,61 @@
+from typing import Literal, Optional
+
+from pydantic import BaseModel, Field, SecretStr
+
+from docling_jobkit.datamodel.target_field_slots import ChunkFieldSlots, FieldMappings
+
+
+class KafkaSaslAuth(BaseModel):
+    # Confluent Cloud uses PLAIN - SCRAMs here for on-prem instances
+    mechanism: Literal["PLAIN", "SCRAM-SHA-256", "SCRAM-SHA-512"] = "PLAIN"
+    username: str
+    password: SecretStr
+    ca_cert_path: Optional[str] = None  # Optional path to CA cert for TLS
+
+
+class KafkaChunkTarget(FieldMappings, ChunkFieldSlots):
+    """Kafka target for chunk-level streaming.
+
+    Each chunk is published as a separate message with JSON value.
+    """
+
+    kind: Literal["kafka_chunks"] = "kafka_chunks"
+
+    bootstrap_servers: list[str] = Field(
+        description="Kafka broker addresses (host:port).",
+        examples=[["localhost:9092"]],
+    )
+
+    topic: str = Field(
+        description="Kafka topic to publish chunks to.",
+        examples=["docling.chunks"],
+    )
+
+    auth: Optional[KafkaSaslAuth] = Field(
+        default=None,
+        description="SASL authentication. Omit for plaintext (no auth).",
+    )
+
+    key_mode: Literal["doc_id", "chunk_id", "none"] = Field(
+        default="doc_id",
+        description=(
+            "- 'doc_id': all chunks of a document land in one partition, ordered.\n"
+            "- 'chunk_id': stable content hash, spread across partitions.\n"
+            "- 'none': null key, round-robin distribution."
+        ),
+    )
+
+    acks: Literal["0", "1", "all"] = Field(
+        default="all",
+        description=(
+            "- '0': no ack (fire-and-forget)\n"
+            "- '1': leader ack only\n"
+            "- 'all': all in-sync replicas (most durable)"
+        ),
+    )
+
+
+__all__ = [
+    "KafkaChunkTarget",
+    "KafkaSaslAuth",
+]

--- a/docling_jobkit/connectors/kafka/models.py
+++ b/docling_jobkit/connectors/kafka/models.py
@@ -14,11 +14,6 @@ class KafkaSaslAuth(BaseModel):
 
 
 class KafkaChunkTarget(FieldMappings, ChunkFieldSlots):
-    """Kafka target for chunk-level streaming.
-
-    Each chunk is published as a separate message with JSON value.
-    """
-
     kind: Literal["kafka_chunks"] = "kafka_chunks"
 
     bootstrap_servers: list[str] = Field(

--- a/docling_jobkit/connectors/kafka/models.py
+++ b/docling_jobkit/connectors/kafka/models.py
@@ -1,11 +1,44 @@
-from typing import Literal, Optional
+from typing import Annotated, Any, Literal, Optional
 
-from pydantic import BaseModel, Field, SecretStr
+from pydantic import (
+    BaseModel,
+    BeforeValidator,
+    ConfigDict,
+    Field,
+    SecretStr,
+    model_validator,
+)
 
 from docling_jobkit.datamodel.target_field_slots import ChunkFieldSlots, FieldMappings
 
 
+def _acks_to_str(value: Any) -> Any:
+    """YAML parses ``acks: 1`` as an int, and pydantic v2 does not coerce
+    int -> str for a string ``Literal``.  Normalise so the unquoted form every
+    Kafka doc uses validates."""
+    if isinstance(value, int) and not isinstance(value, bool):
+        return str(value)
+    return value
+
+
+AcksLiteral = Annotated[Literal["0", "1", "all"], BeforeValidator(_acks_to_str)]
+
+SecurityProtocol = Literal["PLAINTEXT", "SSL", "SASL_PLAINTEXT", "SASL_SSL"]
+
+
 class KafkaSaslAuth(BaseModel):
+    """SASL credentials.
+
+    ``kind`` is the discriminator: it is the natural place to hang a future
+    mTLS or OAUTHBEARER variant without breaking existing configs.
+    """
+
+    # Unknown keys are rejected: a misspelled 'mechanism' or 'username' would
+    # otherwise be silently dropped and only surface as a connection failure
+    # minutes into a job.
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal["sasl"] = "sasl"
     # Confluent Cloud uses PLAIN - SCRAMs here for on-prem instances
     mechanism: Literal["PLAIN", "SCRAM-SHA-256", "SCRAM-SHA-512"] = "PLAIN"
     username: str
@@ -31,23 +64,133 @@ class KafkaChunkTarget(FieldMappings, ChunkFieldSlots):
         description="SASL authentication. Omit for plaintext (no auth).",
     )
 
+    security_protocol: Optional[SecurityProtocol] = Field(
+        default=None,
+        description=(
+            "Broker connection protocol. Defaults to 'SASL_SSL' when 'auth' is "
+            "set and 'PLAINTEXT' otherwise. Set explicitly for "
+            "'SASL_PLAINTEXT' (SCRAM inside a trusted network) or 'SSL' "
+            "(TLS without SASL)."
+        ),
+    )
+
+    verify_certs: bool = Field(
+        default=True,
+        description=(
+            "Verify the broker's TLS certificate. Only applies to the "
+            "SSL / SASL_SSL protocols. Disable for self-signed certs in "
+            "development only."
+        ),
+    )
+
     key_mode: Literal["doc_id", "chunk_id", "none"] = Field(
         default="doc_id",
         description=(
             "- 'doc_id': all chunks of a document land in one partition, ordered.\n"
             "- 'chunk_id': stable content hash, spread across partitions.\n"
-            "- 'none': null key, round-robin distribution."
+            "- 'none': null key, round-robin distribution.\n"
+            "Ordering under 'doc_id' relies on the idempotent producer, which "
+            "is only enabled when acks == 'all'.\n"
+            "WARNING: do not enable log compaction on the topic with "
+            "key_mode='doc_id' — the broker would keep only the last chunk of "
+            "each document and silently discard the rest."
         ),
     )
 
-    acks: Literal["0", "1", "all"] = Field(
+    acks: AcksLiteral = Field(
         default="all",
         description=(
             "- '0': no ack (fire-and-forget)\n"
             "- '1': leader ack only\n"
-            "- 'all': all in-sync replicas (most durable)"
+            "- 'all': all in-sync replicas (most durable)\n"
+            "The idempotent producer requires 'all'; with '0' or '1' it is "
+            "switched off and a retry can reorder messages within a partition."
         ),
     )
+
+    # Producer queue bounds.  produce() memcpy's into librdkafka's internal
+    # queues inside the worker process, so these are *native* client-side
+    # memory (invisible to tracemalloc) that stacks on top of the models and
+    # the DoclingDocument.  librdkafka's own defaults are 1 GiB / 100 000
+    # messages, which under a k8s memory limit surfaces as an OOMKill with no
+    # Python traceback.
+    queue_max_kbytes: int = Field(
+        default=65536,
+        gt=0,
+        description=(
+            "Producer queue size limit in KiB (librdkafka "
+            "'queue.buffering.max.kbytes'). Bounds native client-side memory; "
+            "librdkafka's own default is 1 GiB."
+        ),
+    )
+
+    queue_max_messages: int = Field(
+        default=10_000,
+        gt=0,
+        description=(
+            "Producer queue size limit in messages (librdkafka "
+            "'queue.buffering.max.messages'). librdkafka's own default is "
+            "100 000."
+        ),
+    )
+
+    compression_type: Literal["none", "gzip", "snappy", "lz4", "zstd"] = Field(
+        default="lz4",
+        description=(
+            "Producer-side compression. Close to free on chunk text and cuts "
+            "both queued bytes and broker traffic."
+        ),
+    )
+
+    queue_full_timeout_seconds: float = Field(
+        default=30.0,
+        ge=0.0,
+        description=(
+            "How long to keep retrying a single chunk while the producer queue "
+            "is full before failing the task with TargetWriteError."
+        ),
+    )
+
+    chunk_id_field: str = Field(
+        default="chunk_id",
+        description=(
+            "Field name carrying the deterministic chunk ID in the message "
+            "value. Kafka is append-only, so a re-run after a mid-document "
+            "failure appends a duplicate set of chunks; consumers dedupe on "
+            "this ID. It is also emitted as a message header."
+        ),
+    )
+
+    # Redeclared explicitly (both base classes declare it) so the default is
+    # readable as deliberate rather than an MRO coincidence.  Kafka/JSON carry
+    # uint64 fine; enable if your consumers deserialize into int64 (Kafka
+    # Connect, Jackson, Go) or JavaScript, which lose or reject
+    # DoclingDocument.origin.binary_hash (a uint64, always > 2^53 and > 2^63-1
+    # about half the time).
+    coerce_large_ints_to_str: bool = False
+
+    @model_validator(mode="after")
+    def _check_auth_matches_protocol(self) -> "KafkaChunkTarget":
+        protocol = self.security_protocol
+        if protocol is None:
+            return self
+        if protocol.startswith("SASL_") and self.auth is None:
+            raise ValueError(
+                f"security_protocol '{protocol}' requires an 'auth' block."
+            )
+        if not protocol.startswith("SASL_") and self.auth is not None:
+            raise ValueError(
+                f"security_protocol '{protocol}' does not use SASL, but an "
+                "'auth' block was provided."
+            )
+        return self
+
+    @property
+    def effective_security_protocol(self) -> SecurityProtocol:
+        """Resolved protocol: explicit when set, else derived from ``auth``."""
+        if self.security_protocol is not None:
+            return self.security_protocol
+        return "SASL_SSL" if self.auth is not None else "PLAINTEXT"
 
 
 __all__ = [

--- a/docling_jobkit/connectors/kafka/target_processor.py
+++ b/docling_jobkit/connectors/kafka/target_processor.py
@@ -134,8 +134,10 @@ class KafkaTargetProcessor(BaseDatabaseTargetProcessor[KafkaChunkTarget]):
         # else key_mode == "none", key stays None
 
         # Headers duplicate payload fields so consumers can route without
-        # deserialising the value.
-        headers: list[tuple[str, str]] = [
+        # deserialising the value.  The values are always str, but produce()
+        # takes an invariant list, so the element type has to stay as wide as
+        # its signature.
+        headers: list[tuple[str, str | bytes | None]] = [
             ("doc_id", chunk.filename),
             ("chunk_index", str(chunk.chunk_index)),
             ("chunk_id", chunk_id),

--- a/docling_jobkit/connectors/kafka/target_processor.py
+++ b/docling_jobkit/connectors/kafka/target_processor.py
@@ -41,15 +41,16 @@ class KafkaTargetProcessor(BaseDatabaseTargetProcessor[KafkaChunkTarget]):
 
         try:
             config = build_producer_config(self._target)
+            self._producer = Producer(config)
             _log.info(
-                "Initializing Kafka producer: brokers=%s topic=%s",
-                self._target.bootstrap_servers,
+                "kafka: connected to %s, topic=%s",
+                self._target.bootstrap_servers[0]
+                if len(self._target.bootstrap_servers) == 1
+                else f"{len(self._target.bootstrap_servers)} brokers",
                 self._target.topic,
             )
-            self._producer = Producer(config)
-            _log.info("Kafka producer initialized successfully")
         except Exception as exc:
-            _log.error("Failed to initialize Kafka producer", exc_info=True)
+            _log.error("kafka: connection failed", exc_info=True)
             raise TargetWriteError(
                 f"Could not connect to Kafka brokers {self._target.bootstrap_servers}."
             ) from exc

--- a/docling_jobkit/connectors/kafka/target_processor.py
+++ b/docling_jobkit/connectors/kafka/target_processor.py
@@ -25,6 +25,9 @@ class KafkaTargetProcessor(BaseDatabaseTargetProcessor[KafkaChunkTarget]):
         self._producer: "Optional[Producer]" = None
         self._current_document_hash: Optional[str] = None
         self._delivery_errors: list[Any] = []
+        # Broker/client errors from the error_cb (e.g. _UNKNOWN_TOPIC).
+        # These carry the real reason behind a _MSG_TIMED_OUT delivery failure.
+        self._broker_errors: list[Any] = []
 
     @classmethod
     def check_dependencies(cls) -> None:
@@ -41,19 +44,65 @@ class KafkaTargetProcessor(BaseDatabaseTargetProcessor[KafkaChunkTarget]):
 
         try:
             config = build_producer_config(self._target)
+            config["error_cb"] = self._on_error
             self._producer = Producer(config)
-            _log.info(
-                "kafka: connected to %s, topic=%s",
-                self._target.bootstrap_servers[0]
-                if len(self._target.bootstrap_servers) == 1
-                else f"{len(self._target.bootstrap_servers)} brokers",
-                self._target.topic,
-            )
         except Exception as exc:
             _log.error("kafka: connection failed", exc_info=True)
             raise TargetWriteError(
                 f"Could not connect to Kafka brokers {self._target.bootstrap_servers}."
             ) from exc
+
+        # Verify the topic exists before producing any messages.  librdkafka
+        # surfaces a missing topic only as _MSG_TIMED_OUT on each message
+        # (the real error goes to the internal log, not the delivery callback),
+        # making the root cause invisible.  An explicit metadata fetch here
+        # gives a clear error immediately at connect time.
+        self._verify_topic()
+        _log.info(
+            "kafka: connected to %s, topic=%s",
+            self._target.bootstrap_servers[0]
+            if len(self._target.bootstrap_servers) == 1
+            else f"{len(self._target.bootstrap_servers)} brokers",
+            self._target.topic,
+        )
+
+    def _verify_topic(self) -> None:
+        """Raise TargetWriteError if the configured topic does not exist."""
+        from confluent_kafka.admin import AdminClient
+
+        from docling_jobkit.connectors.kafka.helper import build_producer_config
+
+        config = build_producer_config(self._target)
+        # AdminClient shares the same config shape as Producer.
+        admin = AdminClient(config)
+        try:
+            # list_topics() fetches cluster metadata; timeout is generous
+            # but bounded so a network issue doesn't hang indefinitely.
+            meta = admin.list_topics(
+                topic=self._target.topic,
+                timeout=10.0,
+            )
+        except Exception as exc:
+            raise TargetWriteError(
+                f"Could not fetch Kafka metadata for topic "
+                f"'{self._target.topic}': {exc}"
+            ) from exc
+
+        topic_meta = meta.topics.get(self._target.topic)
+        if topic_meta is None or topic_meta.error is not None:
+            from confluent_kafka import KafkaError
+
+            err = topic_meta.error if topic_meta is not None else None
+            if err is not None and err.code() == KafkaError.UNKNOWN_TOPIC_OR_PART:
+                raise TargetWriteError(
+                    f"Topic '{self._target.topic}' does not exist on the broker. "
+                    f"Create the topic or set 'allow.auto.create.topics=true' on "
+                    f"the broker."
+                )
+            raise TargetWriteError(
+                f"Kafka topic '{self._target.topic}' is not available: {err}"
+            )
+        _log.debug("kafka: topic '%s' exists and is accessible", self._target.topic)
 
     def _finalize(self) -> None:
         """Tear the producer down.
@@ -84,6 +133,7 @@ class KafkaTargetProcessor(BaseDatabaseTargetProcessor[KafkaChunkTarget]):
                 self._delivery_errors[0],
             )
         self._delivery_errors.clear()
+        self._broker_errors.clear()
 
     # Streaming chunk protocol
 
@@ -101,6 +151,7 @@ class KafkaTargetProcessor(BaseDatabaseTargetProcessor[KafkaChunkTarget]):
         _log.info("kafka: begin_chunks for %s (hash=%s)", filename, document_hash)
         self._current_document_hash = document_hash
         self._delivery_errors.clear()
+        self._broker_errors.clear()
 
     def consume_chunk(self, chunk: "ChunkedDocumentResultItem") -> None:
         """Produce one chunk message to Kafka."""
@@ -207,38 +258,66 @@ class KafkaTargetProcessor(BaseDatabaseTargetProcessor[KafkaChunkTarget]):
             return
 
         _log.debug("kafka: flushing producer...")
-        # flush() polls internally and returns only once every outstanding
-        # message has been delivered *and* its callback served, so there is
-        # nothing left to poll for afterwards.
         remaining = self._producer.flush(10.0)
+
+        if remaining > 0:
+            # flush() timed out.  Do one extra poll to drain any callbacks
+            # that fired just as flush() gave up, then check for delivery errors.
+            self._producer.poll(0.5)
+
+        if self._delivery_errors:
+            from confluent_kafka import KafkaException
+
+            first_error = self._delivery_errors[0]
+            # If the error_cb captured broker-level detail (e.g. _SSL,
+            # _ALL_BROKERS_DOWN), surface that; otherwise fall back to the
+            # generic _MSG_TIMED_OUT from the delivery callback.
+            if self._broker_errors:
+                broker_err_str = " | ".join(str(e) for e in self._broker_errors)
+                hint = (
+                    f"Kafka delivery failed for topic '{self._target.topic}': "
+                    f"{broker_err_str}"
+                )
+            else:
+                hint = (
+                    f"Kafka message delivery failed for topic "
+                    f"'{self._target.topic}': {first_error}"
+                )
+            _log.error("kafka: %s", hint)
+            # KafkaError is a C type with no __traceback__; wrap it in a
+            # KafkaException before chaining so 'raise ... from' doesn't
+            # crash the traceback formatter.
+            raise TargetWriteError(hint) from KafkaException(first_error)
+
         if remaining > 0:
             _log.error("kafka: flush timeout, %d messages remain in queue", remaining)
             raise TargetWriteError(
-                f"Kafka producer flush timeout: {remaining} messages still in queue"
+                f"Kafka producer flush timeout: {remaining} messages still in queue "
+                f"for topic '{self._target.topic}'"
             )
-
-        # Check for delivery errors
-        if self._delivery_errors:
-            first_error = self._delivery_errors[0]
-            _log.error(
-                "kafka: delivery failed for topic %s: %s",
-                self._target.topic,
-                first_error,
-            )
-            raise TargetWriteError(
-                f"Kafka message delivery failed for topic {self._target.topic}"
-            ) from first_error
 
         _log.info("kafka: flush completed successfully")
 
         # Reset state
         self._current_document_hash = None
         self._delivery_errors.clear()
+        self._broker_errors.clear()
 
     def abort_chunks(self) -> None:
         """Discard in-flight state. Already-sent messages stay sent."""
         self._current_document_hash = None
         self._delivery_errors.clear()
+        self._broker_errors.clear()
+
+    def _on_error(self, err) -> None:
+        """Error callback for broker/client-level errors (error_cb).
+
+        These fire with the real reason code (e.g. _UNKNOWN_TOPIC) that
+        librdkafka wraps into the generic _MSG_TIMED_OUT delivery error.
+        Captured here so end_chunks() can surface actionable diagnostics.
+        """
+        _log.warning("kafka: broker/client error: %s", err)
+        self._broker_errors.append(err)
 
     def _on_delivery(self, err, msg) -> None:
         """Delivery callback for producer.produce().

--- a/docling_jobkit/connectors/kafka/target_processor.py
+++ b/docling_jobkit/connectors/kafka/target_processor.py
@@ -19,10 +19,6 @@ if TYPE_CHECKING:
 
 
 class KafkaTargetProcessor(BaseDatabaseTargetProcessor[KafkaChunkTarget]):
-    """Kafka target processor for chunk-level streaming.
-    Each chunk is published as a separate Kafka message.
-    """
-
     def __init__(self, target: KafkaChunkTarget) -> None:
         super().__init__(target)
         self._producer: "Optional[Producer]" = None

--- a/docling_jobkit/connectors/kafka/target_processor.py
+++ b/docling_jobkit/connectors/kafka/target_processor.py
@@ -1,0 +1,219 @@
+import hashlib
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Optional
+
+from docling_jobkit.connectors.database_target_processor import (
+    BaseDatabaseTargetProcessor,
+)
+from docling_jobkit.connectors.kafka.models import KafkaChunkTarget
+from docling_jobkit.public_errors import TargetWriteError
+
+_log = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from confluent_kafka import Producer
+
+    from docling_jobkit.datamodel.result import ChunkedDocumentResultItem
+
+
+class KafkaTargetProcessor(BaseDatabaseTargetProcessor[KafkaChunkTarget]):
+    """Kafka target processor for chunk-level streaming.
+    Each chunk is published as a separate Kafka message.
+    """
+
+    def __init__(self, target: KafkaChunkTarget) -> None:
+        super().__init__(target)
+        self._producer: "Optional[Producer]" = None
+        self._current_document_hash: Optional[str] = None
+        self._delivery_errors: list[Any] = []
+
+    @classmethod
+    def check_dependencies(cls) -> None:
+        import confluent_kafka  # noqa: F401
+
+    @classmethod
+    def get_config_types(cls):
+        return (KafkaChunkTarget,)
+
+    def _initialize(self) -> None:
+        from confluent_kafka import Producer
+
+        from docling_jobkit.connectors.kafka.helper import build_producer_config
+
+        try:
+            config = build_producer_config(self._target)
+            _log.info(
+                "Initializing Kafka producer: brokers=%s topic=%s",
+                self._target.bootstrap_servers,
+                self._target.topic,
+            )
+            self._producer = Producer(config)
+            _log.info("Kafka producer initialized successfully")
+        except Exception as exc:
+            _log.error("Failed to initialize Kafka producer", exc_info=True)
+            raise TargetWriteError(
+                f"Could not connect to Kafka brokers {self._target.bootstrap_servers}."
+            ) from exc
+
+    def _finalize(self) -> None:
+        if self._producer is not None:
+            self._producer.flush(10.0)
+            self._producer = None
+
+    # Streaming chunk protocol
+
+    def instance_requires_chunks(self) -> bool:
+        return True
+
+    def begin_chunks(
+        self,
+        filename: str,
+        temp_dir: Path,
+        chunk_target_key: Optional[str] = None,
+        document_hash: Optional[str] = None,
+    ) -> None:
+        """Capture document_hash for stable chunk IDs."""
+        _log.info("kafka: begin_chunks for %s (hash=%s)", filename, document_hash)
+        self._current_document_hash = document_hash
+        self._delivery_errors.clear()
+
+    def consume_chunk(self, chunk: "ChunkedDocumentResultItem") -> None:
+        """Produce one chunk message to Kafka."""
+        from docling_jobkit.convert.chunking import _chunk_row_payload
+
+        if self._producer is None:
+            raise RuntimeError("KafkaTargetProcessor is not initialized")
+
+        # Build the message value from the chunk
+        row = _chunk_row_payload(chunk, self._target)
+        value = json.dumps(row, ensure_ascii=False).encode("utf-8")
+
+        # Derive stable chunk ID
+        chunk_id = self._stable_chunk_id(
+            self._current_document_hash,
+            chunk.filename,
+            chunk.chunk_index,
+        )
+
+        # Determine message key based on key_mode
+        key: Optional[str] = None
+        if self._target.key_mode == "doc_id":
+            key = chunk.filename
+        elif self._target.key_mode == "chunk_id":
+            key = chunk_id
+        # else key_mode == "none", key stays None
+
+        # Build headers (list of tuples for confluent_kafka)
+        headers: list[tuple[str, str | bytes | None]] = [
+            ("doc_id", chunk.filename),
+            ("chunk_index", str(chunk.chunk_index)),
+            ("chunk_id", chunk_id),
+        ]
+
+        _log.debug(
+            "kafka: producing chunk %d for %s (key=%s, value_len=%d)",
+            chunk.chunk_index,
+            chunk.filename,
+            key,
+            len(value),
+        )
+
+        # Produce the message with retry on BufferError
+        for attempt in range(2):
+            try:
+                self._producer.produce(
+                    topic=self._target.topic,
+                    key=key.encode("utf-8") if key else None,
+                    value=value,
+                    headers=headers,
+                    on_delivery=self._on_delivery,
+                )
+                # Process delivery callbacks without blocking
+                self._producer.poll(0)
+                break
+            except BufferError:
+                if attempt == 0:
+                    _log.warning("kafka: producer queue full, waiting...")
+                    self._producer.poll(1.0)
+                else:
+                    raise TargetWriteError(
+                        f"Kafka producer queue full after retry for topic {self._target.topic}"
+                    )
+
+    def end_chunks(self) -> None:
+        """Flush producer and check for delivery errors."""
+        if self._producer is None:
+            return
+
+        _log.debug("kafka: flushing producer...")
+        remaining = self._producer.flush(10.0)
+        if remaining > 0:
+            _log.error("kafka: flush timeout, %d messages remain in queue", remaining)
+            raise TargetWriteError(
+                f"Kafka producer flush timeout: {remaining} messages still in queue"
+            )
+
+        # Poll to process any pending delivery callbacks (flush() only blocks
+        # on transmission, not on broker ack — callbacks may still be pending)
+        self._producer.poll(1.0)
+
+        # Check for delivery errors
+        if self._delivery_errors:
+            first_error = self._delivery_errors[0]
+            _log.error(
+                "kafka: delivery failed for topic %s: %s",
+                self._target.topic,
+                first_error,
+            )
+            raise TargetWriteError(
+                f"Kafka message delivery failed for topic {self._target.topic}"
+            ) from first_error
+
+        _log.info("kafka: flush completed successfully")
+
+        # Reset state
+        self._current_document_hash = None
+        self._delivery_errors.clear()
+
+    def abort_chunks(self) -> None:
+        """Discard in-flight state. Already-sent messages stay sent."""
+        self._current_document_hash = None
+        self._delivery_errors.clear()
+
+    def _on_delivery(self, err, msg) -> None:
+        """Delivery callback for producer.produce().
+
+        Captures errors in self._delivery_errors so end_chunks() can raise them.
+        """
+        if err is not None:
+            _log.error("kafka: delivery error: %s", err)
+            self._delivery_errors.append(err)
+        else:
+            _log.debug(
+                "kafka: delivery success: topic=%s partition=%d offset=%d",
+                msg.topic(),
+                msg.partition(),
+                msg.offset(),
+            )
+
+    @staticmethod
+    def _stable_chunk_id(
+        binary_hash: Optional[str],
+        filename: str,
+        chunk_index: int,
+    ) -> str:
+        """Derive a deterministic, content-addressed ID for a single chunk."""
+        key = f"{binary_hash or filename}:{filename}:{chunk_index}"
+        return hashlib.sha256(key.encode(), usedforsecurity=False).hexdigest()
+
+    # Doc protocol (unused)
+
+    def upsert_row(self, row: dict[str, Any]) -> None:
+        raise NotImplementedError(
+            "kafka_chunks target does not support document-level upsert_row(). "
+        )
+
+
+__all__ = ["KafkaTargetProcessor"]

--- a/docling_jobkit/connectors/kafka/target_processor.py
+++ b/docling_jobkit/connectors/kafka/target_processor.py
@@ -1,6 +1,7 @@
 import hashlib
 import json
 import logging
+import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -54,9 +55,34 @@ class KafkaTargetProcessor(BaseDatabaseTargetProcessor[KafkaChunkTarget]):
             ) from exc
 
     def _finalize(self) -> None:
-        if self._producer is not None:
-            self._producer.flush(10.0)
-            self._producer = None
+        """Tear the producer down.
+
+        ``end_chunks()`` already flushed and raised for the documents it saw;
+        anything left here is a leftover from a path that skipped it. Report it
+        loudly rather than dropping it silently — this runs from ``__exit__``,
+        where raising would mask the exception that caused the teardown.
+        """
+        if self._producer is None:
+            return
+
+        producer, self._producer = self._producer, None
+        remaining = producer.flush(10.0)
+        if remaining:
+            _log.error(
+                "kafka: %d message(s) still queued for topic %s at teardown; "
+                "they were dropped undelivered",
+                remaining,
+                self._target.topic,
+            )
+        if self._delivery_errors:
+            _log.error(
+                "kafka: %d unreported delivery error(s) for topic %s at "
+                "teardown; first: %s",
+                len(self._delivery_errors),
+                self._target.topic,
+                self._delivery_errors[0],
+            )
+        self._delivery_errors.clear()
 
     # Streaming chunk protocol
 
@@ -77,14 +103,12 @@ class KafkaTargetProcessor(BaseDatabaseTargetProcessor[KafkaChunkTarget]):
 
     def consume_chunk(self, chunk: "ChunkedDocumentResultItem") -> None:
         """Produce one chunk message to Kafka."""
+        from confluent_kafka import KafkaException
+
         from docling_jobkit.convert.chunking import _chunk_row_payload
 
         if self._producer is None:
             raise RuntimeError("KafkaTargetProcessor is not initialized")
-
-        # Build the message value from the chunk
-        row = _chunk_row_payload(chunk, self._target)
-        value = json.dumps(row, ensure_ascii=False).encode("utf-8")
 
         # Derive stable chunk ID
         chunk_id = self._stable_chunk_id(
@@ -92,6 +116,14 @@ class KafkaTargetProcessor(BaseDatabaseTargetProcessor[KafkaChunkTarget]):
             chunk.filename,
             chunk.chunk_index,
         )
+
+        # Build the message value from the chunk.  Kafka is append-only, so a
+        # re-run after a mid-document failure appends a duplicate set of chunks
+        # instead of overwriting (as OpenSearch does): the ID has to travel in
+        # the payload so a consumer reading it alone can dedupe.
+        row = _chunk_row_payload(chunk, self._target)
+        row[self._target.chunk_id_field] = chunk_id
+        value = json.dumps(row, ensure_ascii=False).encode("utf-8")
 
         # Determine message key based on key_mode
         key: Optional[str] = None
@@ -101,8 +133,9 @@ class KafkaTargetProcessor(BaseDatabaseTargetProcessor[KafkaChunkTarget]):
             key = chunk_id
         # else key_mode == "none", key stays None
 
-        # Build headers (list of tuples for confluent_kafka)
-        headers: list[tuple[str, str | bytes | None]] = [
+        # Headers duplicate payload fields so consumers can route without
+        # deserialising the value.
+        headers: list[tuple[str, str]] = [
             ("doc_id", chunk.filename),
             ("chunk_index", str(chunk.chunk_index)),
             ("chunk_id", chunk_id),
@@ -116,8 +149,10 @@ class KafkaTargetProcessor(BaseDatabaseTargetProcessor[KafkaChunkTarget]):
             len(value),
         )
 
-        # Produce the message with retry on BufferError
-        for attempt in range(2):
+        # Produce, retrying until the queue drains or the deadline passes.
+        deadline = time.monotonic() + self._target.queue_full_timeout_seconds
+        warned = False
+        while True:
             try:
                 self._producer.produce(
                     topic=self._target.topic,
@@ -128,15 +163,40 @@ class KafkaTargetProcessor(BaseDatabaseTargetProcessor[KafkaChunkTarget]):
                 )
                 # Process delivery callbacks without blocking
                 self._producer.poll(0)
-                break
-            except BufferError:
-                if attempt == 0:
-                    _log.warning("kafka: producer queue full, waiting...")
-                    self._producer.poll(1.0)
-                else:
+                return
+            except BufferError as exc:
+                # Local queue full: bounded by queue_max_kbytes /
+                # queue_max_messages, so this is backpressure, not a failure.
+                time_left = deadline - time.monotonic()
+                if time_left <= 0:
                     raise TargetWriteError(
-                        f"Kafka producer queue full after retry for topic {self._target.topic}"
+                        f"Kafka producer queue still full after "
+                        f"{self._target.queue_full_timeout_seconds:g}s "
+                        f"for topic {self._target.topic}"
+                    ) from exc
+                if not warned:
+                    _log.warning(
+                        "kafka: producer queue full, waiting up to %.1fs...",
+                        time_left,
                     )
+                    warned = True
+                # poll() serves delivery callbacks, which is what frees queue
+                # slots.  The 50 ms floor keeps a near-expired deadline from
+                # spinning.
+                self._producer.poll(max(0.05, min(0.5, time_left)))
+            except KafkaException as exc:
+                # librdkafka rejects an oversized message synchronously from
+                # produce() (MSG_SIZE_TOO_LARGE), and raw KafkaExceptions are
+                # not recognised by classify_public_task_failure(); wrapping
+                # them in TargetWriteError gives the same TARGET_UNAVAILABLE
+                # classification the other targets produce.
+                raise TargetWriteError(
+                    f"Kafka rejected a {len(value)}-byte message for chunk "
+                    f"{chunk.chunk_index} of {chunk.filename} on topic "
+                    f"{self._target.topic}. If the chunk exceeds the message "
+                    f"size limit, raise 'message.max.bytes' on the broker and "
+                    f"'max.message.bytes' on the topic, or chunk smaller."
+                ) from exc
 
     def end_chunks(self) -> None:
         """Flush producer and check for delivery errors."""
@@ -144,16 +204,15 @@ class KafkaTargetProcessor(BaseDatabaseTargetProcessor[KafkaChunkTarget]):
             return
 
         _log.debug("kafka: flushing producer...")
+        # flush() polls internally and returns only once every outstanding
+        # message has been delivered *and* its callback served, so there is
+        # nothing left to poll for afterwards.
         remaining = self._producer.flush(10.0)
         if remaining > 0:
             _log.error("kafka: flush timeout, %d messages remain in queue", remaining)
             raise TargetWriteError(
                 f"Kafka producer flush timeout: {remaining} messages still in queue"
             )
-
-        # Poll to process any pending delivery callbacks (flush() only blocks
-        # on transmission, not on broker ack — callbacks may still be pending)
-        self._producer.poll(1.0)
 
         # Check for delivery errors
         if self._delivery_errors:

--- a/docling_jobkit/connectors/plugins/defaults.py
+++ b/docling_jobkit/connectors/plugins/defaults.py
@@ -88,7 +88,7 @@ def target_connectors():
         HttpPutTargetProcessor,
     )
     from docling_jobkit.connectors.kafka.target_processor import (
-        KafkaChunkTargetProcessor,
+        KafkaTargetProcessor,
     )
     from docling_jobkit.connectors.local_path.target_processor import (
         LocalPathTargetProcessor,
@@ -117,7 +117,7 @@ def target_connectors():
         OpenSearchTargetProcessor,
         AstraDBTargetProcessor,
         SharePointTargetProcessor,
-        KafkaChunkTargetProcessor,
+        KafkaTargetProcessor,
     ):
         _register_if_available(connectors, cls)
 

--- a/docling_jobkit/connectors/plugins/defaults.py
+++ b/docling_jobkit/connectors/plugins/defaults.py
@@ -87,6 +87,9 @@ def target_connectors():
     from docling_jobkit.connectors.http.target_processor import (
         HttpPutTargetProcessor,
     )
+    from docling_jobkit.connectors.kafka.target_processor import (
+        KafkaChunkTargetProcessor,
+    )
     from docling_jobkit.connectors.local_path.target_processor import (
         LocalPathTargetProcessor,
     )
@@ -114,6 +117,7 @@ def target_connectors():
         OpenSearchTargetProcessor,
         AstraDBTargetProcessor,
         SharePointTargetProcessor,
+        KafkaChunkTargetProcessor,
     ):
         _register_if_available(connectors, cls)
 

--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -187,6 +187,32 @@ disallowed target kind fails fast at `enqueue` with `TargetNotAllowedError`.
 deployment can, for example, forbid `local_path` targets that only make sense on
 a single machine.
 
+## Optional dependencies
+
+A connector whose SDK is an optional extra registers itself only when that SDK
+imports (`_register_if_available` in `connectors/plugins/defaults.py`); otherwise
+it is skipped with an INFO log and its `kind` is simply unknown. The database and
+streaming targets are all in this group:
+
+| `kind` | extra | notes |
+|---|---|---|
+| `opensearch_doc`, `opensearch_chunks` | `opensearch` | one indexed document per document / per chunk |
+| `astradb_chunks` | `astradb` | |
+| `kafka_chunks` | `kafka` | one Kafka message per chunk |
+
+(The cloud-storage connectors — `azure`, `gdrive`, `gcloudstorage`, `sharepoint`
+— work the same way.)
+
+**Install the extra on every process that enqueues *and* every process that
+dequeues.** `Task` targets validate through a discriminated union built from the
+*locally registered* connectors, so a worker without the extra pops the task off
+the queue and then fails to validate it (Ray's `dequeue_task` in
+`orchestrators/ray/redis_helper.py` does `lpop` before `validate_task_json`).
+Watch for this when the API pod and the worker image differ: `confluent-kafka`
+is a compiled wheel with manylinux, macOS and Windows builds but **no musllinux
+build**, so an Alpine-based worker cannot install what a Debian-based API pod
+can.
+
 ## Memory note
 
 Documents are fetched one at a time as the converter pulls them (see
@@ -195,3 +221,14 @@ are uploaded (see `export_documents_to_target`). Keep your source connector's
 `fetch_converter_source_by_ref` streaming a single document per call rather than
 materializing whole batches, so per-worker memory stays flat regardless of batch
 size.
+
+A target's own client can break that contract with buffers Python never sees.
+The Kafka producer is the case in point: `produce()` memcpy's each message into
+librdkafka's internal queues inside the worker process and returns before the
+broker has seen anything, so the queue is *native* memory — invisible to
+`tracemalloc` — stacked on top of the models and the `DoclingDocument`, and an
+overrun surfaces as an OOMKill with no Python traceback. librdkafka's own
+defaults allow 1 GiB / 100 000 messages; `kafka_chunks` therefore ships bounded
+defaults (`queue_max_kbytes: 65536`, `queue_max_messages: 10000`) and flushes at
+the end of every document. If your connector wraps a client that buffers, bound
+it explicitly and expose the bound as a config field.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,9 @@ opensearch = [
 astradb = [
     "astrapy>=1.0.0,<2",
 ]
+kafka = [
+    "confluent-kafka>=2.5.0,<3",
+]
 sharepoint = [
     # v3.0.0 imports `Self` from `typing` (stdlib), which only exists on Python >=3.11.
     # Pin <3.0.0 until upstream fixes the backport to use typing_extensions.
@@ -238,6 +241,7 @@ module = [
     "ray.*",
     "codeflare_sdk.*",
     "opensearchpy.*",
+    "confluent_kafka.*",
 ]
 ignore_missing_imports = true
 

--- a/tests/test_connector_factory.py
+++ b/tests/test_connector_factory.py
@@ -63,6 +63,7 @@ def test_builtin_target_connectors_registered():
         "local_path",
         "put",
         "google_drive",
+        "kafka_chunks",
         "presigned_url",
         "opensearch_doc",
         "opensearch_chunks",

--- a/tests/test_kafka_target_processor.py
+++ b/tests/test_kafka_target_processor.py
@@ -1,0 +1,249 @@
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from docling_jobkit.connectors.kafka.models import KafkaChunkTarget
+from docling_jobkit.connectors.kafka.target_processor import KafkaTargetProcessor
+from docling_jobkit.datamodel.result import ChunkedDocumentResultItem
+from docling_jobkit.public_errors import TargetWriteError
+
+
+@pytest.fixture
+def kafka_target():
+    return KafkaChunkTarget(
+        bootstrap_servers=["localhost:9092"],
+        topic="test.chunks",
+        key_mode="doc_id",
+        acks="all",
+    )
+
+
+@pytest.fixture
+def mock_producer(monkeypatch):
+    """Mock confluent_kafka.Producer."""
+    mock_producer_instance = Mock()
+    mock_producer_instance.produce = Mock()
+    mock_producer_instance.poll = Mock()
+    mock_producer_instance.flush = Mock(return_value=0)
+
+    mock_producer_cls = Mock(return_value=mock_producer_instance)
+
+    import sys
+    from unittest.mock import MagicMock
+
+    # Mock the confluent_kafka module
+    mock_confluent_kafka = MagicMock()
+    mock_confluent_kafka.Producer = mock_producer_cls
+    sys.modules["confluent_kafka"] = mock_confluent_kafka
+
+    yield {
+        "producer_cls": mock_producer_cls,
+        "producer": mock_producer_instance,
+    }
+
+
+def test_check_dependencies_present():
+    KafkaTargetProcessor.check_dependencies()
+
+
+def test_get_config_types():
+    config_types = KafkaTargetProcessor.get_config_types()
+    assert len(config_types) == 1
+    assert config_types[0] is KafkaChunkTarget
+
+
+def test_initialization(kafka_target, mock_producer):
+    processor = KafkaTargetProcessor(kafka_target)
+
+    with processor:
+        # Producer should be initialized
+        mock_producer["producer_cls"].assert_called_once()
+        config = mock_producer["producer_cls"].call_args[0][0]
+        assert config["bootstrap.servers"] == "localhost:9092"
+        assert config["acks"] == "all"
+
+
+def test_instance_requires_chunks(kafka_target):
+    processor = KafkaTargetProcessor(kafka_target)
+    assert processor.instance_requires_chunks() is True
+
+
+def test_consume_chunk_doc_id_key(kafka_target, mock_producer):
+    processor = KafkaTargetProcessor(kafka_target)
+    chunk = ChunkedDocumentResultItem(
+        filename="test.pdf",
+        chunk_index=0,
+        text="test chunk text",
+        doc_items=["#/texts/0"],
+        metadata={},
+    )
+
+    with processor:
+        processor.begin_chunks(
+            filename="test.pdf",
+            temp_dir=Path("/tmp"),
+            document_hash="abc123",
+        )
+        processor.consume_chunk(chunk)
+
+        # Check produce was called with doc_id as key
+        mock_producer["producer"].produce.assert_called_once()
+        call_kwargs = mock_producer["producer"].produce.call_args[1]
+        assert call_kwargs["topic"] == "test.chunks"
+        assert call_kwargs["key"] == b"test.pdf"
+        assert b"test chunk text" in call_kwargs["value"]
+
+
+def test_consume_chunk_chunk_id_key(mock_producer):
+    target = KafkaChunkTarget(
+        bootstrap_servers=["localhost:9092"],
+        topic="test.chunks",
+        key_mode="chunk_id",
+    )
+    processor = KafkaTargetProcessor(target)
+    chunk = ChunkedDocumentResultItem(
+        filename="test.pdf",
+        chunk_index=0,
+        text="test chunk text",
+        doc_items=["#/texts/0"],
+        metadata={},
+    )
+
+    with processor:
+        processor.begin_chunks(
+            filename="test.pdf",
+            temp_dir=Path("/tmp"),
+            document_hash="abc123",
+        )
+        processor.consume_chunk(chunk)
+
+        # Check produce was called with chunk_id as key (SHA-256 hash)
+        call_kwargs = mock_producer["producer"].produce.call_args[1]
+        key = call_kwargs["key"].decode("utf-8")
+        assert len(key) == 64  # SHA-256 hex digest length
+
+
+def test_consume_chunk_no_key(mock_producer):
+    target = KafkaChunkTarget(
+        bootstrap_servers=["localhost:9092"],
+        topic="test.chunks",
+        key_mode="none",
+    )
+    processor = KafkaTargetProcessor(target)
+    chunk = ChunkedDocumentResultItem(
+        filename="test.pdf",
+        chunk_index=0,
+        text="test chunk text",
+        doc_items=["#/texts/0"],
+        metadata={},
+    )
+
+    with processor:
+        processor.begin_chunks(
+            filename="test.pdf",
+            temp_dir=Path("/tmp"),
+            document_hash="abc123",
+        )
+        processor.consume_chunk(chunk)
+
+        # Check produce was called with no key
+        call_kwargs = mock_producer["producer"].produce.call_args[1]
+        assert call_kwargs["key"] is None
+
+
+def test_end_chunks_flush_timeout(kafka_target, mock_producer):
+    # Mock flush to return non-zero (timeout)
+    mock_producer["producer"].flush.return_value = 5
+
+    processor = KafkaTargetProcessor(kafka_target)
+    chunk = ChunkedDocumentResultItem(
+        filename="test.pdf",
+        chunk_index=0,
+        text="test chunk text",
+        doc_items=["#/texts/0"],
+        metadata={},
+    )
+
+    with pytest.raises(TargetWriteError, match="flush timeout"):
+        with processor:
+            processor.begin_chunks(
+                filename="test.pdf",
+                temp_dir=Path("/tmp"),
+                document_hash="abc123",
+            )
+            processor.consume_chunk(chunk)
+            processor.end_chunks()
+
+
+def test_end_chunks_delivery_error(kafka_target, mock_producer):
+    processor = KafkaTargetProcessor(kafka_target)
+    chunk = ChunkedDocumentResultItem(
+        filename="test.pdf",
+        chunk_index=0,
+        text="test chunk text",
+        doc_items=["#/texts/0"],
+        metadata={},
+    )
+
+    with pytest.raises(TargetWriteError, match="delivery failed"):
+        with processor:
+            processor.begin_chunks(
+                filename="test.pdf",
+                temp_dir=Path("/tmp"),
+                document_hash="abc123",
+            )
+            processor.consume_chunk(chunk)
+
+            # Simulate delivery error
+            processor._delivery_errors.append(Exception("broker down"))
+
+            processor.end_chunks()
+
+
+def test_buffer_error_retry(kafka_target, mock_producer):
+    # First produce raises BufferError, second succeeds
+    mock_producer["producer"].produce.side_effect = [BufferError(), None]
+
+    processor = KafkaTargetProcessor(kafka_target)
+    chunk = ChunkedDocumentResultItem(
+        filename="test.pdf",
+        chunk_index=0,
+        text="test chunk text",
+        doc_items=["#/texts/0"],
+        metadata={},
+    )
+
+    with processor:
+        processor.begin_chunks(
+            filename="test.pdf",
+            temp_dir=Path("/tmp"),
+            document_hash="abc123",
+        )
+        processor.consume_chunk(chunk)
+
+        # Should have called produce twice (initial + retry)
+        assert mock_producer["producer"].produce.call_count == 2
+
+
+def test_buffer_error_exhausted(kafka_target, mock_producer):
+    # Both attempts raise BufferError
+    mock_producer["producer"].produce.side_effect = BufferError()
+
+    processor = KafkaTargetProcessor(kafka_target)
+    chunk = ChunkedDocumentResultItem(
+        filename="test.pdf",
+        chunk_index=0,
+        text="test chunk text",
+        doc_items=["#/texts/0"],
+        metadata={},
+    )
+
+    with pytest.raises(TargetWriteError, match="queue full after retry"):
+        with processor:
+            processor.begin_chunks(
+                filename="test.pdf",
+                temp_dir=Path("/tmp"),
+                document_hash="abc123",
+            )
+            processor.consume_chunk(chunk)

--- a/tests/test_kafka_target_processor.py
+++ b/tests/test_kafka_target_processor.py
@@ -1,12 +1,20 @@
+import sys
+import types
 from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
+from pydantic import ValidationError
 
-from docling_jobkit.connectors.kafka.models import KafkaChunkTarget
+from docling_jobkit.connectors.kafka.helper import build_producer_config
+from docling_jobkit.connectors.kafka.models import KafkaChunkTarget, KafkaSaslAuth
 from docling_jobkit.connectors.kafka.target_processor import KafkaTargetProcessor
 from docling_jobkit.datamodel.result import ChunkedDocumentResultItem
 from docling_jobkit.public_errors import TargetWriteError
+
+
+class FakeKafkaException(Exception):
+    """Stand-in for confluent_kafka.KafkaException."""
 
 
 @pytest.fixture
@@ -20,8 +28,24 @@ def kafka_target():
 
 
 @pytest.fixture
+def sample_chunk():
+    return ChunkedDocumentResultItem(
+        filename="test.pdf",
+        chunk_index=0,
+        text="test chunk text",
+        doc_items=["#/texts/0"],
+        metadata={},
+    )
+
+
+@pytest.fixture
 def mock_producer(monkeypatch):
-    """Mock confluent_kafka.Producer."""
+    """Install a fake ``confluent_kafka`` module for the duration of one test.
+
+    ``monkeypatch.setitem`` restores whatever was in ``sys.modules`` before —
+    including nothing at all on a checkout without the ``kafka`` extra — so the
+    fake never leaks into later tests.
+    """
     mock_producer_instance = Mock()
     mock_producer_instance.produce = Mock()
     mock_producer_instance.poll = Mock()
@@ -29,13 +53,10 @@ def mock_producer(monkeypatch):
 
     mock_producer_cls = Mock(return_value=mock_producer_instance)
 
-    import sys
-    from unittest.mock import MagicMock
-
-    # Mock the confluent_kafka module
-    mock_confluent_kafka = MagicMock()
-    mock_confluent_kafka.Producer = mock_producer_cls
-    sys.modules["confluent_kafka"] = mock_confluent_kafka
+    fake_confluent_kafka = types.ModuleType("confluent_kafka")
+    fake_confluent_kafka.Producer = mock_producer_cls  # type: ignore[attr-defined]
+    fake_confluent_kafka.KafkaException = FakeKafkaException  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "confluent_kafka", fake_confluent_kafka)
 
     yield {
         "producer_cls": mock_producer_cls,
@@ -44,6 +65,7 @@ def mock_producer(monkeypatch):
 
 
 def test_check_dependencies_present():
+    pytest.importorskip("confluent_kafka", reason="requires the 'kafka' extra")
     KafkaTargetProcessor.check_dependencies()
 
 
@@ -69,15 +91,113 @@ def test_instance_requires_chunks(kafka_target):
     assert processor.instance_requires_chunks() is True
 
 
-def test_consume_chunk_doc_id_key(kafka_target, mock_producer):
-    processor = KafkaTargetProcessor(kafka_target)
-    chunk = ChunkedDocumentResultItem(
-        filename="test.pdf",
-        chunk_index=0,
-        text="test chunk text",
-        doc_items=["#/texts/0"],
-        metadata={},
+# Producer configuration
+
+
+def test_producer_config_bounds_the_queue(kafka_target):
+    config = build_producer_config(kafka_target)
+
+    # librdkafka's own defaults are 1 GiB / 100 000 messages of native,
+    # client-side memory; these must be bounded well below that.
+    assert config["queue.buffering.max.kbytes"] == 65536
+    assert config["queue.buffering.max.messages"] == 10_000
+    assert config["compression.type"] == "lz4"
+    assert config["client.id"] == "docling-jobkit"
+    assert config["security.protocol"] == "PLAINTEXT"
+    # key_mode='doc_id' only orders chunks if the producer is idempotent.
+    assert config["enable.idempotence"] is True
+
+
+def test_producer_config_honours_queue_overrides():
+    target = KafkaChunkTarget(
+        bootstrap_servers=["localhost:9092"],
+        topic="test.chunks",
+        queue_max_kbytes=1024,
+        queue_max_messages=50,
+        compression_type="zstd",
     )
+    config = build_producer_config(target)
+
+    assert config["queue.buffering.max.kbytes"] == 1024
+    assert config["queue.buffering.max.messages"] == 50
+    assert config["compression.type"] == "zstd"
+
+
+@pytest.mark.parametrize("acks", ["0", "1"])
+def test_producer_config_drops_idempotence_for_weak_acks(acks):
+    # librdkafka refuses enable.idempotence together with acks != 'all'.
+    target = KafkaChunkTarget(
+        bootstrap_servers=["localhost:9092"],
+        topic="test.chunks",
+        acks=acks,
+    )
+    config = build_producer_config(target)
+
+    assert "enable.idempotence" not in config
+
+
+@pytest.mark.parametrize(("raw", "expected"), [(1, "1"), (0, "0"), ("all", "all")])
+def test_acks_accepts_yaml_integers(raw, expected):
+    # YAML parses `acks: 1` as an int; pydantic does not coerce it to a string
+    # Literal on its own.
+    target = KafkaChunkTarget(
+        bootstrap_servers=["localhost:9092"],
+        topic="test.chunks",
+        acks=raw,
+    )
+    assert target.acks == expected
+
+
+def test_sasl_defaults_to_sasl_ssl():
+    target = KafkaChunkTarget(
+        bootstrap_servers=["localhost:9092"],
+        topic="test.chunks",
+        auth=KafkaSaslAuth(username="u", password="p"),
+    )
+    config = build_producer_config(target)
+
+    assert config["security.protocol"] == "SASL_SSL"
+    assert config["sasl.username"] == "u"
+    assert config["sasl.password"] == "p"
+    assert config["enable.ssl.certificate.verification"] is True
+
+
+def test_sasl_plaintext_is_expressible():
+    target = KafkaChunkTarget(
+        bootstrap_servers=["localhost:9092"],
+        topic="test.chunks",
+        security_protocol="SASL_PLAINTEXT",
+        auth=KafkaSaslAuth(mechanism="SCRAM-SHA-512", username="u", password="p"),
+    )
+    config = build_producer_config(target)
+
+    assert config["security.protocol"] == "SASL_PLAINTEXT"
+    assert config["sasl.mechanism"] == "SCRAM-SHA-512"
+    # Not an SSL protocol, so no TLS verification knob is emitted.
+    assert "enable.ssl.certificate.verification" not in config
+
+
+def test_sasl_protocol_without_auth_is_rejected():
+    with pytest.raises(ValidationError, match="requires an 'auth' block"):
+        KafkaChunkTarget(
+            bootstrap_servers=["localhost:9092"],
+            topic="test.chunks",
+            security_protocol="SASL_SSL",
+        )
+
+
+def test_auth_rejects_unknown_keys():
+    # A misspelled key must fail at config time, not as a connection timeout
+    # minutes into a job.
+    with pytest.raises(ValidationError):
+        KafkaSaslAuth(username="u", password="p", mechanisms="PLAIN")
+
+
+# Message production
+
+
+def test_consume_chunk_doc_id_key(kafka_target, mock_producer, sample_chunk):
+    processor = KafkaTargetProcessor(kafka_target)
 
     with processor:
         processor.begin_chunks(
@@ -85,7 +205,7 @@ def test_consume_chunk_doc_id_key(kafka_target, mock_producer):
             temp_dir=Path("/tmp"),
             document_hash="abc123",
         )
-        processor.consume_chunk(chunk)
+        processor.consume_chunk(sample_chunk)
 
         # Check produce was called with doc_id as key
         mock_producer["producer"].produce.assert_called_once()
@@ -95,20 +215,13 @@ def test_consume_chunk_doc_id_key(kafka_target, mock_producer):
         assert b"test chunk text" in call_kwargs["value"]
 
 
-def test_consume_chunk_chunk_id_key(mock_producer):
+def test_consume_chunk_chunk_id_key(mock_producer, sample_chunk):
     target = KafkaChunkTarget(
         bootstrap_servers=["localhost:9092"],
         topic="test.chunks",
         key_mode="chunk_id",
     )
     processor = KafkaTargetProcessor(target)
-    chunk = ChunkedDocumentResultItem(
-        filename="test.pdf",
-        chunk_index=0,
-        text="test chunk text",
-        doc_items=["#/texts/0"],
-        metadata={},
-    )
 
     with processor:
         processor.begin_chunks(
@@ -116,7 +229,7 @@ def test_consume_chunk_chunk_id_key(mock_producer):
             temp_dir=Path("/tmp"),
             document_hash="abc123",
         )
-        processor.consume_chunk(chunk)
+        processor.consume_chunk(sample_chunk)
 
         # Check produce was called with chunk_id as key (SHA-256 hash)
         call_kwargs = mock_producer["producer"].produce.call_args[1]
@@ -124,20 +237,13 @@ def test_consume_chunk_chunk_id_key(mock_producer):
         assert len(key) == 64  # SHA-256 hex digest length
 
 
-def test_consume_chunk_no_key(mock_producer):
+def test_consume_chunk_no_key(mock_producer, sample_chunk):
     target = KafkaChunkTarget(
         bootstrap_servers=["localhost:9092"],
         topic="test.chunks",
         key_mode="none",
     )
     processor = KafkaTargetProcessor(target)
-    chunk = ChunkedDocumentResultItem(
-        filename="test.pdf",
-        chunk_index=0,
-        text="test chunk text",
-        doc_items=["#/texts/0"],
-        metadata={},
-    )
 
     with processor:
         processor.begin_chunks(
@@ -145,25 +251,86 @@ def test_consume_chunk_no_key(mock_producer):
             temp_dir=Path("/tmp"),
             document_hash="abc123",
         )
-        processor.consume_chunk(chunk)
+        processor.consume_chunk(sample_chunk)
 
         # Check produce was called with no key
         call_kwargs = mock_producer["producer"].produce.call_args[1]
         assert call_kwargs["key"] is None
 
 
-def test_end_chunks_flush_timeout(kafka_target, mock_producer):
+def test_chunk_id_is_in_the_message_value(kafka_target, mock_producer, sample_chunk):
+    import json
+
+    processor = KafkaTargetProcessor(kafka_target)
+
+    with processor:
+        processor.begin_chunks(
+            filename="test.pdf",
+            temp_dir=Path("/tmp"),
+            document_hash="abc123",
+        )
+        processor.consume_chunk(sample_chunk)
+
+        call_kwargs = mock_producer["producer"].produce.call_args[1]
+        payload = json.loads(call_kwargs["value"].decode("utf-8"))
+        expected_id = KafkaTargetProcessor._stable_chunk_id("abc123", "test.pdf", 0)
+
+        # Kafka is append-only: consumers can only dedupe if the ID is in the
+        # body, not just the header.
+        assert payload["chunk_id"] == expected_id
+        headers = dict(call_kwargs["headers"])
+        assert headers["chunk_id"] == expected_id
+
+
+def test_consume_chunk_does_not_block_on_poll(
+    kafka_target, mock_producer, sample_chunk
+):
+    processor = KafkaTargetProcessor(kafka_target)
+
+    with processor:
+        processor.begin_chunks(
+            filename="test.pdf",
+            temp_dir=Path("/tmp"),
+            document_hash="abc123",
+        )
+        processor.consume_chunk(sample_chunk)
+        processor.end_chunks()
+
+    # flush() serves delivery callbacks itself, so every poll on the happy path
+    # must be non-blocking.
+    assert all(
+        call.args[0] == 0 for call in mock_producer["producer"].poll.call_args_list
+    )
+
+
+def test_produce_kafka_exception_is_wrapped(kafka_target, mock_producer, sample_chunk):
+    # librdkafka rejects an oversized message synchronously from produce().
+    mock_producer["producer"].produce.side_effect = FakeKafkaException(
+        "KafkaError{code=MSG_SIZE_TOO_LARGE}"
+    )
+
+    processor = KafkaTargetProcessor(kafka_target)
+
+    with pytest.raises(TargetWriteError, match=r"message\.max\.bytes") as excinfo:
+        with processor:
+            processor.begin_chunks(
+                filename="test.pdf",
+                temp_dir=Path("/tmp"),
+                document_hash="abc123",
+            )
+            processor.consume_chunk(sample_chunk)
+
+    # The original cause must survive for the logs.
+    assert isinstance(excinfo.value.__cause__, FakeKafkaException)
+    # An oversized message is not retryable.
+    assert mock_producer["producer"].produce.call_count == 1
+
+
+def test_end_chunks_flush_timeout(kafka_target, mock_producer, sample_chunk):
     # Mock flush to return non-zero (timeout)
     mock_producer["producer"].flush.return_value = 5
 
     processor = KafkaTargetProcessor(kafka_target)
-    chunk = ChunkedDocumentResultItem(
-        filename="test.pdf",
-        chunk_index=0,
-        text="test chunk text",
-        doc_items=["#/texts/0"],
-        metadata={},
-    )
 
     with pytest.raises(TargetWriteError, match="flush timeout"):
         with processor:
@@ -172,19 +339,12 @@ def test_end_chunks_flush_timeout(kafka_target, mock_producer):
                 temp_dir=Path("/tmp"),
                 document_hash="abc123",
             )
-            processor.consume_chunk(chunk)
+            processor.consume_chunk(sample_chunk)
             processor.end_chunks()
 
 
-def test_end_chunks_delivery_error(kafka_target, mock_producer):
+def test_end_chunks_delivery_error(kafka_target, mock_producer, sample_chunk):
     processor = KafkaTargetProcessor(kafka_target)
-    chunk = ChunkedDocumentResultItem(
-        filename="test.pdf",
-        chunk_index=0,
-        text="test chunk text",
-        doc_items=["#/texts/0"],
-        metadata={},
-    )
 
     with pytest.raises(TargetWriteError, match="delivery failed"):
         with processor:
@@ -193,7 +353,7 @@ def test_end_chunks_delivery_error(kafka_target, mock_producer):
                 temp_dir=Path("/tmp"),
                 document_hash="abc123",
             )
-            processor.consume_chunk(chunk)
+            processor.consume_chunk(sample_chunk)
 
             # Simulate delivery error
             processor._delivery_errors.append(Exception("broker down"))
@@ -201,18 +361,11 @@ def test_end_chunks_delivery_error(kafka_target, mock_producer):
             processor.end_chunks()
 
 
-def test_buffer_error_retry(kafka_target, mock_producer):
+def test_buffer_error_retry(kafka_target, mock_producer, sample_chunk):
     # First produce raises BufferError, second succeeds
     mock_producer["producer"].produce.side_effect = [BufferError(), None]
 
     processor = KafkaTargetProcessor(kafka_target)
-    chunk = ChunkedDocumentResultItem(
-        filename="test.pdf",
-        chunk_index=0,
-        text="test chunk text",
-        doc_items=["#/texts/0"],
-        metadata={},
-    )
 
     with processor:
         processor.begin_chunks(
@@ -220,30 +373,44 @@ def test_buffer_error_retry(kafka_target, mock_producer):
             temp_dir=Path("/tmp"),
             document_hash="abc123",
         )
-        processor.consume_chunk(chunk)
+        processor.consume_chunk(sample_chunk)
 
         # Should have called produce twice (initial + retry)
         assert mock_producer["producer"].produce.call_count == 2
 
 
-def test_buffer_error_exhausted(kafka_target, mock_producer):
-    # Both attempts raise BufferError
+def test_buffer_error_exhausted(mock_producer, sample_chunk):
+    # Every attempt raises BufferError until the deadline passes.
     mock_producer["producer"].produce.side_effect = BufferError()
 
-    processor = KafkaTargetProcessor(kafka_target)
-    chunk = ChunkedDocumentResultItem(
-        filename="test.pdf",
-        chunk_index=0,
-        text="test chunk text",
-        doc_items=["#/texts/0"],
-        metadata={},
+    target = KafkaChunkTarget(
+        bootstrap_servers=["localhost:9092"],
+        topic="test.chunks",
+        queue_full_timeout_seconds=0.0,
     )
+    processor = KafkaTargetProcessor(target)
 
-    with pytest.raises(TargetWriteError, match="queue full after retry"):
+    with pytest.raises(TargetWriteError, match="queue still full"):
         with processor:
             processor.begin_chunks(
                 filename="test.pdf",
                 temp_dir=Path("/tmp"),
                 document_hash="abc123",
             )
-            processor.consume_chunk(chunk)
+            processor.consume_chunk(sample_chunk)
+
+
+def test_finalize_reports_undelivered_messages(kafka_target, mock_producer, caplog):
+    # A path that never reached end_chunks() leaves messages queued.
+    mock_producer["producer"].flush.return_value = 3
+
+    processor = KafkaTargetProcessor(kafka_target)
+    with caplog.at_level("ERROR"):
+        with processor:
+            processor.begin_chunks(
+                filename="test.pdf",
+                temp_dir=Path("/tmp"),
+                document_hash="abc123",
+            )
+
+    assert "3 message(s) still queued" in caplog.text

--- a/tests/test_kafka_target_processor.py
+++ b/tests/test_kafka_target_processor.py
@@ -56,7 +56,24 @@ def mock_producer(monkeypatch):
     fake_confluent_kafka = types.ModuleType("confluent_kafka")
     fake_confluent_kafka.Producer = mock_producer_cls  # type: ignore[attr-defined]
     fake_confluent_kafka.KafkaException = FakeKafkaException  # type: ignore[attr-defined]
+
+    # _verify_topic() does `from confluent_kafka.admin import AdminClient`; the
+    # fake AdminClient returns a cluster-metadata mock with a non-empty topics dict
+    # so the topic-exists check passes without a real broker.
+    fake_topic_meta = Mock()
+    fake_topic_meta.error = None
+    fake_cluster_meta = Mock()
+    fake_cluster_meta.topics = {"test.chunks": fake_topic_meta}
+    fake_admin_instance = Mock()
+    fake_admin_instance.list_topics = Mock(return_value=fake_cluster_meta)
+    fake_admin_cls = Mock(return_value=fake_admin_instance)
+
+    fake_admin_mod = types.ModuleType("confluent_kafka.admin")
+    fake_admin_mod.AdminClient = fake_admin_cls  # type: ignore[attr-defined]
+    fake_confluent_kafka.admin = fake_admin_mod  # type: ignore[attr-defined]
+
     monkeypatch.setitem(sys.modules, "confluent_kafka", fake_confluent_kafka)
+    monkeypatch.setitem(sys.modules, "confluent_kafka.admin", fake_admin_mod)
 
     yield {
         "producer_cls": mock_producer_cls,

--- a/uv.lock
+++ b/uv.lock
@@ -2,17 +2,17 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
     "python_full_version >= '3.15' and sys_platform == 'darwin'",
-    "python_full_version == '3.14.*' and sys_platform == 'darwin'",
-    "python_full_version < '3.11' and sys_platform == 'darwin'",
     "python_full_version >= '3.15' and sys_platform != 'darwin'",
+    "python_full_version == '3.14.*' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
+    "python_full_version < '3.11' and sys_platform == 'darwin'",
     "python_full_version < '3.11' and sys_platform != 'darwin'",
 ]
 
@@ -333,16 +333,16 @@ name = "av"
 version = "18.0.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
     "python_full_version >= '3.15' and sys_platform == 'darwin'",
-    "python_full_version == '3.14.*' and sys_platform == 'darwin'",
     "python_full_version >= '3.15' and sys_platform != 'darwin'",
+    "python_full_version == '3.14.*' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ae/a4/570a5a35c8638aba01e739925846c35fdd6b0756a15526766d0a4dd3b7df/av-18.0.0.tar.gz", hash = "sha256:4ef7e72c3d3a872584a1215173b16e0226811037f40dcdbf75992631098df1ba", size = 4340222, upload-time = "2026-07-02T06:37:58.907Z" }
 wheels = [
@@ -868,6 +868,42 @@ wheels = [
 ]
 
 [[package]]
+name = "confluent-kafka"
+version = "2.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/90/eb998fedefb63b42910b54b76b7d300ccddc56430a5175122eb60cedc4f3/confluent_kafka-2.15.0.tar.gz", hash = "sha256:7ad9bad1cbabf6713ec039b8204b48d322024fd11397eec88d912e048c732ba7", size = 323365, upload-time = "2026-06-30T19:48:43.395Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/8c/b46a53a5025470bcc6c5c1fa556348096484a6e30421180de7bbd4b1af25/confluent_kafka-2.15.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f8ac4addda1cff47adc316146ee74aa2a83eeef14b176252f6f1abd29ae1d5a2", size = 4362388, upload-time = "2026-06-30T19:47:43.269Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/fa/7be0239c65bdcb47d5aaeaf01090f5e2e118d7899e34a65736c78a5ff31f/confluent_kafka-2.15.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:64c5a9dbe563c964e21a83f3cb4ff1de6536e484a56289fe9aff69fc33302c73", size = 4334523, upload-time = "2026-06-30T19:47:46.155Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/29/8445fa9fd66651b1748cbf0a1650b4f9b90411eecedd8390247f311f83b8/confluent_kafka-2.15.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:f4a8f02dbc93f17e125a201c5e5ce2143794b71bb5c91836ef87959fc5dcf6a4", size = 4974790, upload-time = "2026-06-30T19:47:47.861Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e2/8065a16b2a6390f0612bc387a1879cc35ed7be0875106d9d73f4f25b0412/confluent_kafka-2.15.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:d9c9d240b681427568d9e341cf3deb3b7350b69931e6fbc636c5986432fb03f4", size = 4781067, upload-time = "2026-06-30T19:47:49.611Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/9c/2f4158bfc1a24f3b775f6abbe921045f4b1214c44bb44f8a7fd1631129aa/confluent_kafka-2.15.0-cp310-cp310-win_amd64.whl", hash = "sha256:039444ea430aaef415487df406070f364d956d76bbd980337455c2a7b5c5789b", size = 4548789, upload-time = "2026-06-30T19:47:51.19Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/42/3522fb404e3b4a323fe25c5993cd2e8fcfa5d3a82f65aa8a7ffd49bdbec9/confluent_kafka-2.15.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:3c4493caf1f1d2e295f5be8400d3a9854016456241f7062d0fb22dd01e2632e6", size = 4362085, upload-time = "2026-06-30T19:47:52.751Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/20/7e8aca63fabcbd88bc47c337187f3f6ad34f9950ed58a2184a5473617719/confluent_kafka-2.15.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:c311695a10cefc1579372bd2f3808d28fd0c3d8cc7f578c94a381f351018912e", size = 4334128, upload-time = "2026-06-30T19:47:54.272Z" },
+    { url = "https://files.pythonhosted.org/packages/77/c2/c2f38b593ce622aba2cab5c3272932d1538394cec8bd5fcb2f072c61bf3e/confluent_kafka-2.15.0-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:7868fe2c2e1f6434903e3f1ea0ba6976d9382f5a9ef46f85d205ca7eb6f28689", size = 4974285, upload-time = "2026-06-30T19:47:56.062Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/18/fe516c9e158556b59c16b92da948186ba240925f80242d39795d94255b27/confluent_kafka-2.15.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:e31bbb5775da23f14264b3e6efd3839c1611a639f3d8c15516350798fe6f2750", size = 4780780, upload-time = "2026-06-30T19:47:57.765Z" },
+    { url = "https://files.pythonhosted.org/packages/62/30/3b204e0df740d6941b7da440b3d45cc26c64e1a455e38d6ec4c2360f1a7e/confluent_kafka-2.15.0-cp311-cp311-win_amd64.whl", hash = "sha256:c041b784f25d2b0b8b2abab7390020951229b694a5c037402c493b0eeca12020", size = 4548794, upload-time = "2026-06-30T19:47:59.416Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b3/34811eb66633dce51f583cd0ea5d78a26c9a135847d7dbd536fc5a963055/confluent_kafka-2.15.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:6e5ea2933c0b07782a99dfdfc9d52e92526e7a61839a6994feb994dcf2a78a74", size = 4367689, upload-time = "2026-06-30T19:48:00.855Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/08/9fea6928cd1e678df0be930206e631bb7e44e7ed54560f5b3f76352187ff/confluent_kafka-2.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e4465a060ab215d5d514b181f3e7502c6fd7887529381c4af940a0b60f9d65cc", size = 4338594, upload-time = "2026-06-30T19:48:02.469Z" },
+    { url = "https://files.pythonhosted.org/packages/25/5f/f9728a100ba40d31a957c5f5cb594ea7d49fd1188002543d3543349a063a/confluent_kafka-2.15.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:b68e6f441866542c9150e6fdf106131eee5a51db591937888c866d799fb354ec", size = 4979384, upload-time = "2026-06-30T19:48:04.127Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/2e/9f80cae9dd7b4852b8a24f9f91001916b987a2ba359e9f077c43ca41d5da/confluent_kafka-2.15.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:fd833dab1392f456b9dd52b7ed9ac65b2cc36871ed5e3ebe8d53486c965b6453", size = 4785580, upload-time = "2026-06-30T19:48:05.841Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/b6/02f73ed259d5be5fbbc8dde41527cad097eca56ab7831026039c8abbaffc/confluent_kafka-2.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:2cc8d01a77c534669bb896f731c8917cd63b787618081fdd0d1420d58cd6815b", size = 4549188, upload-time = "2026-06-30T19:48:07.426Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/80/c7bba18644fb748fc1202e2652230652d243c764fc158798d9f2096513c4/confluent_kafka-2.15.0-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:ff43508f8e929d83545272ef4f17e27fdaa9cc8397f77cf2236b22d67de4edc4", size = 4343586, upload-time = "2026-06-30T19:48:09.272Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/41/0be8143a944c70c6055e8d0fb713964ebe173494e280451c927fa02247ab/confluent_kafka-2.15.0-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:41d4c7360c51202785e8e9aa56241dd392b9dbcc311eae7c5e6985b239efc12b", size = 4371325, upload-time = "2026-06-30T19:48:10.996Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/3c/d5c83c20599a82faa065b922b55338c672a268fa2ac75f54e53bed8913d7/confluent_kafka-2.15.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:b0ac3831aac47ea23699a6ca5b9836288a4b9d201015dbfc4c3ec9f20592fdb5", size = 4979865, upload-time = "2026-06-30T19:48:12.447Z" },
+    { url = "https://files.pythonhosted.org/packages/40/79/5be34236697e8fabbed5534a67100b9d9d11c210de55ba3ba2590d7d7634/confluent_kafka-2.15.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:0455754e8294e1e76cb5acc083c300b6bd8d88f2d2c551c583cbf4ab55889a57", size = 4785955, upload-time = "2026-06-30T19:48:14.055Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ff/4da4e954040769d46111f3c0e5b3e76f2d3bc4b27c1deb5fd64fc9cc4055/confluent_kafka-2.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:7c59ea36606e0e946e6b353203136b4d71be6d95c0c8ae5113b81850ff5b7b41", size = 4608827, upload-time = "2026-06-30T19:48:15.746Z" },
+    { url = "https://files.pythonhosted.org/packages/18/20/5c078b9560b8005404e09a5889b9771e8deb5c9dddeb9003f58c7d028258/confluent_kafka-2.15.0-cp314-cp314-macosx_13_0_arm64.whl", hash = "sha256:e781d39ff31d5d10d0502471f92f95aff4f5be1eaae9a1f57aeac164bc9f9029", size = 4343440, upload-time = "2026-06-30T19:48:17.324Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/27/fd83281231b6179e3923822e20861dfc1d6c200edb910c3d8e9a15b9e95a/confluent_kafka-2.15.0-cp314-cp314-macosx_13_0_x86_64.whl", hash = "sha256:000463c822a7adc3293369b63688b68d17c03a1a4a64f86182efc08f8b150676", size = 4371051, upload-time = "2026-06-30T19:48:19.29Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/3e/fa82e6699144e707972bbf57489598defdf67e844ae2a7d29e0ea4e3a187/confluent_kafka-2.15.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:9ddf4cf4647e5d633ef64e3f5a349d5288edfedf974203993e9d86548c2695be", size = 4979624, upload-time = "2026-06-30T19:48:21.454Z" },
+    { url = "https://files.pythonhosted.org/packages/13/ee/b4b6a0da17584b432c83a0500ac79c04864ef92dafdb405614831b995232/confluent_kafka-2.15.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:d8ed33f623ff2a104fb76f99a67e9917f0170fddb4e28380fcdc83347b1646b2", size = 4785678, upload-time = "2026-06-30T19:48:23.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/f4/19a852d16e8e4f8ac930037d8ecda21a220f6d5d050a59bbce10189ac9ec/confluent_kafka-2.15.0-cp314-cp314-win_amd64.whl", hash = "sha256:2e80bd96f61aae2ffba951754a769e6d3c5ebb5a5e778ed0ae8ad899ea91556b", size = 4744444, upload-time = "2026-06-30T19:48:24.698Z" },
+]
+
+[[package]]
 name = "coverage"
 version = "7.15.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1302,6 +1338,9 @@ gdrive = [
     { name = "google-api-python-client" },
     { name = "google-auth-oauthlib" },
 ]
+kafka = [
+    { name = "confluent-kafka" },
+]
 onnxruntime = [
     { name = "docling-slim", extra = ["models-onnxruntime"] },
 ]
@@ -1356,6 +1395,7 @@ requires-dist = [
     { name = "azure-storage-blob", marker = "extra == 'azure'", specifier = ">=12.19.0" },
     { name = "boto3", specifier = "~=1.35" },
     { name = "codeflare-sdk", marker = "python_full_version >= '3.11' and python_full_version < '3.14' and extra == 'ray'", specifier = ">=0.20.0" },
+    { name = "confluent-kafka", marker = "extra == 'kafka'", specifier = ">=2.5.0,<3" },
     { name = "docling-slim", extras = ["models-onnxruntime"], marker = "extra == 'onnxruntime'", specifier = ">=2.94.0,<3.0.0" },
     { name = "docling-slim", extras = ["models-vlm-inline"], marker = "extra == 'vlm'", specifier = ">=2.95.0,<3.0.0" },
     { name = "docling-slim", extras = ["standard"], specifier = ">=2.118.0,<3.0.0" },
@@ -1377,7 +1417,7 @@ requires-dist = [
     { name = "rq", marker = "extra == 'rq'", specifier = "~=2.4" },
     { name = "typer", specifier = ">=0.12.5,<1" },
 ]
-provides-extras = ["vlm", "onnxruntime", "rq", "ray", "gdrive", "gcloudstorage", "azure", "opensearch", "astradb", "sharepoint"]
+provides-extras = ["vlm", "onnxruntime", "rq", "ray", "gdrive", "gcloudstorage", "azure", "opensearch", "astradb", "kafka", "sharepoint"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -3447,16 +3487,16 @@ name = "networkx"
 version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
     "python_full_version >= '3.15' and sys_platform == 'darwin'",
-    "python_full_version == '3.14.*' and sys_platform == 'darwin'",
     "python_full_version >= '3.15' and sys_platform != 'darwin'",
+    "python_full_version == '3.14.*' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
 wheels = [
@@ -3577,16 +3617,16 @@ name = "numpy"
 version = "2.4.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
     "python_full_version >= '3.15' and sys_platform == 'darwin'",
-    "python_full_version == '3.14.*' and sys_platform == 'darwin'",
     "python_full_version >= '3.15' and sys_platform != 'darwin'",
+    "python_full_version == '3.14.*' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
 wheels = [
@@ -3848,16 +3888,16 @@ name = "office365-rest-python-client"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
     "python_full_version >= '3.15' and sys_platform == 'darwin'",
-    "python_full_version == '3.14.*' and sys_platform == 'darwin'",
     "python_full_version >= '3.15' and sys_platform != 'darwin'",
+    "python_full_version == '3.14.*' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
 ]
 dependencies = [
     { name = "msal" },
@@ -5813,16 +5853,16 @@ name = "rpds-py"
 version = "2026.6.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
-    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
     "python_full_version >= '3.15' and sys_platform == 'darwin'",
-    "python_full_version == '3.14.*' and sys_platform == 'darwin'",
     "python_full_version >= '3.15' and sys_platform != 'darwin'",
+    "python_full_version == '3.14.*' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.11.*' and sys_platform != 'darwin'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
 wheels = [
@@ -6181,14 +6221,14 @@ name = "scipy"
 version = "1.18.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
-    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
-    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
     "python_full_version >= '3.15' and sys_platform == 'darwin'",
-    "python_full_version == '3.14.*' and sys_platform == 'darwin'",
     "python_full_version >= '3.15' and sys_platform != 'darwin'",
+    "python_full_version == '3.14.*' and sys_platform == 'darwin'",
     "python_full_version == '3.14.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.13.*' and sys_platform != 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform == 'darwin'",
+    "python_full_version == '3.12.*' and sys_platform != 'darwin'",
 ]
 dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },


### PR DESCRIPTION
Rework of #211 

Uses confluent_kafka python library to stream chunks as messages to a Kafka topic. 

Tested locally against docker-compose.kafka.yaml
To try it out, run `docker-compose -f dev/docker-compose.kafka.yaml up -d`, then use the local/multiproc CLI. 
Dev docker compose includes an open source UI tool for testing. View at http://localhost:8080 when container is up. 

Haven't gotten access to a Confluent Cloud account to test against a Kafka instance hosted there yet. 
Should just be a matter of swapping out the bootstrap_servers field. Confluent cloud uses PLAIN auth I believe, username and password correspond to Confluent API key and secret. 

Messages are keyed either by doc_id, chunk_id, or placed round-robin in available partitions if no key_mode is set. 