### PR TITLE
fix(local_path): enforce max_file_size before reading the file

### DIFF
--- a/docling_jobkit/connectors/local_path/source_processor.py
+++ b/docling_jobkit/connectors/local_path/source_processor.py
@@ -12,6 +12,10 @@ from docling_jobkit.connectors.source_processor import (
     BaseSourceProcessor,
     SourceDocumentRef,
 )
+from docling_jobkit.convert.materialization import (
+    SourceLimitExceededError,
+    normalize_max_file_size,
+)
 
 
 def _should_ignore_file(file_path: Path) -> bool:
@@ -126,7 +130,12 @@ class LocalPathSourceProcessor(
         max_file_size: int | None = None,
     ) -> DocumentStream:
         """Fetch a document by opening the file from the local filesystem."""
-        del max_file_size
+        limit = normalize_max_file_size(max_file_size)
+        if limit is not None and identifier.size > limit:
+            raise SourceLimitExceededError(
+                f"Source '{identifier.path}' exceeds max_file_size={limit} bytes"
+            )
+
         file_path = identifier.path
 
         # Open file in binary mode and return as DocumentStream

--- a/tests/test_local_path_processor.py
+++ b/tests/test_local_path_processor.py
@@ -1,3 +1,4 @@
+import sys
 import tempfile
 from datetime import datetime
 from pathlib import Path
@@ -16,6 +17,7 @@ from docling_jobkit.connectors.local_path.source_processor import (
 from docling_jobkit.connectors.local_path.target_processor import (
     LocalPathTargetProcessor,
 )
+from docling_jobkit.convert.materialization import SourceLimitExceededError
 
 # -------------------------------------------------------------------
 # Pytest fixtures
@@ -163,6 +165,45 @@ def test_local_path_nonexistent_file():
     with pytest.raises(FileNotFoundError):
         with LocalPathSourceProcessor(source) as _:
             pass
+
+
+def test_local_path_fetch_by_ref_rejects_oversized_file(temp_test_dir):
+    """A ref above max_file_size is refused before the file is read."""
+    source = LocalPathSource(
+        kind="local_path",
+        path=temp_test_dir / "file1.pdf",
+    )
+
+    with LocalPathSourceProcessor(source) as processor:
+        identifier = next(iter(processor._list_document_ids()))
+        ref = processor._make_document_ref(identifier, 0)
+
+        with pytest.raises(SourceLimitExceededError, match="max_file_size=5"):
+            processor.fetch_converter_source_by_ref(ref, max_file_size=5)
+
+        # The same ref is still served when it fits within the limit.
+        doc = processor.fetch_converter_source_by_ref(
+            ref, max_file_size=identifier.size
+        )
+        assert isinstance(doc, DocumentStream)
+        assert doc.stream.read() == b"%PDF-1.4 test content 1"
+
+
+def test_local_path_iterate_documents_honors_max_file_size(temp_test_dir):
+    """iterate_documents() applies the limit the same way the remote sources do."""
+    source = LocalPathSource(
+        kind="local_path",
+        path=temp_test_dir,
+        pattern="file1.pdf",
+        recursive=False,
+    )
+
+    with LocalPathSourceProcessor(source) as processor:
+        with pytest.raises(SourceLimitExceededError, match="max_file_size=5"):
+            list(processor.iterate_documents(max_file_size=5))
+
+        docs = list(processor.iterate_documents(max_file_size=sys.maxsize))
+        assert len(docs) == 1
 
 
 # -------------------------------------------------------------------


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #231

## Problem

`LocalPathSourceProcessor._fetch_document_by_id()` accepts `max_file_size` and then
immediately drops it:

```python
del max_file_size
file_path = identifier.path
with open(file_path, "rb") as f:
    content = f.read()
```

So `DoclingConverterManagerConfig.max_file_size` does not bound local-path
materialization — neither through `fetch_converter_source_by_ref()` nor through
`iterate_documents(max_file_size=...)`, which both route into this method. A file of any
size is read into a `BytesIO` buffer.

## Change

Apply the same guard the remote connectors already use, before the file is opened:

```python
limit = normalize_max_file_size(max_file_size)
if limit is not None and identifier.size > limit:
    raise SourceLimitExceededError(
        f"Source '{identifier.path}' exceeds max_file_size={limit} bytes"
    )
```

`identifier.size` is already populated from the `stat()` that `_list_document_ids()`
performs, so no extra I/O is needed and the check happens before any read.

### Scope: why only `local_path`

Surveying `_fetch_document_by_id` across the eight source connectors:

| connector | enforces `max_file_size` today |
|---|---|
| `s3`, `azure_blob`, `google_cloud_storage`, `sharepoint`, `filenet` | ✅ `normalize_max_file_size` + `SourceLimitExceededError` |
| `local_path` | ❌ `del max_file_size` — **this PR** |
| `http` | enforces on the download path (`_check_content_length_limit`) |
| `google_drive` | ❌, but its identifier carries no size, so it needs a different (fetch-time) check |
| `BaseSourceProcessor` | `del max_file_size` in the `NotImplementedError` default |

`local_path` is the one connector that has the size in hand and still ignores it, so it is
the only one changed here. `google_drive` would need a separate fetch-time check and is
deliberately left out of this PR.

## Tested

Two regression tests added to `tests/test_local_path_processor.py`, covering both entry
points named in the issue:

- `test_local_path_fetch_by_ref_rejects_oversized_file` — `fetch_converter_source_by_ref()`
  raises `SourceLimitExceededError` for an over-limit ref, and still serves the same ref
  when it fits.
- `test_local_path_iterate_documents_honors_max_file_size` — `iterate_documents(max_file_size=...)`
  raises for an over-limit file and yields normally at `sys.maxsize`
  (which `normalize_max_file_size` maps to "no limit").

```
$ python -m pytest tests/test_local_path_processor.py -q
12 passed
```

Both new tests fail on `main` (`DID NOT RAISE SourceLimitExceededError`) and pass with the
change. `ruff format` / `ruff check` (v0.11.5, repo `pyproject.toml`) and
`mypy docling_jobkit/connectors/local_path/source_processor.py` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
