### PR TITLE
feat(rq): make the RQ job timeout configurable

### DIFF
--- a/docling_jobkit/orchestrators/rq/orchestrator.py
+++ b/docling_jobkit/orchestrators/rq/orchestrator.py
@@ -46,6 +46,7 @@ class RQOrchestratorConfig(BaseModel):
     queue_name: str = "convert"
     results_ttl: int = 3_600 * 4
     failure_ttl: int = 3_600 * 4
+    job_timeout: int = 3_600 * 4  # RQ death penalty per job; -1 disables it
     results_prefix: str = "docling:results"
     heartbeat_key_prefix: str = "docling:job:alive"
     sub_channel: str = "docling:updates"
@@ -109,7 +110,7 @@ class RQOrchestrator(BaseOrchestrator):
         rq_queue = Queue(
             config.queue_name,
             connection=conn,
-            default_timeout=14400,
+            default_timeout=config.job_timeout,
             result_ttl=config.results_ttl,
             failure_ttl=config.failure_ttl,
         )
@@ -211,7 +212,7 @@ class RQOrchestrator(BaseOrchestrator):
                 self._rq_job_function,
                 kwargs={"task_data": task_data},
                 job_id=task_id,
-                timeout=14400,
+                timeout=self.config.job_timeout,
                 failure_ttl=self.config.failure_ttl,
             )
             await self.init_task_tracking(task)

--- a/tests/test_rq_orchestrator_config.py
+++ b/tests/test_rq_orchestrator_config.py
@@ -2,6 +2,11 @@
 
 from unittest.mock import patch
 
+import pytest
+
+from docling.datamodel.service.requests import HttpSourceRequest
+from docling.datamodel.service.targets import InBodyTarget
+
 from docling_jobkit.orchestrators.rq.orchestrator import (
     RQOrchestrator,
     RQOrchestratorConfig,
@@ -47,3 +52,64 @@ class TestQueueNameConfig:
             RQOrchestrator.make_rq_queue(config)
 
         assert queue_cls.call_args.args[0] == "staging-convert"
+
+
+class TestJobTimeoutConfig:
+    def test_default_job_timeout_preserves_existing_behavior(self):
+        config = RQOrchestratorConfig()
+        assert config.job_timeout == 14400
+
+    def test_default_job_timeout_passed_to_queue(self):
+        config = RQOrchestratorConfig()
+
+        with patch("docling_jobkit.orchestrators.rq.orchestrator.Queue") as queue_cls:
+            RQOrchestrator.make_rq_queue(config)
+
+        assert queue_cls.call_args.kwargs["default_timeout"] == 14400
+
+    def test_custom_job_timeout_passed_to_queue(self):
+        config = RQOrchestratorConfig(job_timeout=86400)
+
+        with patch("docling_jobkit.orchestrators.rq.orchestrator.Queue") as queue_cls:
+            RQOrchestrator.make_rq_queue(config)
+
+        assert queue_cls.call_args.kwargs["default_timeout"] == 86400
+
+    def test_job_timeout_can_be_disabled(self):
+        config = RQOrchestratorConfig(job_timeout=-1)
+
+        with patch("docling_jobkit.orchestrators.rq.orchestrator.Queue") as queue_cls:
+            RQOrchestrator.make_rq_queue(config)
+
+        assert queue_cls.call_args.kwargs["default_timeout"] == -1
+
+
+class TestJobTimeoutOnEnqueue:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("job_timeout", [14400, 86400, -1])
+    async def test_enqueue_uses_configured_job_timeout(
+        self, monkeypatch: pytest.MonkeyPatch, job_timeout: int
+    ):
+        orchestrator = RQOrchestrator(
+            config=RQOrchestratorConfig(job_timeout=job_timeout)
+        )
+        captured: dict[str, object] = {}
+
+        class FakeQueue:
+            def enqueue(self, *args, **kwargs):
+                captured["kwargs"] = kwargs
+
+        async def _noop(*args, **kwargs):
+            return None
+
+        orchestrator._rq_queue = FakeQueue()
+        monkeypatch.setattr(orchestrator, "init_task_tracking", _noop)
+        monkeypatch.setattr(orchestrator, "_store_task_in_redis", _noop)
+
+        await orchestrator.enqueue(
+            sources=[HttpSourceRequest(url="https://example.com/doc.pdf")],
+            convert_options=None,
+            targets=[InBodyTarget()],
+        )
+
+        assert captured["kwargs"]["timeout"] == job_timeout


### PR DESCRIPTION
Closes #226

## What

Adds `RQOrchestratorConfig.job_timeout` and uses it in the two places where the RQ job
timeout was hardcoded to `14400` (4 hours): the queue's `default_timeout` in
`make_rq_queue()` and the `timeout=` argument of `enqueue()`.

## Why

The 4-hour limit was invisible and unreachable from configuration:

- **It silently caps document processing.** `docling-serve` allows a per-document limit of up
  to `max_document_timeout` (default `3600 * 24 * 7`, 7 days) and normalizes requests that
  omit `document_timeout` *to that maximum*. A request can pass policy validation with a
  7-day document timeout and still be killed at 4 hours by RQ. The two limits contradict each
  other, and the effective one is the invisible one.
- **The failure is maximally expensive.** Unlike docling's own `document_timeout` — which ends
  the pipeline with `ConversionStatus.PARTIAL_SUCCESS` and a `FailureCategory.TIMEOUT` error
  item, so the caller still gets the pages processed so far — an RQ death penalty just marks
  the task `FAILURE` after 4 hours of CPU/GPU work, with no partial result. The client cannot
  distinguish "this document is unprocessable" from "the queue backend gave up".
- **>4h conversions are not exotic.** CPU-only deployments, or `do_ocr` +
  `do_table_structure` in accurate mode + `do_formula_enrichment` on documents with several
  hundred pages, routinely exceed it. For batch ingestion over a whole corpus, a single such
  document is an unavoidable hard failure; the only workarounds today are excluding the
  document or forking the package.
- **It is inconsistent with the rest of the class.** Every neighbouring knob in
  `RQOrchestratorConfig` is configurable and env-wired in docling-serve (`results_ttl`,
  `failure_ttl`, `result_removal_delay`, `redis_socket_timeout`, `redis_gate_*`,
  `zombie_reaper_*`), and the Ray orchestrator has an explicit, configurable equivalent of
  this very limit (`task_timeout`). Only the RQ job timeout is a literal.

## The change

```python
class RQOrchestratorConfig(BaseModel):
    ...
    job_timeout: int = 3_600 * 4  # RQ death penalty per job; -1 disables it
```

```python
rq_queue = Queue(
    config.queue_name,
    connection=conn,
    default_timeout=config.job_timeout,   # was: 14400
    ...
)

self._rq_queue.enqueue(
    ...,
    timeout=self.config.job_timeout,      # was: 14400
    ...
)
```

## Compatibility

Non-breaking: the default is `14400`, exactly today's behaviour. Deployments that need more
raise it; deployments that want the document-level `document_timeout` to be the only bound
set `-1`, which RQ interprets as "no timeout".

## Tests

`tests/test_rq_orchestrator_config.py`:

- default `job_timeout` is `14400` and is what reaches `Queue(default_timeout=...)`
- a custom value and `-1` reach `Queue(default_timeout=...)`
- `enqueue()` passes the configured value as `timeout=` (parametrized over `14400`, `86400`,
  `-1`), using the existing fake-queue pattern from `tests/test_s3_source_orchestrators.py`

Verified locally: `pytest tests/test_rq_orchestrator_config.py` → 12 passed; `ruff
format`/`ruff check` clean on the touched files; `mypy docling_jobkit` unchanged versus `main`
(9 pre-existing errors, all from optional extras not installed locally).

## Follow-ups (deliberately not in this PR)

- Companion change in `docling-serve`: expose `eng_rq_job_timeout` →
  `DOCLING_SERVE_ENG_RQ_JOB_TIMEOUT` in `docling_serve/orchestrator_factory.py`. Prepared and
  ready; I'll open it once this is merged and released, so the `docling-jobkit` floor in its
  `pyproject.toml` can be bumped to the release that actually contains the field.
- Optional: warn when the effective `document_timeout` exceeds `job_timeout`, so the two
  limits cannot silently contradict each other. Happy to add it here if you prefer.
