### PR TITLE
fix(manager): register the configured default VLM preset under its own id

### DIFF
--- a/docling_jobkit/convert/manager.py
+++ b/docling_jobkit/convert/manager.py
@@ -584,7 +584,7 @@ class DoclingConverterManager:
         if self.config.allowed_vlm_presets is None:
             # Allow all Docling presets
             for preset_id in VlmConvertOptions.list_preset_ids():
-                if preset_id != self.config.default_vlm_preset:
+                if preset_id != "default":
                     self.vlm_preset_registry[preset_id] = {
                         "source": "docling",
                         "preset_id": preset_id,
@@ -592,7 +592,7 @@ class DoclingConverterManager:
         else:
             # Only allow specified presets
             for preset_id in self.config.allowed_vlm_presets:
-                if preset_id != self.config.default_vlm_preset:
+                if preset_id != "default":
                     self.vlm_preset_registry[preset_id] = {
                         "source": "docling",
                         "preset_id": preset_id,

--- a/tests/test_converter_manager.py
+++ b/tests/test_converter_manager.py
@@ -38,6 +38,46 @@ class TestPresetRegistryBuilding:
         # Other presets should not be in registry
         # (We can't test for specific presets without knowing all Docling presets)
 
+    def test_default_vlm_preset_is_reachable_by_its_own_id(self):
+        """The configured default must also be selectable by name.
+
+        Every other registry excludes the alias "default" from its loop, so that the
+        alias entry survives. The VLM loop excluded default_vlm_preset instead, which
+        dropped a real Docling preset id -- and with the stock config that id is
+        "granite_docling", so the shipped default was the one preset a request could
+        not name.
+        """
+        config = DoclingConverterManagerConfig(
+            default_vlm_preset="granite_docling",
+        )
+        manager = DoclingConverterManager(config)
+
+        assert "granite_docling" in manager.vlm_preset_registry
+        # ...and the alias still resolves to it rather than being overwritten.
+        assert manager.vlm_preset_registry["default"]["preset_id"] == "granite_docling"
+
+        by_id = manager._parse_vlm_options(
+            ConvertDocumentsOptions(vlm_pipeline_preset="granite_docling")
+        )
+        by_alias = manager._parse_vlm_options(
+            ConvertDocumentsOptions(vlm_pipeline_preset="default")
+        )
+        assert by_id == by_alias
+
+    def test_an_explicit_vlm_allowlist_still_restricts(self):
+        """Registering the default by name must not widen an explicit allowlist."""
+        config = DoclingConverterManagerConfig(
+            default_vlm_preset="granite_docling",
+            allowed_vlm_presets=["smoldocling"],
+        )
+        manager = DoclingConverterManager(config)
+
+        assert sorted(manager.vlm_preset_registry) == ["default", "smoldocling"]
+        with pytest.raises(ValueError, match="not allowed"):
+            manager._parse_vlm_options(
+                ConvertDocumentsOptions(vlm_pipeline_preset="qwen")
+            )
+
     def test_custom_presets_added(self):
         """Test that custom presets are added to the registry."""
         custom_preset = {


### PR DESCRIPTION
## What

`DoclingConverterManager._build_preset_registries` skips the configured default when it registers the Docling built-in VLM presets:

```python
for preset_id in VlmConvertOptions.list_preset_ids():
    if preset_id != self.config.default_vlm_preset:   # <- drops a real preset id
        self.vlm_preset_registry[preset_id] = {...}
```

So the preset the deployment ships as its default is the only built-in with no registry entry of its own, and a request that names it is rejected. With the stock config that is `granite_docling`:

```python
m = DoclingConverterManager(DoclingConverterManagerConfig())
m._parse_vlm_options(ConvertDocumentsOptions(vlm_pipeline_preset="granite_docling"))
# ValueError: VLM preset 'granite_docling' is not allowed. Allowed presets:
#   default, smoldocling, deepseek_ocr, granite_vision, pixtral, got_ocr, phi4,
#   qwen, nanonets_ocr2, gemma_12b, gemma_27b, dolphin, glm_ocr, lightonocr,
#   falcon_ocr, chandra_ocr2, unlimited_ocr, dots_ocr, dots_mocr
```

The message enumerates all 19 other built-ins; `granite_docling` is in `VlmConvertOptions.list_preset_ids()` and works fine under the alias `default`. Only its own name is refused.

## Why this is the guard, not the intent

The four sibling registries built in the same method — picture description, code formula, layout, picture classification — all write the guard as:

```python
if preset_id != "default":
```

which is what it is for: the loop must not overwrite the `"default"` alias entry that was just installed above it. The VLM loop compares against the default's *real id* instead, which excludes a legitimate preset rather than protecting the alias.

## Change

Guard on the alias in both VLM loops, matching the siblings. Four characters of behaviour:

- the `"default"` alias still maps to `default_vlm_preset` (asserted);
- an explicit `allowed_vlm_presets` still restricts to exactly that list (asserted — a preset outside it still raises);
- the only difference is that `default_vlm_preset`'s own id now resolves instead of raising, and it resolves to the same options object as `default`.

## Verification

`pytest tests/test_converter_manager.py` — 42 passed before, 44 passed after. Reverting only `manager.py` fails the new registry test and nothing else, so the test is pinned to this change.

## Scope

This is item 5 of #230 only. The other items in that report are separate:

- item 3 (`default_code_formula_preset="default"` names no real preset) is #233;
- items 1, 2 and 4 are about the picture-description / code-formula / picture-classification registries only ever admitting what `allowed_*_presets` lists, so built-in ids are unreachable unless a deployer enumerates them. That is a deliberate-looking opt-in policy that differs from the VLM and OCR registries, and changing it would widen what those stages accept by default — a maintainer call, not a bug fix, so it is deliberately not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
