### PR TITLE
fix(manager): register the built-in presets that no allow-list is meant to exclude (#230)

### DIFF
--- a/docling_jobkit/convert/manager.py
+++ b/docling_jobkit/convert/manager.py
@@ -20,6 +20,9 @@ from docling.backend.pypdfium2_backend import PyPdfiumDocumentBackend
 from docling.datamodel import vlm_model_specs
 from docling.datamodel.base_models import DocumentStream, InputFormat
 from docling.datamodel.document import ConversionResult
+from docling.datamodel.picture_classification_options import (
+    DocumentPictureClassifierOptions,
+)
 from docling.datamodel.pipeline_options import (
     CodeFormulaVlmOptions,
     OcrOptions,
@@ -615,14 +618,19 @@ class DoclingConverterManager:
             "preset_id": self.config.default_picture_description_preset,
         }
 
-        # Add allowed presets if specified
-        if self.config.allowed_picture_description_presets is not None:
-            for preset_id in self.config.allowed_picture_description_presets:
-                if preset_id != "default":
-                    self.picture_description_preset_registry[preset_id] = {
-                        "source": "docling",
-                        "preset_id": preset_id,
-                    }
+        # Add Docling built-in presets (if allowed)
+        if self.config.allowed_picture_description_presets is None:
+            # Allow all Docling presets
+            preset_ids = PictureDescriptionVlmEngineOptions.list_preset_ids()
+        else:
+            # Only allow specified presets
+            preset_ids = self.config.allowed_picture_description_presets
+        for preset_id in preset_ids:
+            if preset_id != "default":
+                self.picture_description_preset_registry[preset_id] = {
+                    "source": "docling",
+                    "preset_id": preset_id,
+                }
 
         # Add custom presets
         for (
@@ -642,14 +650,19 @@ class DoclingConverterManager:
             "preset_id": self.config.default_code_formula_preset,
         }
 
-        # Add allowed presets if specified
-        if self.config.allowed_code_formula_presets is not None:
-            for preset_id in self.config.allowed_code_formula_presets:
-                if preset_id != "default":
-                    self.code_formula_preset_registry[preset_id] = {
-                        "source": "docling",
-                        "preset_id": preset_id,
-                    }
+        # Add Docling built-in presets (if allowed)
+        if self.config.allowed_code_formula_presets is None:
+            # Allow all Docling presets
+            preset_ids = CodeFormulaVlmOptions.list_preset_ids()
+        else:
+            # Only allow specified presets
+            preset_ids = self.config.allowed_code_formula_presets
+        for preset_id in preset_ids:
+            if preset_id != "default":
+                self.code_formula_preset_registry[preset_id] = {
+                    "source": "docling",
+                    "preset_id": preset_id,
+                }
 
         # Add custom presets
         for (
@@ -695,14 +708,19 @@ class DoclingConverterManager:
             "preset_id": self.config.default_picture_classification_preset,
         }
 
-        # Add allowed presets if specified
-        if self.config.allowed_picture_classification_presets is not None:
-            for preset_id in self.config.allowed_picture_classification_presets:
-                if preset_id != "default":
-                    self.picture_classification_preset_registry[preset_id] = {
-                        "source": "docling",
-                        "preset_id": preset_id,
-                    }
+        # Add Docling built-in presets (if allowed)
+        if self.config.allowed_picture_classification_presets is None:
+            # Allow all Docling presets
+            preset_ids = DocumentPictureClassifierOptions.list_preset_ids()
+        else:
+            # Only allow specified presets
+            preset_ids = self.config.allowed_picture_classification_presets
+        for preset_id in preset_ids:
+            if preset_id != "default":
+                self.picture_classification_preset_registry[preset_id] = {
+                    "source": "docling",
+                    "preset_id": preset_id,
+                }
 
         # Add custom presets
         for (

--- a/tests/test_converter_manager.py
+++ b/tests/test_converter_manager.py
@@ -2,6 +2,14 @@
 
 import pytest
 
+from docling.datamodel.picture_classification_options import (
+    DocumentPictureClassifierOptions,
+)
+from docling.datamodel.pipeline_options import (
+    CodeFormulaVlmOptions,
+    PictureDescriptionVlmEngineOptions,
+)
+
 from docling_jobkit.convert.manager import (
     DoclingConverterManager,
     DoclingConverterManagerConfig,
@@ -610,3 +618,79 @@ class TestGetVlmOptionsFromPreset:
         )
         assert options is not None
         assert options == custom_options
+
+
+class TestBuiltInPresetsAllowedByDefault:
+    """`allowed_*_presets=None` is documented as "None means all are allowed".
+
+    The VLM, OCR, chunking and table-structure registries honour that: with no
+    allow-list they enumerate every built-in preset. Picture-description,
+    code/formula and picture-classification instead only ever registered the
+    ``default`` alias, so every real Docling preset id was rejected with
+    "Allowed presets: default" -- the opposite of the documented contract.
+    """
+
+    @pytest.mark.parametrize(
+        "registry_name, expected_ids",
+        [
+            (
+                "picture_description_preset_registry",
+                PictureDescriptionVlmEngineOptions.list_preset_ids(),
+            ),
+            (
+                "code_formula_preset_registry",
+                CodeFormulaVlmOptions.list_preset_ids(),
+            ),
+            (
+                "picture_classification_preset_registry",
+                DocumentPictureClassifierOptions.list_preset_ids(),
+            ),
+        ],
+    )
+    def test_all_built_in_presets_registered_without_allow_list(
+        self, registry_name, expected_ids
+    ):
+        manager = DoclingConverterManager(DoclingConverterManagerConfig())
+
+        registry = getattr(manager, registry_name)
+
+        assert set(registry) == {"default", *expected_ids}
+
+    @pytest.mark.parametrize(
+        "config_field, registry_name, allowed",
+        [
+            (
+                "allowed_picture_description_presets",
+                "picture_description_preset_registry",
+                ["smolvlm"],
+            ),
+            (
+                "allowed_code_formula_presets",
+                "code_formula_preset_registry",
+                ["granite_docling"],
+            ),
+            (
+                "allowed_picture_classification_presets",
+                "picture_classification_preset_registry",
+                ["document_figure_classifier_v2"],
+            ),
+        ],
+    )
+    def test_allow_list_still_restricts(self, config_field, registry_name, allowed):
+        """An explicit allow-list must keep excluding everything else."""
+        config = DoclingConverterManagerConfig(**{config_field: allowed})
+        manager = DoclingConverterManager(config)
+
+        assert set(getattr(manager, registry_name)) == {"default", *allowed}
+
+    def test_layout_registry_is_kind_based_and_unchanged(self):
+        """Layout presets are factory *kinds*, not stage preset ids.
+
+        `_parse_layout_options` resolves a docling-source layout preset with
+        `layout_factory.create_options(kind=preset_id)`, so enumerating
+        `LayoutObjectDetectionOptions.list_preset_ids()` here would register ids
+        the factory cannot build. Layout is deliberately left alone.
+        """
+        manager = DoclingConverterManager(DoclingConverterManagerConfig())
+
+        assert set(manager.layout_preset_registry) == {"default"}


### PR DESCRIPTION
Fixes items 1, 2 and 4 of #230.

## The contract

Every `allowed_*_presets` field carries the same docstring:

> List of allowed \<stage\> preset IDs. **None means all are allowed.**

Four of the seven registries built in `_build_preset_registries` implement that:

| Registry | Source of built-ins when no allow-list |
|---|---|
| VLM | `VlmConvertOptions.list_preset_ids()` |
| Chunking | `CHUNKING_PRESETS` |
| OCR | every registered factory kind, then filtered |
| Table structure | its `built_in_presets` dict, then filtered |

Picture description, code/formula and picture classification register built-ins
only inside `if self.config.allowed_*_presets is not None:`. With the stock
config (`None`) that branch never runs, so the registry ends up holding nothing
but the `default` alias.

## Effect

Registry contents with a stock `DoclingConverterManagerConfig()`, before:

```
vlm                      n=19  [chandra_ocr2, deepseek_ocr, default, dolphin, ...]
ocr                      n= 9  [auto, default, easyocr, kserve_v2_ocr, ...]
chunking                 n= 5  [default, granite_embedding_278m, hierarchical, ...]
table_structure          n= 3  [tableformer_v1_accurate, tableformer_v1_fast, ...]
picture_description      n= 1  [default]      <-- 
code_formula             n= 1  [default]      <-- 
picture_classification   n= 1  [default]      <-- 
```

so every real preset id is rejected, by a message that states the
contradiction outright:

```
picture_description_preset: granite_vision
  -> ValueError: Picture description preset 'granite_vision' is not allowed.
     Allowed presets: default

code_formula_preset: codeformulav2
  -> ValueError: Code/formula preset 'codeformulav2' is not allowed.
     Allowed presets: default

picture_classification_preset: document_figure_classifier_v2
  -> ValueError: Unknown picture classification preset: document_figure_classifier_v2
```

The third is rejected even though `document_figure_classifier_v2` is the value
of `default_picture_classification_preset` — the shipped default is the one id
a request cannot name.

After, the three registries become `n=5` / `n=3` / `n=2`, matching their
`list_preset_ids()`, and all three requests above resolve.

## The change

The same shape the VLM registry already uses: pick `list_preset_ids()` when
there is no allow-list, the configured list otherwise, then run the existing
loop. `docling_jobkit/convert/manager.py` is +42/-24.

Behaviour that is deliberately unchanged, and covered by tests here:

- An explicit `allowed_*_presets` still restricts to exactly its entries.
- The `default` alias still resolves to the configured default.
- For picture classification the docling branch of `_create_options_from_preset`
  still returns `None` (the `PictureClassificationFactory` TODO already in the
  file). `document_figure_classifier_v2` therefore now behaves *identically to
  `default`*, which is what it is — this PR makes it addressable, it does not
  touch the stub.

## Deliberately not in scope

- **Layout** looks like a fourth instance of this pattern and is not one.
  `_parse_layout_options` resolves a docling-source preset with
  `layout_factory.create_options(kind=preset_id)` — for layout the registry's
  `preset_id` is a *factory kind*, not a stage preset id (`default_layout_preset`
  defaults to `docling_layout_default`, a kind). I did enumerate
  `LayoutObjectDetectionOptions.list_preset_ids()` there while writing this, and
  it turns a clean `ValueError` into a `RuntimeError` from the factory:

  ```
  RuntimeError: No class found with the name 'layout_egret_large', known classes are:
        'layout_object_detection' => LayoutObjectDetectionModel
        'docling_layout_default'  => LayoutModel
        ...
  ```

  So layout is left exactly as it is, and a test pins that. Whether
  `allowed_layout_presets` should mean kinds or presets is a separate question
  for you.
- **Items 3 and 5** of #230 are already open as #233 and #235; this PR does not
  touch those lines. Item 3 is visible from here — `code_formula_preset: default`
  still raises `KeyError` on unpatched `main` because `default_code_formula_preset`
  is the string `"default"` — and resolves once #233 lands. The two compose; they
  do not overlap.
- The documentation half of #230 ("say when callers must use the alias
  `default`") is not addressed.

## Tests

`tests/test_converter_manager.py` gains `TestBuiltInPresetsAllowedByDefault`
(7 cases). The 3 contract cases assert the **complete** registry key set equals
`{"default", *list_preset_ids()}` rather than membership, so a partial
registration would still fail them.

```
before this patch:  3 failed, 4 passed   (only the 3 contract cases fail)
after  this patch:  7 passed
whole file:        42 passed -> 49 passed
```

Verified on the pinned tooling: `ruff 0.11.5` format + lint clean
(`--config=pyproject.toml`), `mypy docling_jobkit/convert/manager.py` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
