### PR TITLE
fix: map threaded docling-parse backend for Standard and VLM pipelines

### DIFF
--- a/docling_jobkit/convert/manager.py
+++ b/docling_jobkit/convert/manager.py
@@ -11,7 +11,10 @@ from typing import Any, Callable, Literal, Optional, Type, TypedDict, Union
 
 from pydantic import BaseModel, Field
 
-from docling.backend.docling_parse_backend import DoclingParseDocumentBackend
+from docling.backend.docling_parse_backend import (
+    DoclingParseDocumentBackend,
+    ThreadedDoclingParseDocumentBackend,
+)
 from docling.backend.pdf_backend import PdfDocumentBackend
 from docling.backend.pypdfium2_backend import PyPdfiumDocumentBackend
 from docling.datamodel import vlm_model_specs
@@ -1711,6 +1714,8 @@ class DoclingConverterManager:
         pdf_backend = normalize_pdf_backend(request.pdf_backend)
         if pdf_backend == PdfBackend.DOCLING_PARSE:
             backend: type[PdfDocumentBackend] = DoclingParseDocumentBackend
+        elif pdf_backend == PdfBackend.THREADED_DOCLING_PARSE:
+            backend = ThreadedDoclingParseDocumentBackend
         elif pdf_backend == PdfBackend.PYPDFIUM2:
             backend = PyPdfiumDocumentBackend
         else:
@@ -1866,8 +1871,11 @@ class DoclingConverterManager:
 
         elif request.pipeline == ProcessingPipeline.VLM:
             pipeline_options = self._parse_vlm_pdf_opts(request, artifacts_path)
+            backend = self._parse_backend(request)
             pdf_format_option = PdfFormatOption(
-                pipeline_cls=VlmPipeline, pipeline_options=pipeline_options
+                pipeline_cls=VlmPipeline,
+                pipeline_options=pipeline_options,
+                backend=backend,
             )
         else:
             raise NotImplementedError(

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,8 +1,12 @@
 import sys
+from pathlib import Path
 
 import pytest
 
-from docling.backend.docling_parse_backend import DoclingParseDocumentBackend
+from docling.backend.docling_parse_backend import (
+    DoclingParseDocumentBackend,
+    ThreadedDoclingParseDocumentBackend,
+)
 from docling.backend.pypdfium2_backend import PyPdfiumDocumentBackend
 from docling.datamodel import vlm_model_specs
 from docling.datamodel.base_models import InputFormat
@@ -121,6 +125,44 @@ def test_options_validator():
             pipeline_opts.pipeline_options.vlm_options
             == vlm_model_specs.GRANITEDOCLING_TRANSFORMERS
         )
+
+
+def test_backend_mapping_standard_and_vlm():
+    """Request pdf_backend must map to the right class and be set explicitly
+    for both Standard and VLM pipelines (no reliance on PdfFormatOption's default)."""
+    m = DoclingConverterManager(config=DoclingConverterManagerConfig())
+
+    cases = [
+        (None, DoclingParseDocumentBackend),  # omitted -> service-model default
+        (PdfBackend.DOCLING_PARSE, DoclingParseDocumentBackend),
+        (PdfBackend.THREADED_DOCLING_PARSE, ThreadedDoclingParseDocumentBackend),
+        (PdfBackend.PYPDFIUM2, PyPdfiumDocumentBackend),
+    ]
+
+    for pipeline in (ProcessingPipeline.STANDARD, ProcessingPipeline.VLM):
+        for requested, expected in cases:
+            kwargs = {"pipeline": pipeline}
+            if requested is not None:
+                kwargs["pdf_backend"] = requested
+            opts = ConvertDocumentsOptions(**kwargs)
+            pipeline_opts = m.get_pdf_pipeline_opts(opts)
+            assert pipeline_opts.backend == expected, (pipeline, requested)
+
+
+def test_threaded_request_reaches_conversion():
+    """A threaded-backend request must run a real conversion end to end,
+    not fail in option mapping (regression guard for the J1 compatibility work)."""
+    from docling.datamodel.base_models import ConversionStatus
+
+    m = DoclingConverterManager(config=DoclingConverterManagerConfig())
+    doc = Path(__file__).parent / "2206.01062v1-pg4.pdf"
+    opts = ConvertDocumentsOptions(pdf_backend=PdfBackend.THREADED_DOCLING_PARSE)
+
+    results = list(m.convert_documents([doc], opts))
+
+    assert len(results) == 1
+    assert results[0].status == ConversionStatus.SUCCESS
+    assert results[0].document is not None
 
 
 def test_options_cache_key():


### PR DESCRIPTION
Recognize PdfBackend.THREADED_DOCLING_PARSE in _parse_backend and resolve the request backend once, passing it explicitly into PdfFormatOption for both the Standard and VLM pipelines instead of relying on the default. This is the Jobkit half of the service-stack compatibility work (Session E) that must precede the Docling default flip.

Tests: request-to-converter mapping for omitted/default, threaded, classic docling-parse, and pypdfium2 across Standard and VLM, plus an end-to-end threaded conversion that proves the request reaches conversion.

<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->
