### PR TITLE
fix(results_processor): key artifacts by basename, not by source path (#229)

### DIFF
--- a/docling_jobkit/convert/results_processor.py
+++ b/docling_jobkit/convert/results_processor.py
@@ -226,7 +226,13 @@ class ResultsProcessor:
                         temp_dir = Path(tmpdirname)
                         if conv_res.status == ConversionStatus.SUCCESS:
                             doc_hash = conv_res.input.document_hash
-                            name_without_ext = os.path.splitext(conv_res.input.file)[0]
+                            # Use the basename only: ``input.file`` can be a full
+                            # (even absolute) path, and letting it through would
+                            # both leak that path into every target key and make
+                            # ``temp_dir / name`` resolve back to the source
+                            # directory. The rest of the codebase identifies
+                            # artifacts by ``file.stem`` for the same reason.
+                            name_without_ext = Path(conv_res.input.file).stem
                             _log.debug(f"Converted {doc_hash} now saving results")
 
                             # ── Format upload phase ──────────────────────

--- a/tests/test_results_processor.py
+++ b/tests/test_results_processor.py
@@ -92,3 +92,44 @@ def test_results_processor_uses_narrow_base_target_processor_contract(tmp_path: 
     assert uploaded_targets[3].endswith("input.md")
     assert uploaded_targets[4].endswith("input.pdf")
     assert uploaded_targets[5].endswith("input.txt")
+
+
+def test_results_processor_keys_artifacts_by_basename(tmp_path: Path):
+    """Artifact keys must not carry the source path (#229).
+
+    A nested/absolute source path used to end up inside every target key, and
+    ``temp_dir / <absolute name>`` resolved back to the source directory, so the
+    exported JSON was written next to its own input.
+    """
+    source_dir = tmp_path / "input"
+    source_dir.mkdir()
+    input_path = source_dir / "doc.pdf"
+    input_path.write_bytes(b"%PDF-1.4")
+
+    input_doc = InputDocument(
+        path_or_stream=input_path,
+        format=InputFormat.PDF,
+        backend=_DummyBackend,
+    )
+    conv_res = ConversionResult(
+        input=input_doc,
+        status=ConversionStatus.SUCCESS,
+        document=_FakeDoc.model_construct(),
+    )
+
+    target_processor = _RecordingTargetProcessor()
+    with target_processor:
+        list(
+            ResultsProcessor(
+                target_processors=[target_processor],
+                to_formats=["json", "md"],
+                scratch_dir=tmp_path / "scratch",
+            ).process_documents([conv_res])
+        )
+
+    uploaded_targets = sorted(
+        target for target, _content_type, _obj in target_processor.uploads
+    )
+    assert uploaded_targets == ["json/doc.json", "md/doc.md", "pdf/doc.pdf"]
+    # The export must not have contaminated the source directory.
+    assert sorted(p.name for p in source_dir.iterdir()) == ["doc.pdf"]


### PR DESCRIPTION
Fixes #229 (the path-leak / input-contamination part).

### Problem

`ResultsProcessor.process_documents()` builds the artifact name with

```python
name_without_ext = os.path.splitext(conv_res.input.file)[0]
```

`conv_res.input.file` is the *full* source path — `LocalPathSourceProcessor._fetch_document_by_id()` hands Docling a `DocumentStream(name=str(file_path))`, so every directory component survives `splitext`. That value is then used for both the target keys and the scratch filenames in `_upload_formats()`.

Two things go wrong:

1. **Target keys carry the source path.** With `path: input` the keys become `json/input/<name>.json`, `md/input/<name>.md`, …; with an absolute source path the whole absolute path (including the worker's home directory) appears under every format prefix.

2. **The export is written back into the source directory.** `temp_json_file = temp_dir / f"{name_without_ext}.json"` — joining a `Path` with an *absolute* string discards the left-hand side, so `save_as_json()` writes `<source_dir>/<name>.json` (plus `<name>_artifacts/` in `referenced` image mode) next to the input itself. A subsequent non-recursive batch run then discovers that generated JSON as another input.

Reproduced on `main` (`bce15f7`) with the repo's own test fakes:

```
target keys:
    json/C:\...\Temp\tmp2mnwly0o\input\doc.json
    md/C:\...\Temp\tmp2mnwly0o\input\doc.md
    pdf/C:\...\Temp\tmp2mnwly0o\input\doc.pdf
files left in the SOURCE directory:
    doc.json      <-- generated
    doc.pdf
```

### Fix

Use the basename stem, which is what every sibling artifact-naming site in this codebase already does:

| site | identity used |
|---|---|
| `convert/export.py:259` | `exportable_document.file.stem` |
| `convert/chunking.py:297` | `exportable_document.file.stem` |
| `convert/results.py:687` (streaming twin of this very chunk key) | `_stem = _ed.file.stem` → `chunks/{_stem}.chunks.jsonl` |
| `convert/results_processor.py:229` | **the full path** ← outlier |

`Path(x).stem` strips the extension exactly like `os.path.splitext(x)[0]` does, so for a source that is already a bare filename the emitted keys are byte-for-byte unchanged. The existing `test_results_processor_uses_narrow_base_target_processor_contract` (which asserts with `.endswith(...)`, and therefore never caught this) still passes untouched.

After the change the same reproduction yields:

```
target keys:
    json/doc.json
    md/doc.md
    pdf/doc.pdf
files left in the SOURCE directory:
    doc.pdf
```

### Deliberately not in scope

Issue #229 raises two further points that are separate design decisions, not the same defect, so I left them alone rather than widening this PR:

- **`_upload_formats()` uploads every existing input under `pdf/` with `content_type="application/pdf"`**, including EML/DOCX sources. Whether the original should be copied at all — and under what prefix/MIME — is a target-layout decision for the maintainers.
- **The follow-up comment about picture URIs pointing into the scratch directory** (`/var/folders/.../docling_.../..._artifacts/image_*.png` surviving in exported JSON). That is an image-materialisation concern in the export path, unrelated to how the artifact *name* is derived.

### Verification

- `pytest tests/test_results_processor.py` — 2 passed. The new `test_results_processor_keys_artifacts_by_basename` fails on `main` (`assert ['json/C:\\Us...put\\doc.pdf'] == ['json/doc.js...`) and passes with the fix.
- `ruff format --check` and `ruff check` with the repo's `pyproject.toml`, using the pinned `v0.11.5` from `.pre-commit-config.yaml` — clean.
- `mypy docling_jobkit/convert/results_processor.py` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
