### PR TITLE
fix(ray): prevent tenant limit counter races

### DIFF
--- a/docling_jobkit/orchestrators/ray/redis_helper.py
+++ b/docling_jobkit/orchestrators/ray/redis_helper.py
@@ -638,22 +638,21 @@ class RedisStateManager:
             await self.connect()
 
         limits_key = f"tenant:{tenant_id}:limits"
-
-        # Get current limits or initialize
-        limits = await self.get_tenant_limits(tenant_id)
-
-        # Update counters
-        limits.active_tasks = max(0, limits.active_tasks + delta_active_tasks)
-        limits.queued_tasks = max(0, limits.queued_tasks + delta_queued_tasks)
-        limits.active_documents = max(0, limits.active_documents + delta_docs)
-
-        # Store updated limits
-        limits_dict = limits.model_dump()
-        # Convert None to string for Redis
-        limits_dict = {k: str(v) for k, v in limits_dict.items()}
-
         redis = self._ensure_redis()
-        await redis.hset(limits_key, mapping=limits_dict)  # type: ignore[misc]
+
+        async with redis.pipeline(transaction=True) as pipe:
+            pipe.hsetnx(
+                limits_key, "max_concurrent_tasks", str(self.max_concurrent_tasks)
+            )
+            pipe.hsetnx(limits_key, "max_queued_tasks", str(self.max_queued_tasks))
+            pipe.hsetnx(limits_key, "max_documents", str(self.max_documents))
+            if delta_active_tasks:
+                pipe.hincrby(limits_key, "active_tasks", delta_active_tasks)
+            if delta_queued_tasks:
+                pipe.hincrby(limits_key, "queued_tasks", delta_queued_tasks)
+            if delta_docs:
+                pipe.hincrby(limits_key, "active_documents", delta_docs)
+            await pipe.execute()
 
     async def check_tenant_can_enqueue(
         self, tenant_id: str, task_size: int
@@ -1185,26 +1184,64 @@ class RedisStateManager:
 
     async def resync_tenant_limits(self, tenant_id: str) -> TenantLimits:
         """Resynchronize tenant counters from canonical Redis structures."""
-        active_task_ids = await self.get_tenant_active_task_ids(tenant_id)
-        active_documents = 0
-        converter_units = 0
-        for task_id in active_task_ids:
-            active_documents += await self._get_task_size_for_resync(task_id)
-            lease = await self.get_task_execution_lease(task_id)
-            if lease is not None:
-                converter_units += int(lease.get("converter_units") or 0)
-
-        limits = await self.get_tenant_limits(tenant_id)
-        limits.active_tasks = len(active_task_ids)
-        limits.queued_tasks = await self.get_tenant_queue_size(tenant_id)
-        limits.active_documents = active_documents
-        limits.converter_units = converter_units
+        if not self.redis:
+            await self.connect()
 
         limits_key = f"tenant:{tenant_id}:limits"
-        limits_dict = {key: str(value) for key, value in limits.model_dump().items()}
+        active_key = f"tenant:{tenant_id}:active_tasks"
+        queue_key = f"tenant:{tenant_id}:tasks"
         redis = self._ensure_redis()
-        await redis.hset(limits_key, mapping=limits_dict)  # type: ignore[misc]
-        return limits
+
+        for _ in range(3):
+            async with redis.pipeline(transaction=True) as pipe:
+                try:
+                    await pipe.watch(active_key, queue_key, limits_key)
+
+                    active_task_ids = await self.get_tenant_active_task_ids(tenant_id)
+                    active_documents = 0
+                    converter_units = 0
+                    for task_id in active_task_ids:
+                        active_documents += await self._get_task_size_for_resync(
+                            task_id
+                        )
+                        lease = await self.get_task_execution_lease(task_id)
+                        if lease is not None:
+                            converter_units += int(lease.get("converter_units") or 0)
+
+                    limits = await self.get_tenant_limits(tenant_id)
+                    limits.active_tasks = len(active_task_ids)
+                    limits.queued_tasks = await self.get_tenant_queue_size(tenant_id)
+                    limits.active_documents = active_documents
+                    limits.converter_units = converter_units
+
+                    pipe.multi()
+                    pipe.hsetnx(
+                        limits_key,
+                        "max_concurrent_tasks",
+                        str(self.max_concurrent_tasks),
+                    )
+                    pipe.hsetnx(
+                        limits_key, "max_queued_tasks", str(self.max_queued_tasks)
+                    )
+                    pipe.hsetnx(limits_key, "max_documents", str(self.max_documents))
+                    pipe.hset(
+                        limits_key,
+                        mapping={
+                            "active_tasks": str(limits.active_tasks),
+                            "queued_tasks": str(limits.queued_tasks),
+                            "active_documents": str(limits.active_documents),
+                            "converter_units": str(limits.converter_units),
+                        },
+                    )
+                    await pipe.execute()
+                except WatchError:
+                    continue
+                return limits
+
+        _log.warning(
+            "Tenant limits resync deferred after repeated contention: %s", tenant_id
+        )
+        return await self.get_tenant_limits(tenant_id)
 
     async def get_task_dispatch_hash(self, task_id: str) -> dict:
         """Get the dispatcher-owned dispatch state hash for a task.

--- a/docling_jobkit/orchestrators/ray/redis_helper.py
+++ b/docling_jobkit/orchestrators/ray/redis_helper.py
@@ -1186,9 +1186,6 @@ class RedisStateManager:
 
     async def resync_tenant_limits(self, tenant_id: str) -> TenantLimits:
         """Resynchronize tenant counters from canonical Redis structures."""
-        if not self.redis:
-            await self.connect()
-
         limits_key = f"tenant:{tenant_id}:limits"
         active_key = f"tenant:{tenant_id}:active_tasks"
         queue_key = f"tenant:{tenant_id}:tasks"

--- a/docling_jobkit/orchestrators/ray/redis_helper.py
+++ b/docling_jobkit/orchestrators/ray/redis_helper.py
@@ -640,6 +640,8 @@ class RedisStateManager:
         limits_key = f"tenant:{tenant_id}:limits"
         redis = self._ensure_redis()
 
+        # Change only the requested fields atomically. The old read/modify/write
+        # of the whole hash could restore counters changed by another worker.
         async with redis.pipeline(transaction=True) as pipe:
             pipe.hsetnx(
                 limits_key, "max_concurrent_tasks", str(self.max_concurrent_tasks)
@@ -1192,6 +1194,9 @@ class RedisStateManager:
         queue_key = f"tenant:{tenant_id}:tasks"
         redis = self._ensure_redis()
 
+        # Unlike the atomic increments above, resync derives one snapshot from
+        # several keys. WATCH rejects a stale snapshot; three attempts absorb a
+        # transient conflict without letting a hot tenant stall reconciliation.
         for _ in range(3):
             async with redis.pipeline(transaction=True) as pipe:
                 try:

--- a/docs/plans/redis-tenant-limits-bookkeeping-race-handoff.md
+++ b/docs/plans/redis-tenant-limits-bookkeeping-race-handoff.md
@@ -1,189 +1,89 @@
-# Handoff: suspected Redis tenant-limits bookkeeping race
+# Plan: prevent Redis tenant-limit bookkeeping races
 
-## Status
+## Context
 
-Confirmed. The suspected read-modify-write race is reproduced by a deterministic
-regression test, `test_enqueue_limits_update_does_not_restore_stale_active_usage`
-in `tests/test_ray_lifecycle_counters.py`. On the current code that test fails:
-the final state is `active_tasks=1, queued_tasks=1` over an empty active set —
-the production `BLOCKED_RACE_SIGNATURE`. It is checked in as `xfail(strict=True)`;
-applying the fix in [How to fix](#how-to-fix) flips it to a real pass, at which
-point the marker is removed. See [Confirmation](#confirmation) for details.
+Ray admission reads usage counters from `tenant:<id>:limits`. The tenant queue
+and active-task set are the canonical occupancy state; the limits hash contains
+derived counters such as `queued_tasks`, `active_tasks`, `active_documents`, and
+`converter_units`.
 
-## Incident context
+Two write paths can overwrite concurrent changes with stale values:
 
-All identifiers in this document are synthetic. The affected tenant is called
-`tenant-A`, the task being watched is `task-observed`, and earlier tasks are
-named by their role in the sequence.
+- `update_tenant_limits()` reads and rewrites the complete limits hash to change
+  individual counters.
+- `resync_tenant_limits()` derives counters from several Redis keys and writes
+  them after the source state may have changed.
 
-The client-facing trigger was accepted work remaining pending, the tenant queue
-not moving, and no new tasks beginning processing.
+A stale `active_tasks` value can reach the tenant concurrency limit while the
+active-task set is empty, preventing queued tasks from dispatching.
 
-For `tenant-A` we observed:
+## Implementation
 
-- `task-observed` was accepted and enqueued, but there was no dispatch or task
-  start log for it. Repeated status polling continued to return the pending task.
-- Redis still contained `task-observed` in the tenant queue. It was at position
-  51 in a queue of 52 pending tasks, so it had not been removed or lost between
-  Redis and Ray.
-- The last two tasks dispatched before the queue stopped both reached durable
-  `success`. Their execution completed normally and their results were fetched.
-- The dispatcher heartbeat was current.
-- The canonical active-task set was empty, and there were no remaining dispatch
-  or execution lease hashes for the tenant.
-- The tenant limits hash nevertheless reported:
+### 1. Make incremental updates atomic
 
-  ```text
-  max_concurrent_tasks = 12
-  active_tasks         = 12
-  queued_tasks         = 52
-  active_documents     = 1
-  converter_units      = 5
-  ```
+Change `update_tenant_limits()` to update only the requested fields:
 
-- The monotonic lifecycle counters agreed with the queue: enqueued minus
-  dispatched was 52.
+- Initialize missing configuration fields with `HSETNX`.
+- Apply non-zero counter deltas with `HINCRBY`.
+- Execute the commands in one transactional pipeline.
+- Remove the full-hash `get_tenant_limits()` read and `HSET` rewrite.
 
-### Key observed symptom
+This path needs no retry because it does not compute or write a snapshot.
 
-The decisive Redis symptom was the disagreement between the canonical active
-set and the derived limits hash while the queue remained non-empty:
+### 2. Protect resynchronization from stale snapshots
 
-```text
-LLEN  tenant:tenant-A:tasks                         = 52
-SCARD tenant:tenant-A:active_tasks                  = 0
-HGET  tenant:tenant-A:limits active_tasks           = 12
-HGET  tenant:tenant-A:limits max_concurrent_tasks   = 12
-```
+Change `resync_tenant_limits()` to use Redis optimistic locking:
 
-This state blocks all further dispatch. Redis has no active-task members, but
-`check_tenant_can_process()` rejects the next queued task because the derived
-limits hash says `active_tasks == max_concurrent_tasks`. Both the false capacity
-gate and the race that produced the stale hash are now confirmed — the gate by
-the production observation and recovery, the race by the regression test.
+1. `WATCH` the tenant active-task set, queue, and limits hash.
+2. Recompute active tasks, queued tasks, active documents, and converter units
+   from the canonical Redis structures.
+3. Start `MULTI` and write only those four derived counters. Initialize missing
+   configuration fields with `HSETNX`.
+4. Execute the transaction. If a watched key changed, retry from a fresh
+   snapshot.
 
-## Recovery observation
+Limit resynchronization to three attempts. After three conflicts, log a warning
+and return the current stored limits. The existing reconciliation cycle will
+try again later; an unbounded retry loop could stall dispatch for a busy tenant.
 
-After confirming the active set was empty, no dispatch or execution leases
-remained, the dispatcher heartbeat was fresh, and the queue count matched the
-derived queued count, operations reset only these stale derived fields to zero:
-`active_tasks`, `active_documents`, and `converter_units`.
+### 3. Test against real Redis
 
-The existing queue then drained without deleting or re-enqueuing any task. The
-watched pending task advanced through start and success, all queued work
-completed, and the queue, active set, and usage gauges returned to zero. The
-monotonic lifecycle counters also converged with every dispatched task reaching
-a terminal state.
+Use the Redis service already provided by CI for transaction tests:
 
-This recovery confirmed the immediate causal mechanism: stale values in the
-limits hash can falsely close the capacity gate while canonical Redis state has
-no active work. The read-modify-write interleaving that produces the stale hash
-is now independently confirmed by the regression test (see
-[Confirmation](#confirmation)).
+- Read `REDIS_URL`, defaulting to `redis://localhost:6379/0`.
+- Require a successful `PING` rather than skipping the tests.
+- Use unique tenant and task IDs and delete only their exact keys afterward.
+- Keep the existing in-memory fake for ordinary counter tests; do not emulate
+  `WATCH`, `MULTI`, or `EXEC` in it.
 
-## Root cause (confirmed)
+Cover these cases:
 
-`RedisStateManager.update_tenant_limits()` performs a non-atomic
-read-modify-write of the entire tenant limits hash:
+- Updating `queued_tasks` does not overwrite `active_tasks`.
+- A concurrent finalization invalidates the first resync snapshot; the retry
+  stores `active_tasks=0` and admission allows new work.
+- Continuous contention stops after three attempts, does not write stale
+  counters, logs the deferral, and allows a later uncontended resync to repair
+  the hash.
 
-1. `get_tenant_limits()` reads every field into a `TenantLimits` snapshot.
-2. Python changes one or more fields on that snapshot.
-3. `HSET ... mapping=limits.model_dump()` writes every field back.
-
-`enqueue_task()` first appends the task and increments the monotonic enqueue
-counter atomically, then separately calls `update_tenant_limits()` to increment
-`queued_tasks`.
-
-Terminalization uses a Redis transaction to remove the task from the active set
-and decrement `active_tasks`. These two paths can interleave as follows:
-
-```text
-Initial state:
-  active set = {task-running}
-  limits.active_tasks = 1
-  limits.queued_tasks = 0
-
-Enqueue path:
-  reads a full limits snapshot: active_tasks=1, queued_tasks=0
-  pauses
-
-Terminalization path:
-  marks task-running successful
-  removes task-running from the active set
-  decrements limits.active_tasks to 0
-
-Enqueue path resumes:
-  increments queued_tasks in its stale snapshot
-  writes the full snapshot:
-    active_tasks=1, queued_tasks=1
-
-Final state:
-  active set = {}
-  limits.active_tasks = 1
-  limits.queued_tasks = 1
-```
-
-With a concurrency limit of one, this minimal interleaving wedges the tenant.
-The production value of 12 is the same failure at a larger scale. Because the
-full hash is rewritten, the same race can also restore stale
-`active_documents` or `converter_units` values.
-
-The inconsistency does not self-heal: reconciliation enumerates tenants from
-non-empty active-task sets. A tenant whose canonical active set is already empty
-is not selected for `resync_tenant_limits()`.
-
-## Confirmation
-
-Reproduced by `test_enqueue_limits_update_does_not_restore_stale_active_usage`
-in `tests/test_ray_lifecycle_counters.py`, using the file's in-memory Redis fake
-— no Ray, no live Redis, no sleeps. It seeds one running task
-(`active_tasks=1`, `queued_tasks=0`, `max_concurrent_tasks=1`), pauses the
-enqueue coroutine right after it captures its limits snapshot, runs
-`finalize_task_success_atomic()` to completion (active set → empty,
-`active_tasks` → 0), then releases enqueue and asserts the invariant that should
-hold:
-
-```python
-assert await manager.get_tenant_active_task_count("tenant-A") == 0
-assert (await manager.get_tenant_limits("tenant-A")).active_tasks == 0
-assert (await manager.get_tenant_limits("tenant-A")).queued_tasks == 1
-assert (await manager.check_tenant_can_process("tenant-A", 1))[0]
-```
-
-On current code the enqueue's final `HSET` restores `active_tasks=1`, so the
-assertion fails with `active_tasks=1, queued_tasks=1` over an empty active set —
-the runbook's `BLOCKED_RACE_SIGNATURE`. The test is checked in as
-`xfail(strict=True)` so it stays green until the fix lands and then, on passing,
-turns the strict-xfail into a failure that forces the marker's removal. Run it:
+Run:
 
 ```bash
-.venv/bin/pytest -q tests/test_ray_lifecycle_counters.py \
-  -k enqueue_limits_update_does_not_restore_stale_active_usage
+.venv/bin/pytest -q \
+  tests/test_ray_lifecycle_counters.py \
+  tests/test_ray_dispatcher_hardening.py
 ```
 
-(Adding this test also required a direct awaited `hset` on the file's fake Redis;
-earlier tests had stubbed `update_tenant_limits()` out, so the fake never
-exercised it.)
+## Acceptance criteria
 
-## How to fix
+- Incremental updates never rewrite unrelated limits fields.
+- Resync commits only when its watched snapshot remains current.
+- Resync retries are bounded and cannot stall the dispatcher indefinitely.
+- The focused tests pass against real Redis.
+- No new retry setting, repair loop, dependency, or Redis transaction emulator
+  is added.
 
-Replace the whole-hash read-modify-write in `update_tenant_limits()` with atomic
-per-field `HINCRBY`s — the same primitive terminalization already uses (the
-`HINCRBY active_tasks -1` inside `_finalize_task_terminal_state_atomic()`). Each
-caller then writes only the fields it owns via its deltas (`delta_queued_tasks`,
-`delta_active_tasks`, `delta_docs`), never a field it did not change, so a
-concurrent finalize's decrement can no longer be clobbered. Seed the immutable
-config fields (`max_concurrent_tasks`, `max_queued_tasks`, `max_documents`) once
-at tenant init rather than on every counter update.
+## Out of scope
 
-One gotcha: `HINCRBY` cannot clamp at zero the way today's `max(0, ...)` does.
-Once the writes are atomic a counter should not go negative; if a floor is still
-wanted, apply it in a small Lua/`WATCH` step rather than reintroducing the
-read-modify-write.
-
-Do not add dispatcher retries or a periodic repair loop — those treat the
-symptom. Both callers of `update_tenant_limits()` stay: enqueue increments
-`queued_tasks`, the legacy dequeue path decrements it. Terminalization and
-dispatch already mutate usage fields inside Redis transactions and must not be
-overwritten by either caller. When the fix lands, remove the test's
-`xfail(strict=True)` marker.
+Redis Cluster requires all transaction keys to share a hash slot. Migrating the
+existing tenant key layout is separate work; this change targets standalone
+Redis or Valkey and Sentinel deployments.

--- a/docs/plans/redis-tenant-limits-bookkeeping-race-handoff.md
+++ b/docs/plans/redis-tenant-limits-bookkeeping-race-handoff.md
@@ -1,0 +1,189 @@
+# Handoff: suspected Redis tenant-limits bookkeeping race
+
+## Status
+
+Confirmed. The suspected read-modify-write race is reproduced by a deterministic
+regression test, `test_enqueue_limits_update_does_not_restore_stale_active_usage`
+in `tests/test_ray_lifecycle_counters.py`. On the current code that test fails:
+the final state is `active_tasks=1, queued_tasks=1` over an empty active set —
+the production `BLOCKED_RACE_SIGNATURE`. It is checked in as `xfail(strict=True)`;
+applying the fix in [How to fix](#how-to-fix) flips it to a real pass, at which
+point the marker is removed. See [Confirmation](#confirmation) for details.
+
+## Incident context
+
+All identifiers in this document are synthetic. The affected tenant is called
+`tenant-A`, the task being watched is `task-observed`, and earlier tasks are
+named by their role in the sequence.
+
+The client-facing trigger was accepted work remaining pending, the tenant queue
+not moving, and no new tasks beginning processing.
+
+For `tenant-A` we observed:
+
+- `task-observed` was accepted and enqueued, but there was no dispatch or task
+  start log for it. Repeated status polling continued to return the pending task.
+- Redis still contained `task-observed` in the tenant queue. It was at position
+  51 in a queue of 52 pending tasks, so it had not been removed or lost between
+  Redis and Ray.
+- The last two tasks dispatched before the queue stopped both reached durable
+  `success`. Their execution completed normally and their results were fetched.
+- The dispatcher heartbeat was current.
+- The canonical active-task set was empty, and there were no remaining dispatch
+  or execution lease hashes for the tenant.
+- The tenant limits hash nevertheless reported:
+
+  ```text
+  max_concurrent_tasks = 12
+  active_tasks         = 12
+  queued_tasks         = 52
+  active_documents     = 1
+  converter_units      = 5
+  ```
+
+- The monotonic lifecycle counters agreed with the queue: enqueued minus
+  dispatched was 52.
+
+### Key observed symptom
+
+The decisive Redis symptom was the disagreement between the canonical active
+set and the derived limits hash while the queue remained non-empty:
+
+```text
+LLEN  tenant:tenant-A:tasks                         = 52
+SCARD tenant:tenant-A:active_tasks                  = 0
+HGET  tenant:tenant-A:limits active_tasks           = 12
+HGET  tenant:tenant-A:limits max_concurrent_tasks   = 12
+```
+
+This state blocks all further dispatch. Redis has no active-task members, but
+`check_tenant_can_process()` rejects the next queued task because the derived
+limits hash says `active_tasks == max_concurrent_tasks`. Both the false capacity
+gate and the race that produced the stale hash are now confirmed — the gate by
+the production observation and recovery, the race by the regression test.
+
+## Recovery observation
+
+After confirming the active set was empty, no dispatch or execution leases
+remained, the dispatcher heartbeat was fresh, and the queue count matched the
+derived queued count, operations reset only these stale derived fields to zero:
+`active_tasks`, `active_documents`, and `converter_units`.
+
+The existing queue then drained without deleting or re-enqueuing any task. The
+watched pending task advanced through start and success, all queued work
+completed, and the queue, active set, and usage gauges returned to zero. The
+monotonic lifecycle counters also converged with every dispatched task reaching
+a terminal state.
+
+This recovery confirmed the immediate causal mechanism: stale values in the
+limits hash can falsely close the capacity gate while canonical Redis state has
+no active work. The read-modify-write interleaving that produces the stale hash
+is now independently confirmed by the regression test (see
+[Confirmation](#confirmation)).
+
+## Root cause (confirmed)
+
+`RedisStateManager.update_tenant_limits()` performs a non-atomic
+read-modify-write of the entire tenant limits hash:
+
+1. `get_tenant_limits()` reads every field into a `TenantLimits` snapshot.
+2. Python changes one or more fields on that snapshot.
+3. `HSET ... mapping=limits.model_dump()` writes every field back.
+
+`enqueue_task()` first appends the task and increments the monotonic enqueue
+counter atomically, then separately calls `update_tenant_limits()` to increment
+`queued_tasks`.
+
+Terminalization uses a Redis transaction to remove the task from the active set
+and decrement `active_tasks`. These two paths can interleave as follows:
+
+```text
+Initial state:
+  active set = {task-running}
+  limits.active_tasks = 1
+  limits.queued_tasks = 0
+
+Enqueue path:
+  reads a full limits snapshot: active_tasks=1, queued_tasks=0
+  pauses
+
+Terminalization path:
+  marks task-running successful
+  removes task-running from the active set
+  decrements limits.active_tasks to 0
+
+Enqueue path resumes:
+  increments queued_tasks in its stale snapshot
+  writes the full snapshot:
+    active_tasks=1, queued_tasks=1
+
+Final state:
+  active set = {}
+  limits.active_tasks = 1
+  limits.queued_tasks = 1
+```
+
+With a concurrency limit of one, this minimal interleaving wedges the tenant.
+The production value of 12 is the same failure at a larger scale. Because the
+full hash is rewritten, the same race can also restore stale
+`active_documents` or `converter_units` values.
+
+The inconsistency does not self-heal: reconciliation enumerates tenants from
+non-empty active-task sets. A tenant whose canonical active set is already empty
+is not selected for `resync_tenant_limits()`.
+
+## Confirmation
+
+Reproduced by `test_enqueue_limits_update_does_not_restore_stale_active_usage`
+in `tests/test_ray_lifecycle_counters.py`, using the file's in-memory Redis fake
+— no Ray, no live Redis, no sleeps. It seeds one running task
+(`active_tasks=1`, `queued_tasks=0`, `max_concurrent_tasks=1`), pauses the
+enqueue coroutine right after it captures its limits snapshot, runs
+`finalize_task_success_atomic()` to completion (active set → empty,
+`active_tasks` → 0), then releases enqueue and asserts the invariant that should
+hold:
+
+```python
+assert await manager.get_tenant_active_task_count("tenant-A") == 0
+assert (await manager.get_tenant_limits("tenant-A")).active_tasks == 0
+assert (await manager.get_tenant_limits("tenant-A")).queued_tasks == 1
+assert (await manager.check_tenant_can_process("tenant-A", 1))[0]
+```
+
+On current code the enqueue's final `HSET` restores `active_tasks=1`, so the
+assertion fails with `active_tasks=1, queued_tasks=1` over an empty active set —
+the runbook's `BLOCKED_RACE_SIGNATURE`. The test is checked in as
+`xfail(strict=True)` so it stays green until the fix lands and then, on passing,
+turns the strict-xfail into a failure that forces the marker's removal. Run it:
+
+```bash
+.venv/bin/pytest -q tests/test_ray_lifecycle_counters.py \
+  -k enqueue_limits_update_does_not_restore_stale_active_usage
+```
+
+(Adding this test also required a direct awaited `hset` on the file's fake Redis;
+earlier tests had stubbed `update_tenant_limits()` out, so the fake never
+exercised it.)
+
+## How to fix
+
+Replace the whole-hash read-modify-write in `update_tenant_limits()` with atomic
+per-field `HINCRBY`s — the same primitive terminalization already uses (the
+`HINCRBY active_tasks -1` inside `_finalize_task_terminal_state_atomic()`). Each
+caller then writes only the fields it owns via its deltas (`delta_queued_tasks`,
+`delta_active_tasks`, `delta_docs`), never a field it did not change, so a
+concurrent finalize's decrement can no longer be clobbered. Seed the immutable
+config fields (`max_concurrent_tasks`, `max_queued_tasks`, `max_documents`) once
+at tenant init rather than on every counter update.
+
+One gotcha: `HINCRBY` cannot clamp at zero the way today's `max(0, ...)` does.
+Once the writes are atomic a counter should not go negative; if a floor is still
+wanted, apply it in a small Lua/`WATCH` step rather than reintroducing the
+read-modify-write.
+
+Do not add dispatcher retries or a periodic repair loop — those treat the
+symptom. Both callers of `update_tenant_limits()` stay: enqueue increments
+`queued_tasks`, the legacy dequeue path decrements it. Terminalization and
+dispatch already mutate usage fields inside Redis transactions and must not be
+overwritten by either caller. When the fix lands, remove the test's
+`xfail(strict=True)` marker.

--- a/tests/test_ray_dispatcher_hardening.py
+++ b/tests/test_ray_dispatcher_hardening.py
@@ -1110,47 +1110,6 @@ async def test_reconcile_started_task_without_lease_within_grace_is_unresolved()
 
 
 @pytest.mark.asyncio
-async def test_resync_tenant_limits_rebuilds_counters_from_canonical_structures() -> (
-    None
-):
-    manager = RedisStateManager(redis_url="redis://localhost:6379/")
-    manager.redis = AsyncMock()
-    manager.get_tenant_active_task_ids = AsyncMock(return_value=["task-1", "task-2"])
-    manager.get_task_metadata_model = AsyncMock(
-        side_effect=[
-            RedisTaskMetadata(
-                task_id="task-1",
-                tenant_id="tenant-a",
-                status=TaskStatus.STARTED,
-                task_type=TaskType.CONVERT,
-                task_size=2,
-                created_at=datetime.datetime.now(datetime.timezone.utc),
-                last_update_at=datetime.datetime.now(datetime.timezone.utc),
-            ),
-            None,
-        ]
-    )
-    manager.get_tenant_limits = AsyncMock(
-        return_value=TenantLimits(max_concurrent_tasks=5)
-    )
-    manager.get_tenant_queue_size = AsyncMock(return_value=3)
-    manager.get_task_execution_lease = AsyncMock(
-        side_effect=[
-            {"replica_id": "r1", "converter_units": "2"},
-            None,
-        ]
-    )
-
-    limits = await manager.resync_tenant_limits("tenant-a")
-
-    assert limits.active_tasks == 2
-    assert limits.queued_tasks == 3
-    assert limits.active_documents == 3
-    assert limits.converter_units == 2
-    manager.redis.hset.assert_awaited_once()
-
-
-@pytest.mark.asyncio
 async def test_refresh_runtime_and_get_health_do_not_race_loop_startup() -> None:
     dispatcher = _make_dispatcher()
     dispatcher.redis_manager.connect = AsyncMock()

--- a/tests/test_ray_lifecycle_counters.py
+++ b/tests/test_ray_lifecycle_counters.py
@@ -5,15 +5,16 @@ cumulative counters in a ``tenant:{id}:task_counters`` Redis hash, incremented
 atomically at each transition. docling-serve exposes these as Prometheus
 counters so transitions that happen between two scrapes are never lost.
 
-The suite has no live Redis, so these tests run against a small in-memory fake
-that faithfully models the Redis commands the instrumented code paths use
-(hashes, lists, sets, transactional pipelines, and the mark-started Lua script).
-This mirrors the hermetic style of ``test_ray_converter_units.py``.
+Ordinary counter tests use a small in-memory fake. Transaction race tests use
+the real Redis service provided by CI.
 """
 
 import asyncio
+import os
+import uuid
 
 import pytest
+import pytest_asyncio
 
 pytest.importorskip("msgpack")
 pytest.importorskip("redis")
@@ -210,6 +211,37 @@ def _task(task_id: str, n_sources: int = 1) -> Task:
     )
 
 
+@pytest_asyncio.fixture
+async def real_redis():
+    prefix = uuid.uuid4().hex
+    tenant_id = f"test-{prefix}"
+    task_id = f"test-{prefix}-task"
+    manager = RedisStateManager(
+        redis_url=os.getenv("REDIS_URL", "redis://localhost:6379/0")
+    )
+    await manager.connect()
+    redis = manager._ensure_redis()
+    try:
+        await redis.ping()
+    except Exception as exc:
+        await manager.disconnect()
+        pytest.fail(f"Redis is required for transaction tests: {exc}")
+
+    try:
+        yield manager, redis, tenant_id, task_id
+    finally:
+        await redis.delete(
+            f"tenant:{tenant_id}:active_tasks",
+            f"tenant:{tenant_id}:tasks",
+            f"tenant:{tenant_id}:limits",
+            f"tenant:{tenant_id}:task_counters",
+            f"task:{task_id}",
+            f"task:{task_id}:dispatch",
+            f"task:{task_id}:execution",
+        )
+        await manager.disconnect()
+
+
 # --- get_tenant_task_counters --------------------------------------------------
 
 
@@ -380,81 +412,83 @@ async def test_finalize_is_exactly_once_first_terminal_wins() -> None:
 # --- bookkeeping race between enqueue and terminalization ----------------------
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason="Confirmed bug: update_tenant_limits does a non-atomic whole-hash "
-    "read-modify-write (HGETALL->mutate->HSET) that clobbers a concurrent "
-    "finalize's HINCRBY. Remove this marker when update_tenant_limits switches "
-    "to per-field HINCRBY. See "
-    "docs/plans/redis-tenant-limits-bookkeeping-race-handoff.md.",
-)
 @pytest.mark.asyncio
-async def test_enqueue_limits_update_does_not_restore_stale_active_usage() -> None:
-    """A concurrent finalize must not be clobbered by enqueue's limits write.
-
-    ``update_tenant_limits`` does a non-atomic read-modify-write of the whole
-    limits hash (HGETALL -> mutate -> HSET mapping), while terminalization does
-    per-field HINCRBY under WATCH. If a finalize lands inside the enqueue read
-    window, enqueue's blind HSET restores the stale ``active_tasks`` and wedges
-    the tenant: the active set is empty but the derived limits say it is full.
-    See docs/plans/redis-tenant-limits-bookkeeping-race-handoff.md.
-    """
-    manager, fake = _manager()
+async def test_resync_retries_after_concurrent_finalize(
+    real_redis, monkeypatch
+) -> None:
+    manager, redis, tenant_id, task_id = real_redis
+    active_key = f"tenant:{tenant_id}:active_tasks"
+    limits_key = f"tenant:{tenant_id}:limits"
     manager.max_concurrent_tasks = 1
 
-    # Seed: one task handed out and running, limits say active=1/queued=0.
-    fake.hashes["task:task-running"] = {"status": "started"}
-    fake.sets["tenant:tenant-A:active_tasks"] = {"task-running"}
-    fake.hashes["tenant:tenant-A:limits"] = {
-        "max_concurrent_tasks": "1",
-        "active_tasks": "1",
-        "queued_tasks": "0",
-        "active_documents": "0",
-    }
-
-    # Pause enqueue right after it captures its limits snapshot, before HSET.
-    real_get_limits = manager.get_tenant_limits
-    snapshot_captured = asyncio.Event()
-    release_enqueue = asyncio.Event()
-
-    async def _gated_get_limits(tenant_id):
-        limits = await real_get_limits(tenant_id)
-        snapshot_captured.set()
-        await release_enqueue.wait()
-        return limits
-
-    manager.get_tenant_limits = _gated_get_limits  # type: ignore[method-assign]
-
-    enqueue = asyncio.create_task(
-        manager.enqueue_task("tenant-A", _task("task-queued"))
+    await redis.hset(
+        limits_key,
+        mapping={
+            "max_concurrent_tasks": "1",
+            "active_tasks": "1",
+            "queued_tasks": "0",
+        },
     )
-    await snapshot_captured.wait()  # stale snapshot (active_tasks=1) is held
+    await manager.update_tenant_limits(tenant_id, delta_queued_tasks=1)
+    assert await redis.hmget(limits_key, "active_tasks", "queued_tasks") == [b"1", b"1"]
+    await redis.sadd(active_key, task_id)
 
-    # While enqueue is paused, the running task finishes and frees capacity.
-    manager.get_tenant_limits = real_get_limits  # finalize path uses the real read
-    await manager._finalize_task_terminal_state_atomic(
-        tenant_id="tenant-A",
-        task_id="task-running",
-        task_size=1,
-        terminal_status=TaskStatus.SUCCESS,
-    )
+    attempts = 0
+    get_ids = manager.get_tenant_active_task_ids
 
-    # Intermediate state is consistent: nothing active.
-    assert await manager.get_tenant_active_task_count("tenant-A") == 0
-    assert (await manager.get_tenant_limits("tenant-A")).active_tasks == 0
+    async def finalize_after_read(current_tenant_id):
+        nonlocal attempts
+        members = await get_ids(current_tenant_id)
+        attempts += 1
+        if attempts == 1:
+            await manager._finalize_task_terminal_state_atomic(
+                tenant_id=tenant_id,
+                task_id=task_id,
+                task_size=1,
+                terminal_status=TaskStatus.SUCCESS,
+            )
+        return members
 
-    # Let enqueue resume; its whole-hash HSET must not resurrect active_tasks.
-    release_enqueue.set()
-    await enqueue
+    monkeypatch.setattr(manager, "get_tenant_active_task_ids", finalize_after_read)
 
-    active_set = await manager.get_tenant_active_task_count("tenant-A")
-    limits = await manager.get_tenant_limits("tenant-A")
-    assert active_set == 0
-    assert limits.active_tasks == 0, (
-        f"enqueue restored stale active_tasks={limits.active_tasks} over the "
-        "finalize's decrement -> false full gate"
-    )
-    assert limits.queued_tasks == 1  # the newly enqueued task is preserved
+    await manager.resync_tenant_limits(tenant_id)
 
-    can_process, reason = await manager.check_tenant_can_process("tenant-A", 1)
+    assert attempts == 2
+    assert await redis.scard(active_key) == 0
+    assert int(await redis.hget(limits_key, "active_tasks")) == 0
+    can_process, reason = await manager.check_tenant_can_process(tenant_id, 1)
     assert can_process, reason
+
+
+@pytest.mark.asyncio
+async def test_resync_defers_after_three_conflicts(
+    real_redis, monkeypatch, caplog
+) -> None:
+    manager, redis, tenant_id, _ = real_redis
+    limits_key = f"tenant:{tenant_id}:limits"
+    await redis.hset(
+        limits_key, mapping={"max_concurrent_tasks": "5", "active_tasks": "9"}
+    )
+
+    attempts = 0
+    get_ids = manager.get_tenant_active_task_ids
+
+    async def contend_after_read(current_tenant_id):
+        nonlocal attempts
+        members = await get_ids(current_tenant_id)
+        attempts += 1
+        await redis.hset(limits_key, "contention", attempts)
+        return members
+
+    with monkeypatch.context() as patch:
+        patch.setattr(manager, "get_tenant_active_task_ids", contend_after_read)
+        limits = await asyncio.wait_for(
+            manager.resync_tenant_limits(tenant_id), timeout=1.0
+        )
+
+    assert attempts == 3
+    assert limits.active_tasks == 9
+    assert await redis.hget(limits_key, "active_tasks") == b"9"
+    assert "Tenant limits resync deferred after repeated contention" in caplog.text
+
+    assert (await manager.resync_tenant_limits(tenant_id)).active_tasks == 0

--- a/tests/test_ray_lifecycle_counters.py
+++ b/tests/test_ray_lifecycle_counters.py
@@ -11,6 +11,8 @@ that faithfully models the Redis commands the instrumented code paths use
 This mirrors the hermetic style of ``test_ray_converter_units.py``.
 """
 
+import asyncio
+
 import pytest
 
 pytest.importorskip("msgpack")
@@ -116,6 +118,9 @@ class _FakeRedis:
 
     async def hgetall(self, key):
         return self._apply("hgetall", (key,), {})
+
+    async def hset(self, key, *args, **kwargs):
+        return self._apply("hset", (key, *args), kwargs)
 
     async def scard(self, key):
         return self._apply("scard", (key,), {})
@@ -370,3 +375,86 @@ async def test_finalize_is_exactly_once_first_terminal_wins() -> None:
     counters = await manager.get_tenant_task_counters("tenant-a")
     assert counters.tasks_succeeded_total == 1
     assert counters.tasks_failed_total == 0
+
+
+# --- bookkeeping race between enqueue and terminalization ----------------------
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="Confirmed bug: update_tenant_limits does a non-atomic whole-hash "
+    "read-modify-write (HGETALL->mutate->HSET) that clobbers a concurrent "
+    "finalize's HINCRBY. Remove this marker when update_tenant_limits switches "
+    "to per-field HINCRBY. See "
+    "docs/plans/redis-tenant-limits-bookkeeping-race-handoff.md.",
+)
+@pytest.mark.asyncio
+async def test_enqueue_limits_update_does_not_restore_stale_active_usage() -> None:
+    """A concurrent finalize must not be clobbered by enqueue's limits write.
+
+    ``update_tenant_limits`` does a non-atomic read-modify-write of the whole
+    limits hash (HGETALL -> mutate -> HSET mapping), while terminalization does
+    per-field HINCRBY under WATCH. If a finalize lands inside the enqueue read
+    window, enqueue's blind HSET restores the stale ``active_tasks`` and wedges
+    the tenant: the active set is empty but the derived limits say it is full.
+    See docs/plans/redis-tenant-limits-bookkeeping-race-handoff.md.
+    """
+    manager, fake = _manager()
+    manager.max_concurrent_tasks = 1
+
+    # Seed: one task handed out and running, limits say active=1/queued=0.
+    fake.hashes["task:task-running"] = {"status": "started"}
+    fake.sets["tenant:tenant-A:active_tasks"] = {"task-running"}
+    fake.hashes["tenant:tenant-A:limits"] = {
+        "max_concurrent_tasks": "1",
+        "active_tasks": "1",
+        "queued_tasks": "0",
+        "active_documents": "0",
+    }
+
+    # Pause enqueue right after it captures its limits snapshot, before HSET.
+    real_get_limits = manager.get_tenant_limits
+    snapshot_captured = asyncio.Event()
+    release_enqueue = asyncio.Event()
+
+    async def _gated_get_limits(tenant_id):
+        limits = await real_get_limits(tenant_id)
+        snapshot_captured.set()
+        await release_enqueue.wait()
+        return limits
+
+    manager.get_tenant_limits = _gated_get_limits  # type: ignore[method-assign]
+
+    enqueue = asyncio.create_task(
+        manager.enqueue_task("tenant-A", _task("task-queued"))
+    )
+    await snapshot_captured.wait()  # stale snapshot (active_tasks=1) is held
+
+    # While enqueue is paused, the running task finishes and frees capacity.
+    manager.get_tenant_limits = real_get_limits  # finalize path uses the real read
+    await manager._finalize_task_terminal_state_atomic(
+        tenant_id="tenant-A",
+        task_id="task-running",
+        task_size=1,
+        terminal_status=TaskStatus.SUCCESS,
+    )
+
+    # Intermediate state is consistent: nothing active.
+    assert await manager.get_tenant_active_task_count("tenant-A") == 0
+    assert (await manager.get_tenant_limits("tenant-A")).active_tasks == 0
+
+    # Let enqueue resume; its whole-hash HSET must not resurrect active_tasks.
+    release_enqueue.set()
+    await enqueue
+
+    active_set = await manager.get_tenant_active_task_count("tenant-A")
+    limits = await manager.get_tenant_limits("tenant-A")
+    assert active_set == 0
+    assert limits.active_tasks == 0, (
+        f"enqueue restored stale active_tasks={limits.active_tasks} over the "
+        "finalize's decrement -> false full gate"
+    )
+    assert limits.queued_tasks == 1  # the newly enqueued task is preserved
+
+    can_process, reason = await manager.check_tenant_can_process("tenant-A", 1)
+    assert can_process, reason


### PR DESCRIPTION
## Summary

This fixes two Redis races that could leave a tenant's usage counters out of
sync with its queue and active tasks. A stale `active_tasks` value could make a
tenant appear to be at its concurrency limit and stop queued work from being
dispatched.

## What changed

- `update_tenant_limits()` now uses `HSETNX` for missing limit settings and
  `HINCRBY` for counter changes. It updates only the requested fields instead of
  reading and rewriting the whole limits hash, so it cannot overwrite a change
  made at the same time by dispatch or task finalization.
- `resync_tenant_limits()` now uses Redis `WATCH`/`MULTI`/`EXEC`. It writes the
  recalculated counters only if the active-task set, queue, and limits hash did
  not change while they were being read.
- Resync tries at most three times when Redis reports a watched-key change. If
  the keys keep changing, it logs a warning, returns the current stored values,
  and leaves the next regular reconciliation pass to try again. This prevents a
  busy tenant from holding up the dispatcher indefinitely.
- The race tests run against the Redis service in CI, using unique keys and
  deleting only those keys afterward. The in-memory Redis fake remains small
  and does not attempt to reproduce Redis transaction behavior.

## Validation

- `.venv/bin/pytest -q tests/test_ray_lifecycle_counters.py tests/test_ray_dispatcher_hardening.py` — 40 passed
- Ruff formatting and linting passed
- MyPy passed
- CI passed on Python 3.10 through 3.14

## Scope

This does not add a retry setting, background repair task, dependency, or key
migration. The transaction works with standalone Redis or Valkey and Sentinel.
Redis Cluster would require the tenant keys to share a hash slot, so supporting
that setup remains separate work.
