### PR TITLE
fix(rq): clean up orphaned jobs from StartedJobRegistry

### DIFF
--- a/docling_jobkit/orchestrators/rq/orchestrator.py
+++ b/docling_jobkit/orchestrators/rq/orchestrator.py
@@ -710,13 +710,17 @@ class RQOrchestrator(BaseOrchestrator):
                                         connection=self._redis_conn,
                                     )
                                     job.set_status(JobStatus.FAILED)
+                                    registry.remove_executions(job)
+                                except NoSuchJobError:
+                                    _log.debug(
+                                        f"RQ job {tid} no longer exists, "
+                                        f"skipping started-registry cleanup"
+                                    )
                                 except Exception:
                                     _log.debug(
-                                        f"Could not set RQ job {tid} "
-                                        f"status to FAILED (may already "
-                                        f"be gone)"
+                                        f"Could not clean up RQ state for "
+                                        f"task {tid} (may already be gone)"
                                     )
-                                registry.remove(tid)
 
                             await asyncio.to_thread(_mark_rq_failed, task_id)
                             _log.info(

--- a/tests/test_rq_redis_durability_and_gate.py
+++ b/tests/test_rq_redis_durability_and_gate.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from rq.exceptions import NoSuchJobError
+from rq.job import JobStatus
 
 from docling.datamodel.service.targets import InBodyTarget
 
@@ -385,6 +386,106 @@ class TestRQRedisGate:
             async with orch._redis_gate.acquire(1.0):
                 with pytest.raises(asyncio.CancelledError):
                     await orch._watchdog_task()
+
+    @pytest.mark.asyncio
+    async def test_watchdog_orphan_uses_remove_executions(self):
+        from docling_jobkit.orchestrators.rq.orchestrator import (
+            _WATCHDOG_GRACE_PERIOD,
+        )
+
+        orch = _make_orchestrator()
+        orch._async_redis_conn.exists = AsyncMock(return_value=0)
+        orch._async_redis_conn.publish = AsyncMock()
+
+        job = MagicMock()
+        job.set_status = MagicMock()
+
+        base_time = datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)
+        future_time = base_time + datetime.timedelta(
+            seconds=_WATCHDOG_GRACE_PERIOD + 60
+        )
+
+        registry = MagicMock()
+        registry.get_job_ids.return_value = ["orphan-1"]
+
+        fake_dt = MagicMock()
+        fake_dt.now = MagicMock(side_effect=[base_time, future_time])
+        fake_dt.timezone = datetime.timezone
+
+        sleep_mock = AsyncMock(side_effect=[None, None, asyncio.CancelledError()])
+        with (
+            patch(
+                "docling_jobkit.orchestrators.rq.orchestrator.StartedJobRegistry",
+                return_value=registry,
+            ),
+            patch(
+                "docling_jobkit.orchestrators.rq.orchestrator.Job.fetch",
+                return_value=job,
+            ) as fetch_mock,
+            patch(
+                "docling_jobkit.orchestrators.rq.orchestrator.asyncio.sleep",
+                sleep_mock,
+            ),
+            patch(
+                "docling_jobkit.orchestrators.rq.orchestrator.datetime.datetime",
+                new=fake_dt,
+            ),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await orch._watchdog_task()
+
+        fetch_mock.assert_called()
+        job.set_status.assert_called_once_with(JobStatus.FAILED)
+        registry.remove_executions.assert_called_once_with(job)
+        registry.remove.assert_not_called()
+        orch._async_redis_conn.publish.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_watchdog_missing_job_is_nonfatal(self):
+        from docling_jobkit.orchestrators.rq.orchestrator import (
+            _WATCHDOG_GRACE_PERIOD,
+        )
+
+        orch = _make_orchestrator()
+        orch._async_redis_conn.exists = AsyncMock(return_value=0)
+        orch._async_redis_conn.publish = AsyncMock()
+
+        base_time = datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)
+        future_time = base_time + datetime.timedelta(
+            seconds=_WATCHDOG_GRACE_PERIOD + 60
+        )
+
+        registry = MagicMock()
+        registry.get_job_ids.return_value = ["gone-1"]
+
+        fake_dt = MagicMock()
+        fake_dt.now = MagicMock(side_effect=[base_time, future_time])
+        fake_dt.timezone = datetime.timezone
+
+        sleep_mock = AsyncMock(side_effect=[None, None, asyncio.CancelledError()])
+        with (
+            patch(
+                "docling_jobkit.orchestrators.rq.orchestrator.StartedJobRegistry",
+                return_value=registry,
+            ),
+            patch(
+                "docling_jobkit.orchestrators.rq.orchestrator.Job.fetch",
+                side_effect=NoSuchJobError("already expired"),
+            ),
+            patch(
+                "docling_jobkit.orchestrators.rq.orchestrator.asyncio.sleep",
+                sleep_mock,
+            ),
+            patch(
+                "docling_jobkit.orchestrators.rq.orchestrator.datetime.datetime",
+                new=fake_dt,
+            ),
+        ):
+            with pytest.raises(asyncio.CancelledError):
+                await orch._watchdog_task()
+
+        registry.remove.assert_not_called()
+        registry.remove_executions.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_reaper_is_not_gated(self):


### PR DESCRIPTION
## AI disclosure

I encountered this issue in my deployment. This pull request was prepared with assistance from AI. I reviewed the proposed change, test coverage, and validation results before submitting it.

## Summary

The RQ watchdog cleanup path calls `StartedJobRegistry.remove(task_id)`. In RQ 2.x this method is abstract and raises `NotImplementedError`, leaving orphaned jobs in the started registry.

This pull request replaces that call with the execution-aware `remove_executions(job)` API and adds regression coverage for both successful cleanup and an already-expired RQ job.

**Issue resolved by this Pull Request:**
Resolves #237

## Root cause

When a worker loses its heartbeat, the watchdog publishes a `FAILURE` update and marks the RQ job as failed. The cleanup then calls `StartedJobRegistry.remove(task_id)`, which is not implemented by the RQ 2.x registry and raises `NotImplementedError`.

## Changes

- Mark the fetched RQ job as `FAILED` and remove its execution with `StartedJobRegistry.remove_executions(job)`.
- Treat `NoSuchJobError` as a non-fatal race when the RQ job has already expired or been deleted.
- Add watchdog regression tests asserting the execution-aware cleanup path and missing-job behavior.

## Validation

- `uv run pytest tests/test_rq_redis_durability_and_gate.py -q` -> 21 passed
- `uv run ruff check docling_jobkit/orchestrators/rq/orchestrator.py tests/test_rq_redis_durability_and_gate.py` -> passed
- `uv run ruff format --check docling_jobkit/orchestrators/rq/orchestrator.py tests/test_rq_redis_durability_and_gate.py` -> passed
- `git diff --check` -> passed
- Live API/Valkey smoke test with an isolated RQ `STARTED` job and missing heartbeat -> watchdog changed the job to `FAILED` and removed it from the started registry without `NotImplementedError`
